### PR TITLE
Improve the performance of normalize by simplifing the lemma.

### DIFF
--- a/Solver/Normal.v
+++ b/Solver/Normal.v
@@ -193,11 +193,19 @@ End Normal.
 
 Require Export Category.Solver.Reify.
 
+(* * This is a much easier theorem to apply, so it speeds things up a lot! *)
+Theorem sexprAD_sound' (env : Env) (e : SExpr) : sexprAD e -> sexprD e.
+Proof.
+  apply sexprAD_sound.
+Qed.
+
 Ltac normalize := reify_terms_and_then
   ltac:(fun env g =>
           change (@sexprD env g);
-          apply sexprAD_sound;
+          simple apply sexprAD_sound';
           vm_compute).
+
+
 
 Example sample_2 :
   ∀ (C : Category) (x y z w : C) (f : z ~> w) (g : y ~> z) (h : x ~> y) (i : x ~> z),


### PR DESCRIPTION
This improves the performance of the `normalize` tactic by 22x on the example from ~2.9s to ~0.13s. The key is to make Coq do as little work as possible during unification, so you need to make sure that the form of the lemma syntactically matches the form of the goal.

This works out pretty well for what you're doing, but this doesn't follow the standard recipe for computational reflection. For this problem, it doesn't bite you, but if you were working in a concrete category, the `vm_compute` at the end of this tactic would unfold all of the definitions in your category making a term that is very inefficient. The general way to solve this problem is to use an equation to control reduction, though this does make things a little bit less efficient in some instances.

```coq
Lemma apply_simplify : forall e a b,
  simplify e a = b ->
  denote b ->
  denote a.
```

To apply this lemma, you `vm_compute` the simplify, and then use `eq_refl`. Then you just `simpl` (or `cbv` with controlled simplification) on the `denote` premise so that you don't unfold any definitions that occur in your environment.
