### PR TITLE
Fix an error for coq >= v8.12.2 and other cleanup

### DIFF
--- a/.github/workflows/coq-ci.yml
+++ b/.github/workflows/coq-ci.yml
@@ -13,8 +13,6 @@ jobs:
           - 'coqorg/coq:8.12'
           - 'coqorg/coq:8.11'
           - 'coqorg/coq:8.10'
-          - 'coqorg/coq:8.9'
-          - 'coqorg/coq:8.8'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/coq-ci.yml
+++ b/.github/workflows/coq-ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - 'coqorg/coq:dev'
+          - 'coqorg/coq:8.13'
+          - 'coqorg/coq:8.12'
+          - 'coqorg/coq:8.11'
+          - 'coqorg/coq:8.10'
+          - 'coqorg/coq:8.9'
+          - 'coqorg/coq:8.8'
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - uses: coq-community/docker-coq-action@v1
+        with:
+          opam_file: 'coq-category-theory.opam'
+          custom_image: ${{ matrix.image }}
+
+# See also:
+# https://github.com/coq-community/docker-coq-action#readme
+# https://github.com/erikmd/docker-coq-github-action-demo

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,11 @@
 .*.aux
 *.aux
 *.vo
+*.vok
+*.vos
 *.glob
+.Makefile.coq.d
+.lia.cache
 .coq-native/
 /coqdoc.sty
 /html/

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 /Theory/Metacategory/ObjectsArrows
 /Makefile.coq.conf
 /.coqdeps.d
+/.Makefile.coq.d

--- a/Adjunction/README.md
+++ b/Adjunction/README.md
@@ -4,7 +4,7 @@ There are at least four ways to specify an adjunction F ⊣ G:
 
 1. A bijective mapping between hom-sets `F a ~> b` and `a ~> U b`, natural in
    `a` and `b`. This is the definition given in `Category.Theory.Adjunction`.
-   
+
 2. A pair of `unit` and `counit` natural transformations, and that they
    compose to the identity functor in certain ways. This is given in
    `Category.Adjunction.Natural.Transformation`.

--- a/Instance/Sets.v
+++ b/Instance/Sets.v
@@ -160,9 +160,15 @@ Defined.
 Next Obligation.
   proper; simpl in *.
   - destruct s.
-    now rewrite X.
+    match goal with
+    | H : ?a ≈ ?b |- _ ?a ≈ _ ?b =>
+      now rewrite H
+    end.
   - destruct s0.
-    now rewrite H.
+    match goal with
+    | H : ?a ≈ ?b |- _ ?a ≈ _ ?b =>
+      now rewrite H
+    end.
 Qed.
 Next Obligation.
   construct.

--- a/Lib/Equality.v
+++ b/Lib/Equality.v
@@ -109,7 +109,7 @@ Definition nth_pos_bounded {a} (xs : list a) (n : positive)
 Proof.
   generalize dependent n.
   induction xs; intros.
-    unfold within_bounds in H; simpl in H; lia.
+    unfold within_bounds in H; simpl in H. exfalso. inversion H.
   destruct n using Pos.peano_rect.
     exact a0.
   clear IHn.

--- a/Lib/Equality.v
+++ b/Lib/Equality.v
@@ -7,7 +7,7 @@ Require Import Coq.Bool.Bool.
 Require Import Coq.Lists.List.
 Require Import Coq.Arith.PeanoNat.
 Require Import Coq.NArith.NArith.
-Require Import Coq.omega.Omega.
+Require Import Coq.micromega.Lia.
 
 Generalizable All Variables.
 Set Primitive Projections.
@@ -109,18 +109,18 @@ Definition nth_pos_bounded {a} (xs : list a) (n : positive)
 Proof.
   generalize dependent n.
   induction xs; intros.
-    unfold within_bounds in H; simpl in H; omega.
+    unfold within_bounds in H; simpl in H; lia.
   destruct n using Pos.peano_rect.
     exact a0.
   clear IHn.
   apply IHxs with (n:=n).
   unfold within_bounds in *.
   simpl in H.
-  rewrite Pos2Nat.inj_succ in H.
+  rewrite Pnat.Pos2Nat.inj_succ in H.
   simpl in H.
-  apply lt_S_n.
+  apply Lt.lt_S_n.
   rewrite Nat.succ_pred_pos; auto.
-  apply Pos2Nat.is_pos.
+  apply Pnat.Pos2Nat.is_pos.
 Defined.
 
 Lemma Nat_eqb_eq n m : Nat.eqb n m = true <-> n = m.

--- a/Lib/MapDecide.v
+++ b/Lib/MapDecide.v
@@ -422,7 +422,7 @@ Next Obligation.
   apply map_contains_MapsTo; auto.
 Defined.
 Next Obligation.
