### PR TITLE
Yoneda rearrangement

### DIFF
--- a/Theory/Yoneda.v
+++ b/Theory/Yoneda.v
@@ -17,10 +17,8 @@ Definition Copresheaves (C : Category) := [C, Sets].
 (** This is the Yoneda embedding. *)
 Instance Yoneda `{C : Category} : C ⟶ [C^op, Sets] := CoHomFunctor C.
 
-Program Instance YonedaLemma `(C : Category) `(F : C ⟶ Sets) {A : C} :
-
+Program Instance CovariantYonedaLemma `(C : Category) `(F : C ⟶ Sets) {A : C} :
   [C, Sets] Hom(A,─) F ≅ F A
-
 := {
   to   := {| morphism := fun X => X A id |};
   from := {| morphism := fun Y : F A =>
@@ -69,7 +67,7 @@ Next Obligation.
   apply transform; cat.
 Qed.
 
-Program Instance CoonedaLemma `(C : Category) `(F : C^op ⟶ Sets) {A : C} :
+Program Instance YonedaLemma `(C : Category) `(F : C^op ⟶ Sets) {A : C} :
 
   [C^op, Sets] Hom(─,A) F ≅ F A
 

--- a/Theory/Yoneda.v
+++ b/Theory/Yoneda.v
@@ -17,55 +17,6 @@ Definition Copresheaves (C : Category) := [C, Sets].
 (** This is the Yoneda embedding. *)
 Instance Yoneda `{C : Category} : C ⟶ [C^op, Sets] := CoHomFunctor C.
 
-Program Instance CovariantYonedaLemma `(C : Category) `(F : C ⟶ Sets) {A : C} :
-  [C, Sets] Hom(A,─) F ≅ F A
-:= {
-  to   := {| morphism := fun X => X A id |};
-  from := {| morphism := fun Y : F A =>
-             {| transform := fun X : C =>
-                {| morphism := fun phi : A ~{ C }~> X =>
-                     @fmap C Sets F A X phi Y |} |} |}
-}.
-Next Obligation.
-  repeat intros x y HA.
-  destruct x, y; simpl in *.
-  unfold nat_equiv in HA; simpl in HA.
-  rewrite HA; reflexivity.
-Qed.
-Next Obligation.
-  repeat intros ?? HA.
-  destruct F; simpl in *.
-  apply fmap_respects.
-  apply HA.
-Qed.
-Next Obligation.
-  destruct F; simpl in *.
-  unfold Basics.compose in *.
-  rewrite <- fmap_comp.
-  reflexivity.
-Qed.
-Next Obligation.
-  repeat intro; simpl in *.
-  destruct F; simpl in *.
-  destruct (fmap A A0 x0); simpl.
-  apply proper_morphism.
-  assumption.
-Qed.
-Next Obligation.
-  unfold Basics.compose; simpl.
-  destruct F; simpl in *.
-  rewrite fmap_id.
-  reflexivity.
-Qed.
-Next Obligation.
-  unfold Basics.compose; simpl.
-  destruct F; simpl in *.
-  unfold nat_equiv; simpl; intros.
-  destruct x; simpl in *.
-  unfold Basics.compose in *; simpl.
-  rewrite natural_transformation.
-  apply transform; cat.
-Qed.
 
 Program Instance YonedaLemma `(C : Category) `(F : C^op ⟶ Sets) {A : C} :
 
@@ -118,3 +69,54 @@ Next Obligation.
   rewrite natural_transformation.
   apply transform; cat.
 Qed.
+
+Program Instance CovariantYonedaLemma `(C : Category) `(F : C ⟶ Sets) {A : C} :
+  [C, Sets] Hom(A,─) F ≅ F A
+:= {
+  to   := {| morphism := fun X => X A id |};
+  from := {| morphism := fun Y : F A =>
+             {| transform := fun X : C =>
+                {| morphism := fun phi : A ~{ C }~> X =>
+                     @fmap C Sets F A X phi Y |} |} |}
+}.
+Next Obligation.
+  repeat intros x y HA.
+  destruct x, y; simpl in *.
+  unfold nat_equiv in HA; simpl in HA.
+  rewrite HA; reflexivity.
+Qed.
+Next Obligation.
+  repeat intros ?? HA.
+  destruct F; simpl in *.
+  apply fmap_respects.
+  apply HA.
+Qed.
+Next Obligation.
+  destruct F; simpl in *.
+  unfold Basics.compose in *.
+  rewrite <- fmap_comp.
+  reflexivity.
+Qed.
+Next Obligation.
+  repeat intro; simpl in *.
+  destruct F; simpl in *.
+  destruct (fmap A A0 x0); simpl.
+  apply proper_morphism.
+  assumption.
+Qed.
+Next Obligation.
+  unfold Basics.compose; simpl.
+  destruct F; simpl in *.
+  rewrite fmap_id.
+  reflexivity.
+Qed.
+Next Obligation.
+  unfold Basics.compose; simpl.
+  destruct F; simpl in *.
+  unfold nat_equiv; simpl; intros.
+  destruct x; simpl in *.
+  unfold Basics.compose in *; simpl.
+  rewrite natural_transformation.
+  apply transform; cat.
+Qed.
+


### PR DESCRIPTION
The "Yoneda Lemma" is usually understood as the statement about presheaves (contravariant functors); the one about copresheaves is, I think, just called the "covariant Yoneda lemma".

The "Coyoneda lemma" states that every presheaf is a colimit of representables. This would be interesting to prove as well!

I hope you don't mind these changes!