-  rewrite formula_size_subst_all_formula; simpl; omega.
+  rewrite formula_size_subst_all_formula; simpl; lia.
 Defined.
 
 Definition formula_tauto : ∀ env t, [formula_denote env t].

--- a/Lib/MapDecide.v
+++ b/Lib/MapDecide.v
@@ -2,6 +2,7 @@ Set Warnings "-notation-overridden".
 
 Require Import Coq.NArith.NArith.
 Require Import Coq.FSets.FMaps.
+Import ListNotations.
 
 Require Import Category.Lib.
 Require Import Category.Lib.Nomega.

--- a/Lib/Nomega.v
+++ b/Lib/Nomega.v
@@ -4,19 +4,9 @@ Set Warnings "-deprecated".
 Require Export
   Coq.Arith.Arith
   Coq.NArith.NArith
-  Coq.omega.Omega.
+  Coq.micromega.Lia.
 
 Local Open Scope N_scope.
-
-Hint Rewrite
-  Nplus_0_r
-  nat_of_Nsucc
-  nat_of_Nplus
-  nat_of_Nminus
-  N_of_nat_of_N
-  nat_of_N_of_nat
-  nat_of_P_o_P_of_succ_nat_eq_succ
-  nat_of_P_succ_morphism : N.
 
 Corollary sumbool_split : forall P Q : Prop,
   {P} + {~P} -> {Q} + {~Q} -> {P /\ Q} + {~ (P /\ Q)}.
@@ -28,14 +18,12 @@ Variables n m : N.
 
 Lemma Neq_in : nat_of_N n = nat_of_N m -> n = m.
 Proof.
-  intros H; apply (f_equal N_of_nat) in H;
-  autorewrite with N in *; assumption.
+  lia.
 Qed.
 
 Lemma Neq_out : n = m -> nat_of_N n = nat_of_N m.
 Proof.
-  intros H; apply (f_equal N.to_nat) in H;
-  autorewrite with N in *; assumption.
+  lia.
 Qed.
 
 Lemma Nneq_out : n <> m -> nat_of_N n <> nat_of_N m.
@@ -258,7 +246,7 @@ Ltac pre_nomega :=
 Ltac nomega' :=
   pre_nomega;
   repeat progress match goal with
-  | _ => omega || (unfold nat_of_P in *; simpl in *; omega)
+  | _ => lia || (unfold nat_of_P in *; simpl in *; lia)
 
   | [ H : _ \/ _ |- _ ] => destruct H; nomega'
   | [ |- _ /\ _ ]       => split; intros; nomega'

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,6 @@ all: Makefile.coq
 Makefile.coq: _CoqProject
 	$(COQBIN)coq_makefile -f $< -o $@
 
-install: _CoqProject Makefile.coq
-	@+$(MAKE) -f Makefile.coq COQLIB=$(COQLIB) install
-
 clean: _CoqProject Makefile.coq
 	@+$(MAKE) -f Makefile.coq cleanall
 	@rm -f Makefile.coq Makefile.coq.conf

--- a/Makefile
+++ b/Makefile
@@ -4,25 +4,17 @@ all: Makefile.coq
 		echo NOT IN _CoqProject: $$i;			\
 	    fi;							\
 	done
-	make -k -j$(JOBS) -f Makefile.coq $(CMD) # TIMECMD=time
+	@+$(MAKE) -f Makefile.coq all
 
 Makefile.coq: _CoqProject
-	coq_makefile -f $< -o $@
+	$(COQBIN)coq_makefile -f $< -o $@
 
 install: _CoqProject Makefile.coq
-	make -f Makefile.coq COQLIB=$(COQLIB) install
+	@+$(MAKE) -f Makefile.coq COQLIB=$(COQLIB) install
 
 clean: _CoqProject Makefile.coq
-	make -f Makefile.coq clean
-	@find . \( -name '*.glob' -o				\
-		  -name '*.v.d' -o				\
-		  -name '*.vo' -o				\
-		  -name '*.hi' -o				\
-		  -name '*.o' -o				\
-		  -name '.*.aux' -o				\
-		  -name '*.hp' -o				\
-		  -name 'result' -o				\
-		  -name 'dist' \) -print0 | xargs -0 rm -fr
+	@+$(MAKE) -f Makefile.coq cleanall
+	@rm -f Makefile.coq Makefile.coq.conf
 
 fullclean: clean
 	rm -f Makefile.coq
@@ -34,3 +26,10 @@ todo:
 		      egrep -v '(Definition undefined|DEFERRED)'   | \
 		      egrep -v '(old|new|research|Pending)/'	     \
 	    || echo "No pending tasks!"
+
+force _CoqProject Makefile: ;
+
+%: Makefile.coq force
+	@+$(MAKE) -f Makefile.coq $@
+
+.PHONY: all clean force todo

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This development encodes category theory in Coq, with the primary aim being to
 allow representation and manipulation of categorical terms, as well
 realization of those terms in various target categories.
 
-Versions used: [Coq](https://github.com/coq/coq/) 8.8.2, [Coq-Equations](https://github.com/mattam82/Coq-Equations) v1.0-8.8.
+Versions used: [Coq](https://github.com/coq/coq/) 8.10.2.
+Some incomplete parts depend on [Coq-Equations](https://github.com/mattam82/Coq-Equations).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ avoid repetition when stating the dual of whole structures.
 As a result, the definition of comonads, for example, is reduced to one line:
 
     Definition Comonad `{M : C ⟶ C} := @Monad (C^op) (M^op).
-    
+
 Most dual constructions are similarly defined, with the exception of `Initial`
 and `Cocartesian` structures. Although the core classes are indeed defined in
 terms of their dual construction, an alternate surface syntax and set of

--- a/Theory/Isomorphism.v
+++ b/Theory/Isomorphism.v
@@ -86,8 +86,12 @@ Definition isomorphism_equiv {x y : C} : crelation (x ≅ y) :=
 Global Program Instance isomorphism_equiv_equivalence {x y : C} :
   Equivalence (@isomorphism_equiv x y).
 Next Obligation. firstorder reflexivity. Qed.
-Next Obligation. firstorder. Qed.
-Next Obligation. firstorder. Qed.
+Next Obligation. firstorder; symmetry; assumption. Qed.
+Next Obligation.
+  firstorder;
+    try (transitivity (to y0); assumption);
+    try (transitivity (from y0); assumption).
+Qed.
 
 Global Program Instance isomorphism_setoid {x y : C} : Setoid (x ≅ y) := {
   equiv := isomorphism_equiv;

--- a/Theory/Metacategory/Graph.v
+++ b/Theory/Metacategory/Graph.v
@@ -6,7 +6,7 @@ Require Import Category.Theory.Functor.
 Require Import Coq.FSets.FMaps.
 Require Import Category.Lib.FMapExt.
 Require Import Coq.Vectors.Vector.
-Require Import Coq.omega.Omega.
+Require Import Coq.micromega.Lia.
 
 Generalizable All Variables.
 Set Primitive Projections.
@@ -230,7 +230,7 @@ Next Obligation.
     destruct H1.
     inversion_clear H.
     inversion_clear H1.
-    split; omega.
+    split; lia.
   - destruct (fst (in_mapsto_iffT _ _ _) H); clear H.
     cleanup.
       destruct H1; discriminate.
@@ -238,12 +238,12 @@ Next Obligation.
       destruct H1.
       simpl in *.
       rewrite <- H, <- H0.
-      split; omega.
+      split; lia.
     cleanup.
       destruct H1.
       simpl in *.
       rewrite <- H, <- H1.
-      split; omega.
+      split; lia.
     cleanup.
     destruct H1.
     inversion_clear H.

--- a/Theory/Metacategory/Graph.v
+++ b/Theory/Metacategory/Graph.v
@@ -290,13 +290,11 @@ Next Obligation.
 Qed.
 Next Obligation.
   unfold composite; simpl.
-  repeat destruct f using caseS';
-  repeat destruct p using caseS'; cleanup.
-  inversion p.
+  repeat destruct f as [|f] using caseS'; cleanup.
+  inversion f.
 Qed.
 Next Obligation.
   unfold composite; simpl.
-  repeat destruct f using caseS';
-  repeat destruct p using caseS'; cleanup.
-  inversion p.
+  repeat destruct f as [|f] using caseS'; cleanup.
+  inversion f.
 Qed.

--- a/coq-category-theory.opam
+++ b/coq-category-theory.opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "johnw@newartisans.com"
+version: "dev"
+
+homepage: "https://github.com/jwiegley/category-theory"
+dev-repo: "git+https://github.com/jwiegley/category-theory.git"
+bug-reports: "https://github.com/jwiegley/category-theory/issues"
+license: "MIT"
+
+synopsis: "An axiom-free formalization of category theory in Coq"
+description: """
+An axiom-free formalization of category theory in Coq for personal study and
+practical work.
+"""
+
+build: [make "-j%{jobs}%" ]
+install: [make "install"]
+depends: [
+  "coq" {(>= "8.8" & < "8.14~") | (= "dev")}
+]
+
+tags: [
+]
+authors: [
+  "John Wiegley"
+]

--- a/coq-category-theory.opam
+++ b/coq-category-theory.opam
@@ -16,7 +16,7 @@ practical work.
 build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.8" & < "8.14~") | (= "dev")}
+  "coq" {(>= "8.10" & < "8.14~") | (= "dev")}
 ]
 
 tags: [


### PR DESCRIPTION
This adresses the most important incompatibility with coq v8.12.2 (see issue #18). There are still some anomalies and other problems that appear, but large parts of the library build now. I’m pretty certain that the change is backwards compatible with older coq versions, but I haven’t verified.