### PR TITLE
Speed up some proofs

### DIFF
--- a/.github/workflows/coq-ci.yml
+++ b/.github/workflows/coq-ci.yml
@@ -9,6 +9,7 @@ jobs:
       matrix:
         image:
           - 'coqorg/coq:dev'
+          - 'coqorg/coq:8.16'
           - 'coqorg/coq:8.15'
           - 'coqorg/coq:8.14'
       fail-fast: false

--- a/Functor/Construction/Product/Monoidal.v
+++ b/Functor/Construction/Product/Monoidal.v
@@ -28,70 +28,48 @@ Context {G : D ⟶ K}.
 
 Local Obligation Tactic := program_simpl.
 
-Lemma ProductFunctor_Monoidal_ap_functor_iso :
-  MonoidalFunctor F → MonoidalFunctor G
-    → (⨂) ◯ (F ∏⟶ G) ∏⟶ (F ∏⟶ G) ≅[[(C ∏ D) ∏ (C ∏ D), J ∏ K]] F ∏⟶ G ◯ (⨂).
-Proof.
-  intros O P.
-  isomorphism.
-
-  transform. all:simpl. {
-    intros [[x z] [y w]]; split.
-      exact (transform[to ap_functor_iso] (x, y)).
-    exact (transform[to ap_functor_iso] (z, w)).
-  }
-
-  all:simpl.
-  all:(try destruct x as [[x1 x2] [y1 y2]],
-                    y as [[z1 z2] [w1 w2]]; simpl).
-
-  split.
-    abstract apply (naturality (to ap_functor_iso) (x1, y1)).
-  abstract apply (naturality (to ap_functor_iso) (x2, y2)).
-
-  all:simpl.
-  all:(try destruct x as [[x1 x2] [y1 y2]],
-                    y as [[z1 z2] [w1 w2]];
-       try destruct f as [[f1a f1b] [f2a f2b]]; simpl).
-
-  split.
-    abstract apply (naturality_sym (to ap_functor_iso)
-                                   (x1, y1) (z1, w1) (f1a, f2a)).
-  abstract apply (naturality_sym (to ap_functor_iso)
-                                 (x2, y2) (z2, w2) (f1b, f2b)).
-
-  all:simpl.
-  transform. all:simpl. {
-    intros [[x z] [y w]]; split.
-      exact (transform[from ap_functor_iso] (x, y)).
-    exact (transform[from ap_functor_iso] (z, w)).
-  }
-
-  all:simpl.
-  all:(try destruct x as [[x1 x2] [y1 y2]],
-                    y as [[z1 z2] [w1 w2]],
-                    f as [[f1a f1b] [f2a f2b]]; simpl).
-
-  split.
-    abstract apply (naturality (from ap_functor_iso)
-                               (x1, y1) (z1, w1) (f1a, f2a)).
-  abstract apply (naturality (from ap_functor_iso)
-                             (x2, y2) (z2, w2) (f1b, f2b)).
-
-  split.
-    abstract apply (naturality_sym (from ap_functor_iso)
-                                   (x1, y1) (z1, w1) (f1a, f2a)).
-  abstract apply (naturality_sym (from ap_functor_iso)
-                                 (x2, y2) (z2, w2) (f1b, f2b)).
-
-  split; simplify.
-    abstract sapply (iso_to_from (ap_functor_iso[O])).
-  abstract sapply (iso_to_from (ap_functor_iso[P])).
-
-  split; simplify.
-    abstract apply (iso_from_to (ap_functor_iso[O]) (A, H3)).
-  abstract apply (iso_from_to (ap_functor_iso[P]) (H5, H4)).
+Program Definition ProductFunctor_Monoidal_ap_functor_iso
+  (O : MonoidalFunctor F) (P : MonoidalFunctor G) :
+    (⨂) ◯ (F ∏⟶ G) ∏⟶ (F ∏⟶ G) ≅[[(C ∏ D) ∏ (C ∏ D), J ∏ K]] F ∏⟶ G ◯ (⨂) :=
+  {|
+    to := {| transform := _; naturality := _; naturality_sym := _ |};
+    from := {| transform := _; naturality := _; naturality_sym := _ |};
+    iso_to_from := _;
+    iso_from_to := _;
+  |}.
+Next Obligation.
+  simpl. split;
+    exact (transform[to ap_functor_iso] (_, _)).
 Defined.
+Next Obligation.
+  simpl. split;
+    apply (naturality (to ap_functor_iso) (_, _)).
+Qed.
+Next Obligation.
+  simpl. split;
+    apply (naturality_sym (to ap_functor_iso) (_, _) (_, _) (_, _)).
+Qed.
+Next Obligation.
+  simpl. split; exact (transform[from ap_functor_iso] (_, _)).
+Defined.
+Next Obligation.
+  simpl. split;
+    apply (naturality (from ap_functor_iso) (_, _) (_, _) (_, _)).
+Qed.
+Next Obligation.
+  simpl. split;
+    apply (naturality_sym (from ap_functor_iso) (_, _) (_, _) (_, _)).
+Qed.
+Next Obligation.
+  simpl. split.
+  - sapply (iso_to_from (ap_functor_iso[O])).
+  - sapply (iso_to_from (ap_functor_iso[P])).
+Qed.
+Next Obligation.
+  simpl. split.
+  - apply (iso_from_to (ap_functor_iso[O]) (_, _)).
+  - apply (iso_from_to (ap_functor_iso[P]) (_, _)).
+Qed.
 
 Program Definition ProductFunctor_Monoidal :
   MonoidalFunctor F -> MonoidalFunctor G
@@ -119,74 +97,83 @@ Next Obligation.
 Qed.
 Next Obligation.
   simpl.
-  unfold ProductFunctor_Monoidal_obligation_2.
-  unfold ProductFunctor_Monoidal_obligation_3.
-  intros; split; apply monoidal_unit_left.
+  split; apply monoidal_unit_left.
 Qed.
 Next Obligation.
   simpl.
-  unfold ProductFunctor_Monoidal_obligation_2.
-  unfold ProductFunctor_Monoidal_obligation_3.
-  intros; split; apply monoidal_unit_right.
+  split; apply monoidal_unit_right.
 Qed.
 Next Obligation.
   simpl.
-  unfold ProductFunctor_Monoidal_obligation_2.
-  unfold ProductFunctor_Monoidal_obligation_3.
   intros; split; apply monoidal_assoc.
 Qed.
 
-Lemma ProductFunctor_Monoidal_proj1_ap_functor_iso :
-  MonoidalFunctor F ∏⟶ G
-    → (⨂) ◯ F ∏⟶ F ≅[[(C ∏ C), J]] F ◯ (⨂).
-Proof.
-  intros P.
-
-  isomorphism.
-
-  transform. {
-    intros [x y].
-    exact (fst (transform[to (ap_functor_iso[P])] ((x, I), (y, I)))).
-  }
-
-  all:(try rename x into x0;
-       try rename y into y0;
-       try destruct x0 as [x y],
-                    y0 as [z w],
-                    f as [f g];
-       try destruct A as [x y]; simpl).
-
-  exact (fst (naturality (to (ap_functor_iso[P]))
-                         (x, I, (y, I)) (z, I, (w, I))
-                         ((f, id), (g, id)))).
-
-  exact (fst (naturality_sym (to (ap_functor_iso[P]))
-                             (x, I, (y, I)) (z, I, (w, I))
-                             ((f, id), (g, id)))).
-
-  transform. {
-    intros [x y].
-    exact (fst (transform[from (ap_functor_iso[P])] ((x, I), (y, I)))).
-  }
-
-  all:(try rename x into x0;
-       try rename y into y0;
-       try destruct x0 as [x y],
-                    y0 as [z w],
-                    f as [f g];
-       try destruct A as [x y]; simpl).
-
-  exact (fst (naturality (from (ap_functor_iso[P]))
-                         (x, I, (y, I)) (z, I, (w, I))
-                         ((f, id), (g, id)))).
-
-  exact (fst (naturality_sym (from (ap_functor_iso[P]))
-                             (x, I, (y, I)) (z, I, (w, I))
-                             ((f, id), (g, id)))).
-
-  apply (iso_to_from (ap_functor_iso[P]) (x0, I, (y0, I))).
-  apply (iso_from_to (ap_functor_iso[P]) (x0, I, (y0, I))).
+Program Definition ProductFunctor_Monoidal_proj1_ap_functor_iso
+  (P : MonoidalFunctor F ∏⟶ G) :
+    (⨂) ◯ F ∏⟶ F ≅[[(C ∏ C), J]] F ◯ (⨂) :=
+  {|
+    to := {| transform := _; naturality := _; naturality_sym := _ |};
+    from := {| transform := _; naturality := _; naturality_sym := _ |};
+    iso_to_from := _;
+    iso_from_to := _;
+  |}.
+Next Obligation.
+  exact (fst (transform[to (ap_functor_iso[P])] ((o, I), (o0, I)))).
 Defined.
+Next Obligation.
+  simpl in *.
+  epose proof (@naturality _ _ _ _ (to (ap_functor_iso[P]))).
+  simpl in X.
+  epose proof (X (_, I, (_, I)) (_, I, (_, I))).
+  simpl in X0.
+  clear X.
+  epose proof (X0 ((_, id), (_, id))).
+  simpl in X.
+  apply X.
+Qed.
+Next Obligation.
+  simpl in *.
+  epose proof (@naturality_sym _ _ _ _ (to (ap_functor_iso[P]))).
+  simpl in X.
+  epose proof (X (_, I, (_, I)) (_, I, (_, I))).
+  simpl in X0.
+  clear X.
+  epose proof (X0 ((_, id), (_, id))).
+  simpl in X.
+  apply X.
+Qed.
+Next Obligation.
+  simpl in *.
+  apply (fst (transform[from (ap_functor_iso[P])] ((_, I), (_, I)))).
+Defined.
+Next Obligation.
+  simpl in *.
+  epose proof (@naturality _ _ _ _ (from (ap_functor_iso[P]))).
+  simpl in X.
+  epose proof (X (_, I, (_, I)) (_, I, (_, I))).
+  simpl in X0.
+  clear X.
+  epose proof (X0 ((_, id), (_, id))).
+  simpl in X.
+  apply X.
+Qed.
+Next Obligation.
+  simpl in *.
+  epose proof (@naturality_sym _ _ _ _ (from (ap_functor_iso[P]))).
+  simpl in X.
+  epose proof (X (_, I, (_, I)) (_, I, (_, I))).
+  simpl in X0.
+  clear X.
+  epose proof (X0 ((_, id), (_, id))).
+  simpl in X.
+  apply X.
+Qed.
+Next Obligation.
+  apply (iso_to_from (ap_functor_iso[P]) (_, I, (_, I))).
+Qed.
+Next Obligation.
+  apply (iso_from_to (ap_functor_iso[P]) (_, I, (_, I))).
+Qed.
 
 Program Definition ProductFunctor_Monoidal_proj1 :
   MonoidalFunctor (F ∏⟶ G) -> MonoidalFunctor F := fun P => {|

--- a/Instance/Cat.v
+++ b/Instance/Cat.v
@@ -35,119 +35,154 @@ Record Isomorphism_FullyFaithful `(iso : C ≅ D) := {
   from_faithful : Faithful (from iso)
 }.
 
-Theorem Cat_Iso_FullyFaithful `(iso : C ≅ D) :
-  let φ := to iso in
-  let ψ := from iso in
-  let η x := to (`1 (iso_from_to iso) x) in
-  let μ x := to (`1 (iso_to_from iso) x) in
-  (* jww (2018-10-25): Do these two preconditions follow from [iso]? *)
-  (∀ x, fmap[φ] (η x) ≈ μ (φ x)) ->
-  (∀ x, fmap[ψ] (μ x) ≈ η (ψ x)) ->
-  Isomorphism_FullyFaithful iso.
-Proof.
-  construct.
-  - construct.
-    + exact (to (`1 (iso_from_to iso) y)
-               ∘ fmap[from iso] g
-               ∘ from (`1 (iso_from_to iso) x)).
-    + abstract
-        (proper;
-         now rewrite X1).
-    + abstract
-        (simpl;
-         rewrite fmap_id, id_right;
-         now apply iso_to_from).
-    + abstract
-        (simpl;
-         comp_left;
-         comp_right;
-         rewrite <- !comp_assoc;
-         rewrite (comp_assoc (`1 (iso_from_to iso) y)⁻¹);
-         rewrite (iso_from_to (`1 (iso_from_to iso) y)), id_left;
-         now apply fmap_comp).
-    + abstract
-        (simpl;
-         rewrite !fmap_comp;
-         srewrite X;
-         srewrite (`2 (iso_to_from iso));
-         rewrite !comp_assoc;
-         rewrite iso_to_from, id_left;
-         srewrite_r X;
-         rewrite <- comp_assoc;
-         rewrite <- fmap_comp;
-         rewrite iso_to_from, fmap_id, id_right;
-         reflexivity).
-  - construct.
-    abstract
-      (rewrite <- id_left;
-       rewrite <- id_right;
-       symmetry;
-       rewrite <- id_left;
-       rewrite <- id_right;
-       symmetry;
-       spose (`2 (iso_from_to iso)) as X2;
-       rewrite <- (iso_to_from (`1 (iso_from_to iso) y));
-       rewrite <- (iso_to_from (`1 (iso_from_to iso) x));
-       rewrite <- !comp_assoc;
-       rewrite (comp_assoc _ f _);
-       rewrite (comp_assoc _ g _);
-       rewrite (comp_assoc (_ ∘ _) _ _);
-       rewrite (comp_assoc (_ ∘ _) _ _);
-       rewrite <- (X2 x y f);
-       rewrite <- (X2 x y g);
-       comp_left;
-       comp_right;
-       now apply (@fmap_respects D C iso⁻¹)).
-  - construct.
-    + exact (to (`1 (iso_to_from iso) y)
-               ∘ fmap[to iso] g
-               ∘ from (`1 (iso_to_from iso) x)).
-    + abstract
-        (proper;
-         now rewrite X1).
-    + abstract
-        (simpl;
-         rewrite fmap_id, id_right;
-         now apply iso_to_from).
-    + abstract
-        (simpl;
-         comp_left;
-         comp_right;
-         rewrite <- !comp_assoc;
-         rewrite (comp_assoc (`1 (iso_to_from iso) y)⁻¹);
-         rewrite (iso_from_to (`1 (iso_to_from iso) y)), id_left;
-         now apply fmap_comp).
-    + abstract
-        (simpl;
-         rewrite !fmap_comp;
-         srewrite X0;
-         srewrite (`2 (iso_from_to iso));
-         rewrite !comp_assoc;
-         rewrite iso_to_from, id_left;
-         srewrite_r X0;
-         rewrite <- comp_assoc;
-         rewrite <- fmap_comp;
-         rewrite iso_to_from, fmap_id, id_right;
-         reflexivity).
-  - construct.
-    abstract
-      (rewrite <- id_left;
-       rewrite <- id_right;
-       symmetry;
-       rewrite <- id_left;
-       rewrite <- id_right;
-       symmetry;
-       spose (`2 (iso_to_from iso)) as X2;
-       rewrite <- (iso_to_from (`1 (iso_to_from iso) y));
-       rewrite <- (iso_to_from (`1 (iso_to_from iso) x));
-       rewrite <- !comp_assoc;
-       rewrite (comp_assoc _ f _);
-       rewrite (comp_assoc _ g _);
-       rewrite (comp_assoc (_ ∘ _) _ _);
-       rewrite (comp_assoc (_ ∘ _) _ _);
-       rewrite <- (X2 x y f);
-       rewrite <- (X2 x y g);
-       comp_left;
-       comp_right;
-       now apply (@fmap_respects C D (to iso))).
-Defined.
+Section Cat_Iso_FullyFaithful.
+  Local Obligation Tactic := simpl; intros.
+
+  Program Definition Cat_Iso_FullyFaithful `(iso : C ≅ D) :
+    let φ := to iso in
+    let ψ := from iso in
+    let η x := to (`1 (iso_from_to iso) x) in
+    let μ x := to (`1 (iso_to_from iso) x) in
+    (* jww (2018-10-25): Do these two preconditions follow from [iso]? *)
+    (∀ x, fmap[φ] (η x) ≈ μ (φ x)) ->
+    (∀ x, fmap[ψ] (μ x) ≈ η (ψ x)) ->
+    Isomorphism_FullyFaithful iso :=
+    let φ := to iso in
+    let ψ := from iso in
+    let η x := to (`1 (iso_from_to iso) x) in
+    let μ x := to (`1 (iso_to_from iso) x) in
+    fun H0 H1 =>
+    {| to_full :=
+         {| prefmap x y g := to (`1 (iso_from_to iso) y)
+                 ∘ fmap[from iso] g
+                 ∘ from (`1 (iso_from_to iso) x) |};
+       from_full :=
+         {| prefmap x y g := to (`1 (iso_to_from iso) y)
+                 ∘ fmap[to iso] g
+                 ∘ from (`1 (iso_to_from iso) x) |};
+    |}.
+  Next Obligation.
+    proper. comp_right. comp_left. now rewrite X.
+  Qed.
+  Next Obligation.
+    rewrite fmap_id, id_right.
+    apply iso_to_from.
+  Qed.
+  Next Obligation.
+    comp_right.
+    comp_left.
+    rewrite !fmap_comp.
+    comp_left.
+    rewrite comp_assoc.
+    rewrite iso_from_to.
+    cat.
+  Qed.
+  Next Obligation.
+    rewrite !fmap_comp.
+    srewrite H0.
+    srewrite (`2 (iso_to_from iso)).
+    rewrite !comp_assoc.
+    rewrite iso_to_from, id_left.
+    srewrite_r H0.
+    rewrite <- comp_assoc.
+    rewrite <- fmap_comp.
+    transitivity (g ∘ id).
+    - comp_left. rewrite iso_to_from. apply fmap_id.
+    - apply id_right.
+  Qed.
+  Next Obligation.
+    construct.
+    rewrite <- id_left.
+    rewrite <- id_right.
+    symmetry.
+    rewrite <- id_left.
+    rewrite <- id_right.
+    symmetry.
+    spose (`2 (iso_from_to iso) x y) as X2.
+    transitivity (`1 (iso_from_to iso) y ∘ (`1 (iso_from_to iso) y)⁻¹ ∘ f
+                   ∘ (`1 (iso_from_to iso) x ∘ (`1 (iso_from_to iso) x)⁻¹)).
+    { repeat apply compose_respects.
+      - symmetry. apply (iso_to_from (`1 (iso_from_to iso) y)).
+      - reflexivity.
+      - symmetry. apply (iso_to_from (`1 (iso_from_to iso) x)).
+    }
+    transitivity (`1 (iso_from_to iso) y ∘ (`1 (iso_from_to iso) y)⁻¹ ∘ g
+                   ∘ (`1 (iso_from_to iso) x ∘ (`1 (iso_from_to iso) x)⁻¹)).
+    2: {
+      repeat apply compose_respects.
+      - apply (iso_to_from (`1 (iso_from_to iso) y)).
+      - reflexivity.
+      - apply (iso_to_from (`1 (iso_from_to iso) x)).
+    }
+    rewrite <- !comp_assoc.
+    rewrite (comp_assoc _ f _).
+    rewrite (comp_assoc _ g _).
+    rewrite (comp_assoc (_ ∘ _) _ _).
+    rewrite (comp_assoc (_ ∘ _) _ _).
+    rewrite <- (X2 f).
+    rewrite <- (X2 g).
+    comp_left.
+    comp_right.
+    now apply (@fmap_respects D C iso⁻¹).
+  Qed.
+  Next Obligation.
+    proper. comp_left. comp_right. now rewrite X.
+  Qed.
+  Next Obligation.
+    cat. apply iso_to_from.
+  Qed.
+  Next Obligation.
+    comp_right. comp_left.
+    rewrite !fmap_comp.
+    comp_left.
+    rewrite comp_assoc.
+    rewrite iso_from_to.
+    cat.
+  Qed.
+  Next Obligation.
+    simpl.
+    rewrite !fmap_comp.
+    srewrite H1.
+    srewrite (`2 (iso_from_to iso)).
+    rewrite !comp_assoc.
+    rewrite iso_to_from, id_left.
+    srewrite_r H1.
+    rewrite <- comp_assoc.
+    rewrite <- fmap_comp.
+    rewrite iso_to_from, fmap_id, id_right.
+    reflexivity.
+  Qed.
+  Next Obligation.
+    construct.
+    rewrite <- id_left, <- id_right.
+    symmetry.
+    rewrite <- id_left, <- id_right.
+    symmetry.
+    transitivity (`1 (iso_to_from iso) y ∘ (`1 (iso_to_from iso) y)⁻¹ ∘ f
+                   ∘ (`1 (iso_to_from iso) x ∘ (`1 (iso_to_from iso) x)⁻¹)).
+    { repeat apply compose_respects.
+      - symmetry; apply (iso_to_from (`1 (iso_to_from iso) y)).
+      - reflexivity.
+      - symmetry; apply (iso_to_from (`1 (iso_to_from iso) x)).
+    }
+    transitivity (`1 (iso_to_from iso) y ∘ (`1 (iso_to_from iso) y)⁻¹ ∘ g
+                   ∘ (`1 (iso_to_from iso) x ∘ (`1 (iso_to_from iso) x)⁻¹)).
+    2: {
+      repeat apply compose_respects.
+      - apply (iso_to_from (`1 (iso_to_from iso) y)).
+      - reflexivity.
+      - apply (iso_to_from (`1 (iso_to_from iso) x)).
+    }
+    rewrite <- !comp_assoc.
+    rewrite (comp_assoc _ f _).
+    rewrite (comp_assoc _ g _).
+    rewrite (comp_assoc (_ ∘ _) _ _).
+    rewrite (comp_assoc (_ ∘ _) _ _).
+    spose (`2 (iso_to_from iso) x y) as X2.
+    rewrite <- (X2 f).
+    rewrite <- (X2 g).
+    comp_left.
+    comp_right.
+    now apply (@fmap_respects C D (to iso)).
+  Qed.
+End Cat_Iso_FullyFaithful.

--- a/Instance/Cat.v
+++ b/Instance/Cat.v
@@ -35,6 +35,48 @@ Record Isomorphism_FullyFaithful `(iso : C ≅ D) := {
   from_faithful : Faithful (from iso)
 }.
 
+Global Instance Cat_Iso_to_Faithful `(iso : C ≅ D) : Faithful (to iso).
+Proof.
+  construct.
+  rewrite <- id_left.
+  rewrite <- id_right.
+  symmetry.
+  rewrite <- id_left.
+  rewrite <- id_right.
+  symmetry.
+  spose (`2 (iso_from_to iso) x y) as X2.
+  transitivity (`1 (iso_from_to iso) y ∘ (`1 (iso_from_to iso) y)⁻¹ ∘ f
+                 ∘ (`1 (iso_from_to iso) x ∘ (`1 (iso_from_to iso) x)⁻¹)).
+  { repeat apply compose_respects.
+    - symmetry. apply (iso_to_from (`1 (iso_from_to iso) y)).
+    - reflexivity.
+    - symmetry. apply (iso_to_from (`1 (iso_from_to iso) x)).
+  }
+  transitivity (`1 (iso_from_to iso) y ∘ (`1 (iso_from_to iso) y)⁻¹ ∘ g
+                 ∘ (`1 (iso_from_to iso) x ∘ (`1 (iso_from_to iso) x)⁻¹)).
+  2: {
+    repeat apply compose_respects.
+    - apply (iso_to_from (`1 (iso_from_to iso) y)).
+    - reflexivity.
+    - apply (iso_to_from (`1 (iso_from_to iso) x)).
+  }
+  rewrite <- !comp_assoc.
+  rewrite (comp_assoc _ f _).
+  rewrite (comp_assoc _ g _).
+  rewrite (comp_assoc (_ ∘ _) _ _).
+  rewrite (comp_assoc (_ ∘ _) _ _).
+  rewrite <- (X2 f).
+  rewrite <- (X2 g).
+  comp_left.
+  comp_right.
+  now apply (@fmap_respects D C iso⁻¹).
+Qed.
+
+Global Instance Cat_Iso_from_Faithful `(iso : C ≅ D) : Faithful (from iso).
+Proof.
+  apply (Cat_Iso_to_Faithful (iso_sym iso)).
+Qed.
+
 Section Cat_Iso_FullyFaithful.
   Local Obligation Tactic := simpl; intros.
 
@@ -60,6 +102,10 @@ Section Cat_Iso_FullyFaithful.
          {| prefmap x y g := to (`1 (iso_to_from iso) y)
                  ∘ fmap[to iso] g
                  ∘ from (`1 (iso_to_from iso) x) |};
+       to_faithful :=
+         Cat_Iso_to_Faithful iso;
+       from_faithful :=
+         Cat_Iso_from_Faithful iso;
     |}.
   Next Obligation.
     proper. comp_right. comp_left. now rewrite X.
@@ -91,41 +137,6 @@ Section Cat_Iso_FullyFaithful.
     - apply id_right.
   Qed.
   Next Obligation.
-    construct.
-    rewrite <- id_left.
-    rewrite <- id_right.
-    symmetry.
-    rewrite <- id_left.
-    rewrite <- id_right.
-    symmetry.
-    spose (`2 (iso_from_to iso) x y) as X2.
-    transitivity (`1 (iso_from_to iso) y ∘ (`1 (iso_from_to iso) y)⁻¹ ∘ f
-                   ∘ (`1 (iso_from_to iso) x ∘ (`1 (iso_from_to iso) x)⁻¹)).
-    { repeat apply compose_respects.
-      - symmetry. apply (iso_to_from (`1 (iso_from_to iso) y)).
-      - reflexivity.
-      - symmetry. apply (iso_to_from (`1 (iso_from_to iso) x)).
-    }
-    transitivity (`1 (iso_from_to iso) y ∘ (`1 (iso_from_to iso) y)⁻¹ ∘ g
-                   ∘ (`1 (iso_from_to iso) x ∘ (`1 (iso_from_to iso) x)⁻¹)).
-    2: {
-      repeat apply compose_respects.
-      - apply (iso_to_from (`1 (iso_from_to iso) y)).
-      - reflexivity.
-      - apply (iso_to_from (`1 (iso_from_to iso) x)).
-    }
-    rewrite <- !comp_assoc.
-    rewrite (comp_assoc _ f _).
-    rewrite (comp_assoc _ g _).
-    rewrite (comp_assoc (_ ∘ _) _ _).
-    rewrite (comp_assoc (_ ∘ _) _ _).
-    rewrite <- (X2 f).
-    rewrite <- (X2 g).
-    comp_left.
-    comp_right.
-    now apply (@fmap_respects D C iso⁻¹).
-  Qed.
-  Next Obligation.
     proper. comp_left. comp_right. now rewrite X.
   Qed.
   Next Obligation.
@@ -151,38 +162,5 @@ Section Cat_Iso_FullyFaithful.
     rewrite <- fmap_comp.
     rewrite iso_to_from, fmap_id, id_right.
     reflexivity.
-  Qed.
-  Next Obligation.
-    construct.
-    rewrite <- id_left, <- id_right.
-    symmetry.
-    rewrite <- id_left, <- id_right.
-    symmetry.
-    transitivity (`1 (iso_to_from iso) y ∘ (`1 (iso_to_from iso) y)⁻¹ ∘ f
-                   ∘ (`1 (iso_to_from iso) x ∘ (`1 (iso_to_from iso) x)⁻¹)).
-    { repeat apply compose_respects.
-      - symmetry; apply (iso_to_from (`1 (iso_to_from iso) y)).
-      - reflexivity.
-      - symmetry; apply (iso_to_from (`1 (iso_to_from iso) x)).
-    }
-    transitivity (`1 (iso_to_from iso) y ∘ (`1 (iso_to_from iso) y)⁻¹ ∘ g
-                   ∘ (`1 (iso_to_from iso) x ∘ (`1 (iso_to_from iso) x)⁻¹)).
-    2: {
-      repeat apply compose_respects.
-      - apply (iso_to_from (`1 (iso_to_from iso) y)).
-      - reflexivity.
-      - apply (iso_to_from (`1 (iso_to_from iso) x)).
-    }
-    rewrite <- !comp_assoc.
-    rewrite (comp_assoc _ f _).
-    rewrite (comp_assoc _ g _).
-    rewrite (comp_assoc (_ ∘ _) _ _).
-    rewrite (comp_assoc (_ ∘ _) _ _).
-    spose (`2 (iso_to_from iso) x y) as X2.
-    rewrite <- (X2 f).
-    rewrite <- (X2 g).
-    comp_left.
-    comp_right.
-    now apply (@fmap_respects C D (to iso)).
   Qed.
 End Cat_Iso_FullyFaithful.

--- a/Instance/Cat.v
+++ b/Instance/Cat.v
@@ -80,33 +80,20 @@ Qed.
 Section Cat_Iso_FullyFaithful.
   Local Obligation Tactic := simpl; intros.
 
-  Program Definition Cat_Iso_FullyFaithful `(iso : C ≅ D) :
+  Program Definition Cat_Iso_to_Full `(iso : C ≅ D) :
     let φ := to iso in
-    let ψ := from iso in
     let η x := to (`1 (iso_from_to iso) x) in
     let μ x := to (`1 (iso_to_from iso) x) in
-    (* jww (2018-10-25): Do these two preconditions follow from [iso]? *)
     (∀ x, fmap[φ] (η x) ≈ μ (φ x)) ->
-    (∀ x, fmap[ψ] (μ x) ≈ η (ψ x)) ->
-    Isomorphism_FullyFaithful iso :=
+    Full (to iso) :=
     let φ := to iso in
-    let ψ := from iso in
     let η x := to (`1 (iso_from_to iso) x) in
     let μ x := to (`1 (iso_to_from iso) x) in
-    fun H0 H1 =>
-    {| to_full :=
-         {| prefmap x y g := to (`1 (iso_from_to iso) y)
-                 ∘ fmap[from iso] g
-                 ∘ from (`1 (iso_from_to iso) x) |};
-       from_full :=
-         {| prefmap x y g := to (`1 (iso_to_from iso) y)
-                 ∘ fmap[to iso] g
-                 ∘ from (`1 (iso_to_from iso) x) |};
-       to_faithful :=
-         Cat_Iso_to_Faithful iso;
-       from_faithful :=
-         Cat_Iso_from_Faithful iso;
-    |}.
+    fun H0 =>
+      {| prefmap x y g := to (`1 (iso_from_to iso) y)
+                             ∘ fmap[from iso] g
+                             ∘ from (`1 (iso_from_to iso) x)
+      |}.
   Next Obligation.
     proper. comp_right. comp_left. now rewrite X.
   Qed.
@@ -136,31 +123,37 @@ Section Cat_Iso_FullyFaithful.
     - comp_left. rewrite iso_to_from. apply fmap_id.
     - apply id_right.
   Qed.
-  Next Obligation.
-    proper. comp_left. comp_right. now rewrite X.
-  Qed.
-  Next Obligation.
-    cat. apply iso_to_from.
-  Qed.
-  Next Obligation.
-    comp_right. comp_left.
-    rewrite !fmap_comp.
-    comp_left.
-    rewrite comp_assoc.
-    rewrite iso_from_to.
-    cat.
-  Qed.
-  Next Obligation.
-    simpl.
-    rewrite !fmap_comp.
-    srewrite H1.
-    srewrite (`2 (iso_from_to iso)).
-    rewrite !comp_assoc.
-    rewrite iso_to_from, id_left.
-    srewrite_r H1.
-    rewrite <- comp_assoc.
-    rewrite <- fmap_comp.
-    rewrite iso_to_from, fmap_id, id_right.
-    reflexivity.
-  Qed.
 End Cat_Iso_FullyFaithful.
+
+Corollary Cat_Iso_from_Full `(iso : C ≅ D) :
+  let ψ := from iso in
+  let η x := to (`1 (iso_from_to iso) x) in
+  let μ x := to (`1 (iso_to_from iso) x) in
+  (∀ x, fmap[ψ] (μ x) ≈ η (ψ x)) ->
+  Full (from iso).
+Proof.
+  apply (Cat_Iso_to_Full (iso_sym iso)).
+Qed.
+
+Definition Cat_Iso_FullyFaithful `(iso : C ≅ D) :
+  let φ := to iso in
+  let ψ := from iso in
+  let η x := to (`1 (iso_from_to iso) x) in
+  let μ x := to (`1 (iso_to_from iso) x) in
+  (* jww (2018-10-25): Do these two preconditions follow from [iso]?
+     Columbus240 (2021-06-24): I believe, if every [iso] has these
+        properties, then the axiom of choice holds in [Cat]. See
+        https://ncatlab.org/nlab/show/equivalence+of+categories *)
+  (∀ x, fmap[φ] (η x) ≈ μ (φ x)) ->
+  (∀ x, fmap[ψ] (μ x) ≈ η (ψ x)) ->
+  Isomorphism_FullyFaithful iso :=
+  let φ := to iso in
+  let ψ := from iso in
+  let η x := to (`1 (iso_from_to iso) x) in
+  let μ x := to (`1 (iso_to_from iso) x) in
+  fun H0 H1 =>
+  {| to_full := Cat_Iso_to_Full iso H0;
+     from_full := Cat_Iso_from_Full iso H1;
+     to_faithful := Cat_Iso_to_Faithful iso;
+     from_faithful := Cat_Iso_from_Faithful iso;
+  |}.

--- a/Lib/FMapExt.v
+++ b/Lib/FMapExt.v
@@ -150,12 +150,18 @@ apply P.fold_rec.
         rewrite <- H2.
         simplify_maps.
         intuition.
-        rewrite <- H4.
+        match goal with
+        | H : M.Equal _ _ |- _ =>
+            rewrite <- H
+        end.
         simplify_maps.
       simplify_maps.
       simplify_maps.
       intuition.
-      rewrite <- H4.
+      match goal with
+      | H : M.Equal _ _ |- _ =>
+          rewrite <- H
+      end.
       simplify_maps.
     * intros H0. simplify_maps.
     rewrite <- H4 in H2.
@@ -178,7 +184,10 @@ apply P.fold_rec.
   *
   rewrite <- H4 in H2; clear H4.
   simplify_maps.
-  rewrite H0 in Heqe.
+  match goal with
+  | H : E.eq _ _ |- _ =>
+      rewrite H in *
+  end.
   congruence.
 Qed.
 

--- a/Lib/TList.v
+++ b/Lib/TList.v
@@ -25,7 +25,22 @@ Derive Signature for tlist.
 Derive NoConfusion for tlist.
 Derive Subterm for tlist.
 Next Obligation.
-Admitted.
+apply Transitive_Closure.wf_clos_trans.
+intros a.
+destruct a as [[] pr0].
+simpl in pr0.
+induction pr0.
+- (* tnil *)
+  constructor.
+  intros y H.
+  inversion H; subst; clear H.
+- (* tcons *)
+  constructor.
+  intros [[l m] pr1] H.
+  simpl in *.
+  dependent induction H.
+  assumption.
+Defined.
 
 Arguments tnil {A B i}.
 Arguments tcons {A B i} j {k} x xs.

--- a/Structure/Cartesian.v
+++ b/Structure/Cartesian.v
@@ -64,7 +64,7 @@ Next Obligation.
   reflexivity.
 Qed.
 
-Global Program Instance parametric_morphism_split {a b c d : C} :
+Global Program Instance split_respects {a b c d : C} :
   Proper (equiv ==> equiv ==> equiv) (@split a b c d).
 Next Obligation.
   proper.

--- a/Structure/Cartesian.v
+++ b/Structure/Cartesian.v
@@ -46,7 +46,7 @@ Definition split  {x y z w : C} (f : x ~> y) (g : z ~> w) :
   x × z ~> y × w :=
   (f ∘ exl) △ (g ∘ exr).
 
-Global Program Instance parametric_morphism_first {a b c : C} :
+Global Program Instance first_respects {a b c : C} :
   Proper (equiv ==> equiv) (@first a b c).
 Next Obligation.
   proper.
@@ -55,7 +55,7 @@ Next Obligation.
   reflexivity.
 Qed.
 
-Global Program Instance parametric_morphism_second {a b c : C} :
+Global Program Instance second_respects {a b c : C} :
   Proper (equiv ==> equiv) (@second a b c).
 Next Obligation.
   proper.

--- a/Structure/Cartesian/Closed.v
+++ b/Structure/Cartesian/Closed.v
@@ -46,7 +46,7 @@ Arguments eval' {_ _ _} /.
 Definition ump_exponents {x y z} (f : x × y ~> z) :
   eval ∘ first (curry f) ≈ f := @ump_exponents' _ x y z f.
 
-Global Program Instance parametric_morphism_curry (a b c : C) :
+Global Program Instance curry_respects (a b c : C) :
   Proper (equiv ==> equiv) (@curry a b c).
 Next Obligation.
   proper.
@@ -56,7 +56,7 @@ Next Obligation.
   rewrites; reflexivity.
 Qed.
 
-Global Program Instance parametric_morphism_uncurry (a b c : C) :
+Global Program Instance uncurry_respects (a b c : C) :
   Proper (equiv ==> equiv) (@uncurry a b c).
 Next Obligation.
   proper.

--- a/Structure/Cocartesian.v
+++ b/Structure/Cocartesian.v
@@ -50,15 +50,15 @@ Definition cover  {x y z w : C} (f : x ~> y) (g : z ~> w) :
   x + z ~{C}~> y + w :=
   (inl ∘ f) ▽ (inr ∘ g).
 
-Global Program Instance parametric_morphism_left {a b c : C} :
+Global Program Instance left_respects {a b c : C} :
   Proper (equiv ==> equiv) (@left a b c).
-Next Obligation. apply (@parametric_morphism_first _ O). Qed.
+Next Obligation. apply (@first_respects _ O). Qed.
 
-Global Program Instance parametric_morphism_right {a b c : C} :
+Global Program Instance right_respects {a b c : C} :
   Proper (equiv ==> equiv) (@right a b c).
-Next Obligation. apply (@parametric_morphism_second _ O). Qed.
+Next Obligation. apply (@second_respects _ O). Qed.
 
-Global Program Instance parametric_morphism_cover {a b c d : C} :
+Global Program Instance cover_respects {a b c d : C} :
   Proper (equiv ==> equiv ==> equiv) (@cover a b c d).
 Next Obligation.
   proper.

--- a/Structure/Monoid.v
+++ b/Structure/Monoid.v
@@ -168,12 +168,28 @@ Next Obligation.
   spose (@mappend_assoc _ _ _ X) as HX.
   spose (@mappend_assoc _ _ _ Y) as HY.
   assert ((split mappend[X] mappend[Y] ∘ toggle ∘ exl) △ (id[x × y] ∘ exr)
-            ≈ split (split mappend[X] mappend[Y] ∘ toggle) id[x × y])
-    by (unfork; cat).
+            ≈ split (split mappend[X] mappend[Y] ∘ toggle) id[x × y]).
+  { unfold toggle, split.
+    fork_simpl.
+    2: reflexivity.
+    fork_simpl.
+    fork_simpl.
+    fork_simpl.
+    - reflexivity.
+    - reflexivity.
+  }
   rewrite X0; clear X0.
   assert ((id[x × y] ∘ exl) △ (split mappend[X] mappend[Y] ∘ toggle ∘ exr)
-            ≈ split id[x × y] (split mappend[X] mappend[Y] ∘ toggle))
-    by (unfork; cat).
+            ≈ split id[x × y] (split mappend[X] mappend[Y] ∘ toggle)).
+  { unfold toggle, split.
+    fork_simpl.
+    1: reflexivity.
+    fork_simpl.
+    fork_simpl.
+    fork_simpl.
+    - reflexivity.
+    - reflexivity.
+  }
   rewrite X0; clear X0.
   unfold toggle.
   rewrite !split_fork.

--- a/Structure/Monoid.v
+++ b/Structure/Monoid.v
@@ -68,44 +68,96 @@ Next Obligation.
   spose (@mempty_left _ _ _ X) as HX.
   spose (@mempty_left _ _ _ Y) as HY.
   assert ((mempty[X] △ mempty[Y] ∘ exl) △ (id[x × y] ∘ exr)
-            ≈ split (mempty[X] △ mempty[Y]) id[x × y])
-    by (unfork; cat).
-  rewrite X0; clear X0.
-  unfold toggle.
-  rewrite <- !comp_assoc.
-  rewrite <- fork_comp.
-  rewrite !split_comp.
-  rewrite exl_fork, exr_fork.
-  rewrite !id_right.
-  rewrite <- (id_right mempty[X]).
-  rewrite <- (id_left exl).
-  rewrite <- (id_right mempty[Y]).
-  rewrite <- (id_left exr).
-  rewrite <- !split_comp.
-  rewrite split_fork.
-  rewrite !comp_assoc.
-  rewrite HX, HY.
-  unfold split; cat.
+            ≈ split (mempty[X] △ mempty[Y]) id[x × y]).
+  { symmetry.
+    unfold split.
+    fork_simpl; reflexivity.
+  }
+  etransitivity.
+  { apply compose_respects; [reflexivity|].
+    eapply X0.
+  }
+  clear X0.
+  transitivity (split mappend[X] mappend[Y] ∘ split mempty[X] exl △ split mempty[Y] exr).
+  { unfold toggle.
+    rewrite comp_assoc_sym.
+    apply compose_respects; [reflexivity|].
+    fork_simpl. apply fork_respects.
+    - rewrite split_comp.
+      apply split_respects.
+      + apply exl_fork.
+      + apply id_right.
+    - rewrite split_comp.
+      apply split_respects.
+      + apply exr_fork.
+      + apply id_right.
+  }
+  transitivity (split mappend[X] mappend[Y]
+  ∘ split (mempty[X] ∘ id{C}) (id{C} ∘ exl) △ split (mempty[Y] ∘ id{C}) (id{C} ∘ exr)).
+  { apply compose_respects; [reflexivity|].
+    apply fork_respects; apply split_respects;
+      try rewrite id_right; try rewrite id_left;
+      reflexivity.
+  }
+  transitivity ((mappend[X] ∘ split mempty[X] id{C} ∘ split id{C} exl)
+  △ (mappend[Y] ∘ split mempty[Y] id{C} ∘ split id{C} exr)).
+  { etransitivity.
+    { apply compose_respects; [reflexivity|].
+      rewrite <- split_comp.
+      reflexivity.
+    }
+    rewrite split_fork.
+    apply fork_respects.
+    - apply comp_assoc.
+    - etransitivity.
+      { apply compose_respects; [reflexivity|].
+        rewrite <- split_comp.
+        reflexivity.
+      }
+      apply comp_assoc.
+  }
+  etransitivity.
+  { apply fork_respects; apply compose_respects;
+      try eassumption; reflexivity.
+  }
+  clear HX HY.
+  unfold split.
+  etransitivity.
+  { apply fork_respects; fork_simpl; reflexivity. }
   now rewrite fork_comp; cat.
 Qed.
 Next Obligation.
   spose (@mempty_right _ _ _ X) as HX.
   spose (@mempty_right _ _ _ Y) as HY.
   assert ((id[x × y] ∘ exl) △ (mempty[X] △ mempty[Y] ∘ exr)
-            ≈ split id[x × y] (mempty[X] △ mempty[Y]))
-    by (unfork; cat).
-  rewrite X0; clear X0.
+            ≈ split id[x × y] (mempty[X] △ mempty[Y])).
+  { symmetry.
+    unfold split.
+    fork_simpl; reflexivity.
+  }
+  etransitivity.
+  { apply compose_respects; [reflexivity|].
+    eapply X0.
+  }
+  clear X0.
   unfold toggle.
-  rewrite <- !comp_assoc.
-  rewrite <- fork_comp.
-  rewrite !split_comp.
-  rewrite exl_fork, exr_fork.
-  rewrite !id_right.
-  rewrite <- (id_right mempty[X]).
-  rewrite <- (id_left exl).
-  rewrite <- (id_right mempty[Y]).
-  rewrite <- (id_left exr).
-  rewrite <- !split_comp.
+  transitivity (split mappend[X] mappend[Y] ∘ split exl mempty[X] △ split exr mempty[Y]).
+  { rewrite comp_assoc_sym.
+    apply compose_respects; [reflexivity|].
+    repeat fork_simpl;
+      rewrite split_comp;
+      apply split_respects; fork_simpl; reflexivity.
+  }
+  transitivity (split mappend[X] mappend[Y]
+                      ∘ split (id{C} ∘ exl) (mempty[X] ∘ id{C}) △ split (id{C} ∘ exr) (mempty[Y] ∘ id{C})).
+  { apply compose_respects; [reflexivity|].
+    fork_simpl; apply split_respects; cat.
+  }
+  etransitivity.
+  { apply compose_respects; [reflexivity|].
+    rewrite <- !split_comp.
+    reflexivity.
+  }
   rewrite split_fork.
   rewrite !comp_assoc.
   rewrite HX, HY.

--- a/Structure/Monoid.v
+++ b/Structure/Monoid.v
@@ -38,8 +38,13 @@ Lemma mappend_assoc_sym :
 Proof.
   rewrite mappend_assoc.
   rewrite <- comp_assoc.
-  rewrite iso_to_from.
-  cat.
+  symmetry.
+  etransitivity.
+  { apply compose_respects.
+    1: reflexivity.
+    apply  iso_to_from.
+  }
+  apply id_right.
 Qed.
 
 End MonoidObject.

--- a/Structure/Monoid.v
+++ b/Structure/Monoid.v
@@ -192,27 +192,190 @@ Next Obligation.
   }
   rewrite X0; clear X0.
   unfold toggle.
-  rewrite !split_fork.
+  etransitivity.
+  { apply compose_respects.
+    - apply split_fork.
+    - apply split_respects; [|reflexivity].
+      apply split_fork.
+  }
+  etransitivity.
+  2: {
+    symmetry.
+    apply compose_respects.
+    2: reflexivity.
+    apply compose_respects.
+    - apply split_fork.
+    - apply split_respects; [reflexivity|].
+      apply split_fork.
+  }
   rewrite <- !fork_comp.
-  rewrite <- !comp_assoc.
-  rewrite !split_fork.
-  rewrite !id_left.
-  rewrite !comp_assoc.
-  rewrite !exl_fork.
-  rewrite !exr_fork.
-  rewrite <- !comp_assoc.
-  rewrite !split_comp.
-  rewrite !exl_fork.
-  rewrite !exr_fork.
-  rewrite !id_right.
-  rewrite <- (id_left (exl (x:=x) (y:=y))) at 1.
-  rewrite <- (id_left (exr (x:=x) (y:=y))) at 1.
-  rewrite <- !split_comp.
-  rewrite !comp_assoc.
-  rewrite HX, HY.
-  rewrite !id_left.
-  apply fork_respects; clear;
-  now unfold split; unfork; cat.
+  apply fork_respects.
+  - rewrite <- !comp_assoc.
+    etransitivity.
+    2: {
+      symmetry.
+      apply compose_respects; [reflexivity|].
+      etransitivity.
+      { apply compose_respects; [reflexivity|].
+        rewrite split_fork.
+        rewrite id_left.
+        reflexivity.
+      }
+      rewrite split_fork.
+      apply fork_respects.
+      + apply comp_assoc.
+      + rewrite comp_assoc.
+        rewrite exl_fork.
+        reflexivity.
+    }
+    etransitivity.
+    { apply compose_respects; [reflexivity|].
+      rewrite split_comp.
+      apply split_respects.
+      - apply exl_fork.
+      - apply id_right.
+    }
+    rewrite <- (id_left (exl (x:=x) (y:=y))) at 1.
+    rewrite <- split_comp.
+    rewrite !comp_assoc.
+    rewrite HX.
+    rewrite id_left.
+    clear.
+    unfold split.
+    etransitivity.
+    { fork_simpl. fork_simpl.
+      apply compose_respects; [reflexivity|].
+      fork_simpl. fork_simpl.
+      apply fork_respects.
+      - rewrite comp_assoc.
+        etransitivity.
+        { apply compose_respects; [| reflexivity].
+          fork_simpl.
+          reflexivity.
+        }
+        fork_simpl.
+        etransitivity.
+        { apply compose_respects; [reflexivity|].
+          fork_simpl.
+          reflexivity.
+        }
+        rewrite comp_assoc.
+        apply compose_respects; [|reflexivity].
+        fork_simpl.
+        reflexivity.
+      - fork_simpl.
+        apply compose_respects; [reflexivity|].
+        rewrite comp_assoc.
+        etransitivity.
+        { apply compose_respects.
+          2: reflexivity.
+          fork_simpl.
+          reflexivity.
+        }
+        fork_simpl.
+        apply fork_respects.
+        + fork_simpl.
+          etransitivity.
+          { apply compose_respects; [reflexivity|].
+            fork_simpl.
+            reflexivity.
+          }
+          rewrite comp_assoc.
+          apply compose_respects; [|reflexivity].
+          fork_simpl.
+          reflexivity.
+        + fork_simpl.
+          reflexivity.
+    }
+    apply compose_respects; [reflexivity|].
+    apply fork_respects; [reflexivity|].
+    rewrite <- comp_assoc.
+    apply compose_respects; [reflexivity|].
+    rewrite <- comp_assoc.
+    unfork.
+  - rewrite <- !comp_assoc.
+    etransitivity.
+    2: {
+      symmetry.
+      apply compose_respects; [reflexivity|].
+      etransitivity.
+      { apply compose_respects; [reflexivity|].
+        rewrite split_fork.
+        rewrite id_left.
+        reflexivity.
+      }
+      rewrite split_fork.
+      apply fork_respects.
+      + apply comp_assoc.
+      + rewrite comp_assoc.
+        rewrite exr_fork.
+        reflexivity.
+    }
+    etransitivity.
+    { apply compose_respects; [reflexivity|].
+      rewrite split_comp.
+      apply split_respects.
+      - apply exr_fork.
+      - apply id_right.
+    }
+    rewrite <- (id_left (exr (x:=x) (y:=y))) at 1.
+    rewrite <- split_comp.
+    rewrite !comp_assoc.
+    rewrite HY.
+    rewrite id_left.
+    clear.
+    unfold split.
+    etransitivity.
+    { fork_simpl. fork_simpl.
+      apply compose_respects; [reflexivity|].
+      fork_simpl. fork_simpl.
+      apply fork_respects.
+      - rewrite comp_assoc.
+        etransitivity.
+        { apply compose_respects; [| reflexivity].
+          fork_simpl.
+          reflexivity.
+        }
+        fork_simpl.
+        etransitivity.
+        { apply compose_respects; [reflexivity|].
+          fork_simpl.
+          reflexivity.
+        }
+        rewrite comp_assoc.
+        apply compose_respects; [|reflexivity].
+        fork_simpl.
+        reflexivity.
+      - fork_simpl.
+        apply compose_respects; [reflexivity|].
+        rewrite comp_assoc.
+        etransitivity.
+        { apply compose_respects.
+          2: reflexivity.
+          fork_simpl.
+          reflexivity.
+        }
+        fork_simpl.
+        apply fork_respects.
+        + fork_simpl.
+          etransitivity.
+          { apply compose_respects; [reflexivity|].
+            fork_simpl.
+            reflexivity.
+          }
+          rewrite comp_assoc.
+          apply compose_respects; [|reflexivity].
+          fork_simpl.
+          reflexivity.
+        + fork_simpl.
+          reflexivity.
+    }
+    apply compose_respects; [reflexivity|].
+    apply fork_respects; [reflexivity|].
+    rewrite <- comp_assoc.
+    apply compose_respects; [reflexivity|].
+    rewrite <- comp_assoc.
+    unfork.
 Qed.
 
 Context `{@Closed C _}.
@@ -236,22 +399,29 @@ Global Program Instance Hom_Monoid {x} `(Y : Monoid y) :
 Next Obligation.
   spose (@mempty_left _ _ _ Y) as HY.
   remember ((curry _ ∘ exl) △ (id[y ^ x] ∘ exr)) as h.
-  assert (h ≈ split (curry (mempty[Y] ∘ exl)) id[y ^ x])
-    by (rewrite Heqh; unfork; cat).
+  assert (h ≈ split (curry (mempty[Y] ∘ exl)) id[y ^ x]).
+  { rewrite Heqh.
+    reflexivity.
+  }
   rewrite X; clear X Heqh h.
   rewrite uncurry_exl_fork_exr.
   unfold doppel.
   rewrite split_fork.
   rewrite curry_comp_l.
-  rewrite <- comp_assoc.
-  rewrite <- fork_comp.
-  rewrite <- !comp_assoc.
-  rewrite <- !first_comp.
-  rewrite exl_split.
-  rewrite exr_split.
-  rewrite !eval_first.
-  rewrite !uncurry_comp.
-  rewrite !uncurry_curry.
+  etransitivity.
+  { apply curry_respects.
+    rewrite comp_assoc_sym.
+    apply compose_respects; [reflexivity|].
+    rewrite <- fork_comp.
+    rewrite <- !comp_assoc.
+    rewrite <- !first_comp.
+    rewrite exl_split.
+    rewrite exr_split.
+    rewrite !eval_first.
+    rewrite !uncurry_comp.
+    rewrite !uncurry_curry.
+    reflexivity.
+  }
   rewrite <- !comp_assoc.
   rewrite !exl_first.
   rewrite <- split_fork.
@@ -269,22 +439,29 @@ Qed.
 Next Obligation.
   spose (@mempty_right _ _ _ Y) as HY.
   remember ((id[y ^ x] ∘ exl) △ (curry _ ∘ exr)) as h.
-  assert (h ≈ split id[y ^ x] (curry (mempty[Y] ∘ exl)))
-    by (rewrite Heqh; unfork; cat).
+  assert (h ≈ split id[y ^ x] (curry (mempty[Y] ∘ exl))).
+  { rewrite Heqh.
+    reflexivity.
+  }
   rewrite X; clear X Heqh h.
   rewrite uncurry_exl_fork_exr.
   unfold doppel.
   rewrite split_fork.
   rewrite curry_comp_l.
-  rewrite <- comp_assoc.
-  rewrite <- fork_comp.
-  rewrite <- !comp_assoc.
-  rewrite <- !first_comp.
-  rewrite exl_split.
-  rewrite exr_split.
-  rewrite !eval_first.
-  rewrite !uncurry_comp.
-  rewrite !uncurry_curry.
+  etransitivity.
+  { apply curry_respects.
+    rewrite comp_assoc_sym.
+    apply compose_respects; [reflexivity|].
+    rewrite <- fork_comp.
+    rewrite <- !comp_assoc.
+    rewrite <- !first_comp.
+    rewrite exl_split.
+    rewrite exr_split.
+    rewrite !eval_first.
+    rewrite !uncurry_comp.
+    rewrite !uncurry_curry.
+    reflexivity.
+  }
   rewrite <- !comp_assoc.
   rewrite !exl_first.
   rewrite <- split_fork.
@@ -301,28 +478,119 @@ Next Obligation.
 Qed.
 Next Obligation.
   spose (@mappend_assoc _ _ _ Y) as HY.
-  rewrite uncurry_exl_fork_exr.
+  etransitivity.
+  { apply compose_respects.
+    - apply curry_respects.
+      apply compose_respects; [reflexivity|].
+      apply uncurry_exl_fork_exr.
+    - apply fork_respects.
+      2: reflexivity.
+      apply compose_respects; [|reflexivity].
+      apply curry_respects.
+      apply compose_respects; [reflexivity|].
+      apply uncurry_exl_fork_exr.
+  }
+  etransitivity.
+  2: {
+    symmetry.
+    apply compose_respects; [|reflexivity].
+    apply compose_respects.
+    - apply curry_respects.
+      apply compose_respects; [reflexivity|].
+      apply uncurry_exl_fork_exr.
+    - apply fork_respects.
+      1: reflexivity.
+      apply compose_respects; [|reflexivity].
+      apply curry_respects.
+      apply compose_respects; [reflexivity|].
+      apply uncurry_exl_fork_exr.
+  }
   remember ((curry _ ∘ exl) △ (id[y ^ x] ∘ exr)) as h.
-  assert (h ≈ split (curry (mappend[Y] ∘ split eval eval ∘ doppel)) id[y ^ x])
-    by (rewrite Heqh; unfork; cat).
+  assert (h ≈ split (curry (mappend[Y] ∘ split eval eval ∘ doppel)) id[y ^ x]).
+  { rewrite Heqh.
+    unfold split.
+    apply fork_respects; try reflexivity.
+    apply compose_respects; try reflexivity.
+    apply curry_respects.
+    apply comp_assoc.
+  }
   rewrite X; clear X Heqh h.
   remember ((id[y ^ x] ∘ exl) △ (curry _ ∘ exr)) as h.
-  assert (h ≈ split id[y ^ x] (curry (mappend[Y] ∘ split eval eval ∘ doppel)))
-    by (rewrite Heqh; unfork; cat).
+  assert (h ≈ split id[y ^ x] (curry (mappend[Y] ∘ split eval eval ∘ doppel))).
+  { rewrite Heqh.
+    unfold split.
+    apply fork_respects; try reflexivity.
+    apply compose_respects; try reflexivity.
+    apply curry_respects.
+    apply comp_assoc.
+  }
   rewrite X; clear X Heqh h.
   unfold doppel.
+  etransitivity.
+  { apply compose_respects.
+    - apply curry_respects.
+      apply compose_respects; [reflexivity|].
+      rewrite !split_fork.
+      rewrite !eval_first.
+      reflexivity.
+    - rewrite <- !comp_assoc.
+      reflexivity.
+  }
   rewrite <- !comp_assoc.
   rewrite !split_fork.
   rewrite !eval_first.
   simpl.
-  rewrite split_fork.
-  rewrite !eval_first.
+  etransitivity.
+  { apply compose_respects; [reflexivity|].
+    apply split_respects; [|reflexivity].
+    rewrite split_fork.
+    rewrite !eval_first.
+    reflexivity.
+  }
+  etransitivity.
+  2: {
+    symmetry.
+    apply compose_respects; [reflexivity|].
+    apply fork_respects; [reflexivity|].
+    rewrite split_fork.
+    rewrite !eval_first.
+    reflexivity.
+  }
   unfold split.
   rewrite !id_left.
   rewrite !curry_comp_l.
-  rewrite <- !comp_assoc.
-  rewrite <- !fork_comp.
-  rewrite <- !uncurry_comp.
+  etransitivity.
+  { apply curry_respects.
+    fork_simpl.
+    apply compose_respects; [reflexivity|].
+    fork_simpl.
+    apply fork_respects.
+    - rewrite <- !comp_assoc.
+      rewrite <- !fork_comp.
+      rewrite <- !uncurry_comp.
+      reflexivity.
+    - rewrite <- !comp_assoc.
+      rewrite <- !fork_comp.
+      rewrite <- !uncurry_comp.
+      reflexivity.
+  }
+  etransitivity.
+  2: {
+    symmetry.
+    apply curry_respects.
+    fork_simpl.
+    apply compose_respects; [reflexivity|].
+    fork_simpl.
+    apply fork_respects.
+    - rewrite <- !comp_assoc.
+      rewrite <- !fork_comp.
+      rewrite <- !uncurry_comp.
+      reflexivity.
+    - rewrite <- !comp_assoc.
+      rewrite <- !fork_comp.
+      rewrite <- !uncurry_comp.
+      reflexivity.
+  }
   rewrite exl_fork.
   rewrite exr_fork.
   rewrite !uncurry_curry.
@@ -331,12 +599,52 @@ Next Obligation.
   rewrite comp_assoc.
   rewrite HY; clear HY.
   rewrite id_left.
-  rewrite <- !comp_assoc.
-  rewrite <- !fork_comp.
-  rewrite <- !comp_assoc.
-  rewrite !exl_fork.
-  rewrite !exr_fork.
-  now rewrite uncurry_curry.
+  etransitivity.
+  { apply curry_respects.
+    fork_simpl. fork_simpl.
+    etransitivity.
+    { apply compose_respects; [reflexivity|].
+      fork_simpl.
+      apply fork_respects.
+      - rewrite <- !fork_comp.
+        fork_simpl.
+        fork_simpl.
+        reflexivity.
+      - rewrite <- !fork_comp.
+        fork_simpl.
+        rewrite exr_fork.
+        rewrite <- comp_assoc.
+        rewrite exl_fork.
+        rewrite !exr_fork.
+        reflexivity.
+    }
+    rewrite !exl_fork.
+    reflexivity.
+  }
+  etransitivity.
+  2: {
+    symmetry.
+    apply curry_respects.
+    apply compose_respects; [reflexivity|].
+    apply fork_respects.
+    - rewrite !exl_fork.
+      reflexivity.
+    - apply uncurry_respects.
+      rewrite exr_fork.
+      apply curry_respects.
+      rewrite exl_fork.
+      rewrite exr_fork.
+      reflexivity.
+  }
+  etransitivity.
+  2: {
+    symmetry.
+    apply curry_respects.
+    apply compose_respects; [reflexivity|].
+    apply fork_respects; [reflexivity|].
+    apply uncurry_curry.
+  }
+  reflexivity.
 Qed.
 
 End Monoid.

--- a/Structure/Monoidal/Internal/Product.v
+++ b/Structure/Monoidal/Internal/Product.v
@@ -109,39 +109,42 @@ Next Obligation.
   intros; simpl.
   repeat fork_simpl.
   symmetry. repeat fork_simpl.
-  - solve_fork_split; [reflexivity|].
+  { solve_fork_split; [reflexivity|].
     symmetry.
     repeat fork_simpl.
     solve_fork_split.
     solve_fork_split.
     reflexivity.
-  - symmetry. repeat fork_simpl.
-    + symmetry. repeat fork_simpl.
-      solve_fork_split; [reflexivity|].
-      symmetry.
-      solve_fork_split.
-      { solve_fork_split.
-        { solve_fork_split. }
-        repeat fork_simpl.
-        solve_fork_split.
-      }
+  }
+  symmetry. repeat fork_simpl.
+  all: symmetry; repeat fork_simpl.
+  { solve_fork_split; [reflexivity|].
+    symmetry.
+    solve_fork_split.
+    { solve_fork_split.
+      { solve_fork_split. }
       repeat fork_simpl.
-      reflexivity.
-    + symmetry. repeat fork_simpl.
-      * symmetry. repeat fork_simpl.
-        solve_fork_split.
-        { solve_fork_split.
-          { solve_fork_split. }
-          repeat fork_simpl.
-          solve_fork_split.
-        }
-        repeat fork_simpl.
-        reflexivity.
-      * symmetry.
-        solve_fork_split.
-        { solve_fork_split. }
-        repeat fork_simpl.
-        reflexivity.
+      solve_fork_split.
+    }
+    repeat fork_simpl.
+    reflexivity.
+  }
+  { symmetry. repeat fork_simpl.
+    solve_fork_split.
+    { solve_fork_split.
+      { solve_fork_split. }
+      repeat fork_simpl.
+      solve_fork_split.
+    }
+    repeat fork_simpl.
+    reflexivity.
+  }
+  { symmetry.
+    solve_fork_split.
+    { solve_fork_split. }
+    repeat fork_simpl.
+    reflexivity.
+  }
 Qed.
 
 Program Definition InternalProduct_SymmetricMonoidal :

--- a/Structure/Monoidal/Internal/Product.v
+++ b/Structure/Monoidal/Internal/Product.v
@@ -22,9 +22,58 @@ Context {C : Category}.
 Context `{@Cartesian C}.
 Context `{@Terminal C}.
 
-Local Obligation Tactic :=
-  unfold proj_left, proj_right; simpl;
-  cat_simpl; try split; intros; unfork; cat.
+Local Obligation Tactic := unfold proj_left, proj_right.
+
+Local Ltac fork_simpl :=
+  match goal with
+  | |- _ ∘ _ ∘ _ ≈ _ =>
+    rewrite comp_assoc_sym
+  | |- id{C} ∘ _ ≈ _ =>
+    rewrite id_left
+  | |- _ ∘ id{C} ≈ _ =>
+    rewrite id_right
+  | |- exl ∘ exl △ _ ≈ _ =>
+    apply exl_fork
+  | |- exl ∘ exr △ _ ≈ _ =>
+    apply exl_fork
+  | |- exl ∘ _ △ _ ≈ _ =>
+    rewrite exl_fork
+  | |- exr ∘ _ △ _ ≈ _ =>
+    rewrite exr_fork
+  | |- _ △ _ ∘ _ ≈ _ =>
+    rewrite <- fork_comp
+  | |- (exl △ exr) △ _ ≈ _ =>
+    eapply transitivity;
+      [apply fork_respects; [apply fork_exl_exr|reflexivity]|]
+  | |- _ △ (exl △ exr) ≈ _ =>
+    eapply transitivity;
+      [apply fork_respects; [reflexivity|apply fork_exl_exr]|]
+  | |- _ △ _ ≈ _ △ _ => apply fork_respects
+  end.
+
+Local Ltac solve_fork_split :=
+  match goal with
+  | |- exr ∘ _ ≈ _ =>
+    eapply transitivity; [apply compose_respects; [reflexivity|]; repeat fork_simpl;
+                          match goal with
+                          | |- _ △ _ ≈ _ => reflexivity
+                          | _ => idtac
+                          end
+                         |]; repeat fork_simpl; match goal with
+                                                | |- _ △ _ ≈ _ => reflexivity
+                                                | _ => idtac
+                                                end
+  | |- exl ∘ _ ≈ _ =>
+    eapply transitivity; [apply compose_respects; [reflexivity|]; repeat fork_simpl;
+                          match goal with
+                          | |- _ △ _ ≈ _ => reflexivity
+                          | _ => idtac
+                          end
+                         |]; repeat fork_simpl; match goal with
+                                                | |- _ △ _ ≈ _ => reflexivity
+                                                | _ => idtac
+                                                end
+  end.
 
 (* Every cartesian category with terminal objects gives rise to a monoidal
    category taking the terminal object as unit, and the tensor as product. *)
@@ -33,6 +82,118 @@ Program Definition InternalProduct_Monoidal : @Monoidal C := {|
   tensor := InternalProductFunctor C;
   I := 1
 |}.
+Next Obligation.
+  cat_simpl.
+Qed.
+Next Obligation.
+  cat_simpl.
+  rewrite <- !fork_comp.
+  repeat fork_simpl.
+  { cat. }
+  transitivity (g ∘ id{C}).
+  2: { cat. }
+  apply compose_respects; [reflexivity|].
+  cat.
+Qed.
+Next Obligation.
+  cat_simpl.
+Qed.
+Next Obligation.
+  cat_simpl.
+  rewrite <- !fork_comp.
+  repeat fork_simpl.
+  2: { cat. }
+  transitivity (g ∘ id{C}).
+  2: { cat. }
+  apply compose_respects; [reflexivity|].
+  cat.
+Qed.
+Next Obligation.
+  cat_simpl.
+  repeat fork_simpl.
+  symmetry; repeat fork_simpl; symmetry; repeat fork_simpl.
+  - symmetry.
+    solve_fork_split.
+    apply compose_respects; [reflexivity|].
+    symmetry.
+    repeat fork_simpl.
+    reflexivity.
+  - symmetry.
+    repeat fork_simpl.
+    solve_fork_split.
+    apply compose_respects; [reflexivity|].
+    symmetry.
+    solve_fork_split.
+    reflexivity.
+  - symmetry.
+    fork_simpl.
+    apply compose_respects; [reflexivity|].
+    symmetry.
+    solve_fork_split.
+    reflexivity.
+Qed.
+Next Obligation.
+  cat_simpl.
+  repeat fork_simpl; symmetry; repeat fork_simpl; symmetry; repeat fork_simpl; symmetry; repeat fork_simpl.
+  - apply compose_respects; [reflexivity|].
+    symmetry.
+    solve_fork_split.
+  - solve_fork_split.
+    apply compose_respects; [reflexivity|].
+    symmetry.
+    solve_fork_split.
+    reflexivity.
+  - solve_fork_split.
+    apply compose_respects; [reflexivity|].
+    symmetry.
+    fork_simpl.
+    reflexivity.
+Qed.
+Next Obligation.
+  intros. simpl.
+  symmetry; repeat fork_simpl.
+  { reflexivity. }
+  solve_fork_split.
+  cat.
+Qed.
+Next Obligation.
+  intros; simpl.
+  repeat fork_simpl.
+  symmetry. repeat fork_simpl.
+  - solve_fork_split; [reflexivity|].
+    symmetry.
+    repeat fork_simpl.
+    solve_fork_split.
+    solve_fork_split.
+    reflexivity.
+  - symmetry. repeat fork_simpl.
+    + symmetry. repeat fork_simpl.
+      solve_fork_split; [reflexivity|].
+      symmetry.
+      solve_fork_split.
+      { solve_fork_split.
+        { solve_fork_split. }
+        repeat fork_simpl.
+        solve_fork_split.
+      }
+      repeat fork_simpl.
+      reflexivity.
+    + symmetry. repeat fork_simpl.
+      * symmetry. repeat fork_simpl.
+        solve_fork_split.
+        { solve_fork_split.
+          { solve_fork_split. }
+          repeat fork_simpl.
+          solve_fork_split.
+        }
+        repeat fork_simpl.
+        reflexivity.
+      * symmetry.
+        solve_fork_split.
+        { solve_fork_split. }
+        repeat fork_simpl.
+        reflexivity.
+Qed.
 
 Program Definition InternalProduct_SymmetricMonoidal :
   @SymmetricMonoidal C InternalProduct_Monoidal := {|
@@ -43,6 +204,71 @@ Program Definition InternalProduct_SymmetricMonoidal :
      ; iso_from_to := swap_invol
     |}
 |}.
+Next Obligation.
+  unfold swap.
+  simpl. split; intros.
+  - repeat fork_simpl.
+    symmetry. repeat fork_simpl.
+    + solve_fork_split.
+      rewrite comp_assoc_sym.
+      apply compose_respects; [reflexivity|].
+      repeat fork_simpl.
+      symmetry.
+      solve_fork_split.
+    + solve_fork_split.
+      symmetry.
+      repeat fork_simpl.
+      solve_fork_split.
+      apply compose_respects; [reflexivity|].
+      fork_simpl.
+      reflexivity.
+  - repeat fork_simpl.
+    symmetry. repeat fork_simpl.
+    + solve_fork_split.
+      symmetry.
+      repeat fork_simpl.
+      solve_fork_split.
+      apply compose_respects; [reflexivity|].
+      fork_simpl.
+    + solve_fork_split.
+      rewrite comp_assoc_sym.
+      apply compose_respects; [reflexivity|].
+      solve_fork_split.
+      symmetry.
+      solve_fork_split.
+      reflexivity.
+Qed.
+Next Obligation.
+  simpl. intros. apply swap_invol.
+Defined.
+Next Obligation.
+  simpl. unfold swap. intros.
+  repeat fork_simpl. symmetry. repeat fork_simpl.
+  - solve_fork_split.
+    solve_fork_split.
+    symmetry.
+    repeat fork_simpl.
+    solve_fork_split.
+    { solve_fork_split. }
+    repeat fork_simpl.
+    reflexivity.
+  - symmetry. repeat fork_simpl.
+    + solve_fork_split.
+      { solve_fork_split. }
+      repeat fork_simpl.
+      symmetry.
+      solve_fork_split.
+      { solve_fork_split. }
+      repeat fork_simpl.
+      reflexivity.
+    + solve_fork_split.
+      symmetry.
+      solve_fork_split.
+      { solve_fork_split. }
+      solve_fork_split.
+      solve_fork_split.
+      reflexivity.
+Qed.
 
 Program Definition InternalProduct_CartesianMonoidal :
   @CartesianMonoidal C InternalProduct_Monoidal := {|
@@ -50,12 +276,82 @@ Program Definition InternalProduct_CartesianMonoidal :
   is_relevance := {| diagonal  := fun _ => id △ id |}
 |}.
 Next Obligation.
+  cat_simpl.
+Qed.
+Next Obligation.
   apply InternalProduct_SymmetricMonoidal.
 Defined.
+Next Obligation.
+  cat_simpl.
+  repeat fork_simpl.
+  symmetry. repeat fork_simpl.
+  all: symmetry; repeat fork_simpl.
+  all: transitivity (g ∘ id{C}); [|cat].
+  all: apply compose_respects; [reflexivity|].
+  all: cat.
+Qed.
 Next Obligation.
   apply fork_respects.
     apply one_unique.
   reflexivity.
+Qed.
+Next Obligation.
+  intros. simpl.
+  repeat fork_simpl.
+  symmetry. repeat fork_simpl.
+  - solve_fork_split.
+    { solve_fork_split. }
+    repeat fork_simpl.
+    symmetry.
+    repeat fork_simpl.
+    reflexivity.
+  - symmetry. repeat fork_simpl; symmetry; repeat fork_simpl.
+    all: solve_fork_split.
+    3: reflexivity.
+    { solve_fork_split. }
+    solve_fork_split.
+    reflexivity.
+Qed.
+Next Obligation.
+  simpl. unfold swap.
+  intros.
+  repeat fork_simpl; reflexivity.
+Qed.
+
+Next Obligation.
+  intros. simpl. unfold swap. symmetry.
+  eapply transitivity.
+  2: {
+    apply fork_respects; apply fork_exl_exr.
+  }
+  repeat fork_simpl.
+  - repeat solve_fork_split.
+    reflexivity.
+  - repeat solve_fork_split.
+    all: reflexivity.
+  - repeat solve_fork_split.
+    all: reflexivity.
+Qed.
+Next Obligation.
+  intros. simpl.
+  repeat fork_simpl.
+  solve_fork_split.
+  reflexivity.
+Qed.
+Next Obligation.
+  intros. simpl.
+  repeat fork_simpl.
+  solve_fork_split.
+  reflexivity.
+Qed.
+Next Obligation.
+  intros. simpl. unfold swap.
+  fork_simpl.
+  reflexivity.
+Qed.
+Next Obligation.
+  intros. simpl. unfold swap.
+  fork_simpl.
 Qed.
 
 End InternalProduct.

--- a/Structure/Monoidal/Internal/Product.v
+++ b/Structure/Monoidal/Internal/Product.v
@@ -87,13 +87,15 @@ Next Obligation.
 Qed.
 Next Obligation.
   cat_simpl.
+  rewrite id_left.
   rewrite <- !fork_comp.
-  repeat fork_simpl.
+  rewrite exl_fork.
+  apply fork_respects.
   { cat. }
-  transitivity (g ∘ id{C}).
-  2: { cat. }
-  apply compose_respects; [reflexivity|].
   cat.
+  rewrite <- comp_assoc.
+  rewrite <- id_right with (f := g) at 2;
+  apply compose_respects; cat.
 Qed.
 Next Obligation.
   cat_simpl.
@@ -111,43 +113,17 @@ Qed.
 Next Obligation.
   cat_simpl.
   repeat fork_simpl.
-  symmetry; repeat fork_simpl; symmetry; repeat fork_simpl.
-  - symmetry.
-    solve_fork_split.
-    apply compose_respects; [reflexivity|].
-    symmetry.
-    repeat fork_simpl.
-    reflexivity.
-  - symmetry.
-    repeat fork_simpl.
-    solve_fork_split.
-    apply compose_respects; [reflexivity|].
-    symmetry.
-    solve_fork_split.
-    reflexivity.
-  - symmetry.
-    fork_simpl.
-    apply compose_respects; [reflexivity|].
-    symmetry.
-    solve_fork_split.
-    reflexivity.
+  symmetry; repeat fork_simpl; symmetry; repeat fork_simpl;
+    symmetry; repeat fork_simpl; try solve_fork_split;
+    (apply compose_respects; [reflexivity|]);
+    symmetry; solve_fork_split; reflexivity.
 Qed.
 Next Obligation.
   cat_simpl.
-  repeat fork_simpl; symmetry; repeat fork_simpl; symmetry; repeat fork_simpl; symmetry; repeat fork_simpl.
-  - apply compose_respects; [reflexivity|].
-    symmetry.
-    solve_fork_split.
-  - solve_fork_split.
-    apply compose_respects; [reflexivity|].
-    symmetry.
-    solve_fork_split.
-    reflexivity.
-  - solve_fork_split.
-    apply compose_respects; [reflexivity|].
-    symmetry.
-    fork_simpl.
-    reflexivity.
+  repeat fork_simpl; symmetry; repeat fork_simpl; symmetry;
+    repeat fork_simpl; symmetry; repeat fork_simpl;
+    try solve_fork_split; (apply compose_respects; [reflexivity|]);
+    symmetry; solve_fork_split; reflexivity.
 Qed.
 Next Obligation.
   intros. simpl.

--- a/Structure/Monoidal/Internal/Product.v
+++ b/Structure/Monoidal/Internal/Product.v
@@ -24,33 +24,6 @@ Context `{@Terminal C}.
 
 Local Obligation Tactic := unfold proj_left, proj_right.
 
-Local Ltac fork_simpl :=
-  match goal with
-  | |- _ ∘ _ ∘ _ ≈ _ =>
-    rewrite comp_assoc_sym
-  | |- id{C} ∘ _ ≈ _ =>
-    rewrite id_left
-  | |- _ ∘ id{C} ≈ _ =>
-    rewrite id_right
-  | |- exl ∘ exl △ _ ≈ _ =>
-    apply exl_fork
-  | |- exl ∘ exr △ _ ≈ _ =>
-    apply exl_fork
-  | |- exl ∘ _ △ _ ≈ _ =>
-    rewrite exl_fork
-  | |- exr ∘ _ △ _ ≈ _ =>
-    rewrite exr_fork
-  | |- _ △ _ ∘ _ ≈ _ =>
-    rewrite <- fork_comp
-  | |- (exl △ exr) △ _ ≈ _ =>
-    eapply transitivity;
-      [apply fork_respects; [apply fork_exl_exr|reflexivity]|]
-  | |- _ △ (exl △ exr) ≈ _ =>
-    eapply transitivity;
-      [apply fork_respects; [reflexivity|apply fork_exl_exr]|]
-  | |- _ △ _ ≈ _ △ _ => apply fork_respects
-  end.
-
 Local Ltac solve_fork_split :=
   match goal with
   | |- exr ∘ _ ≈ _ =>

--- a/Structure/Monoidal/Proofs.v
+++ b/Structure/Monoidal/Proofs.v
@@ -24,7 +24,17 @@ Proof.
   intros.
   rewrite <- id_right; symmetry;
   rewrite <- id_right; symmetry.
-  rewrite <- (iso_to_from unit_left).
+  etransitivity.
+  { apply compose_respects; [reflexivity|].
+    rewrite <- (iso_to_from unit_left).
+    reflexivity.
+  }
+  etransitivity.
+  2: {
+    apply compose_respects; [reflexivity|].
+    rewrite <- (iso_to_from unit_left).
+    reflexivity.
+  }
   rewrite !comp_assoc.
   rewrite !to_unit_left_natural.
   rewrites; reflexivity.
@@ -36,7 +46,17 @@ Proof.
   intros.
   rewrite <- id_right; symmetry;
   rewrite <- id_right; symmetry.
-  rewrite <- (iso_to_from unit_right).
+  etransitivity.
+  { apply compose_respects; [reflexivity|].
+    rewrite <- (iso_to_from unit_right).
+    reflexivity.
+  }
+  etransitivity.
+  2: {
+    apply compose_respects; [reflexivity|].
+    rewrite <- (iso_to_from unit_right).
+    reflexivity.
+  }
   rewrite !comp_assoc.
   rewrite !to_unit_right_natural.
   rewrites; reflexivity.
@@ -54,8 +74,8 @@ Proof.
      following diagram commutes..." *)
   assert (unit_left ∘ id ⨂ unit_left
             << I ⨂ (I ⨂ x) ~~> x >>
-          unit_left ∘ unit_left).
-    rewrite to_unit_left_natural; reflexivity.
+            unit_left ∘ unit_left)
+    by (rewrite to_unit_left_natural; reflexivity).
 
   (* "Since lX is an isomorphism, the first identity follows." *)
   symmetry.
@@ -72,8 +92,8 @@ Proof.
      following diagram commutes..." *)
   assert (unit_right ∘ unit_right ⨂ id
             << (x ⨂ I) ⨂ I ~~> x >>
-          unit_right ∘ unit_right).
-    rewrite to_unit_right_natural; reflexivity.
+          unit_right ∘ unit_right)
+    by (rewrite to_unit_right_natural; reflexivity).
 
   (* "The second one follows similarly from naturality of r." *)
   symmetry.
@@ -94,7 +114,7 @@ Proof.
   pose proof (to_tensor_assoc_natural (id[x]) (@unit_left _ _ y) (id[z])) as X0.
   assert (X1 : ∀ x y z w (f g : (x ⨂ y) ⨂ z ~> w),
              f ≈ g -> f ∘ tensor_assoc⁻¹ ≈ g ∘ tensor_assoc⁻¹).
-    intros; rewrites; reflexivity.
+  { intros; rewrites; reflexivity. }
   apply X1 in X0.
   rewrite <- !comp_assoc in X0.
   rewrite iso_to_from, id_right in X0.

--- a/Structure/Monoidal/Relevant.v
+++ b/Structure/Monoidal/Relevant.v
@@ -47,24 +47,102 @@ Class RelevantMonoidal `{@Monoidal C} := {
 Lemma twist2_natural `{@Monoidal C} `{@RelevantMonoidal _} :
   natural (@twist2 _ _).
 Proof.
-  unfold twist2; simpl; intros; normal.
+  unfold twist2; simpl; intros.
+  transitivity ((g ⨂ i) ⨂ h ⨂ j ∘ tensor_assoc⁻¹ ∘
+                        id{C} ⨂ (tensor_assoc ∘ twist ⨂ id{C} ∘ tensor_assoc⁻¹) ∘ tensor_assoc).
+  { rewrite comp_assoc.
+    apply compose_respects.
+    2: reflexivity.
+    rewrite comp_assoc.
+    apply compose_respects.
+    2: reflexivity.
+    apply compose_respects.
+    2: reflexivity.
+    etransitivity.
+    { apply compose_respects.
+      2: reflexivity.
+      transitivity ((@id C y ⨂ i) ⨂ h ⨂ j).
+      2: reflexivity.
+      etransitivity.
+      { apply compose_respects.
+        - rewrite <- bimap_comp.
+          reflexivity.
+        - reflexivity.
+      }
+      rewrite <- bimap_comp.
+      apply bimap_respects.
+      - normal.
+        reflexivity.
+      - rewrite id_right.
+        apply bimap_id_left_right.
+    }
+    rewrite <- bimap_comp.
+    apply bimap_respects.
+    - apply bimap_id_left_right.
+    - apply id_right.
+  }
+  transitivity (tensor_assoc⁻¹ ∘ id{C} ⨂ (tensor_assoc ∘ twist ⨂ id{C} ∘ tensor_assoc⁻¹)
+                               ∘ tensor_assoc ∘ (g ⨂ h) ⨂ i ⨂ j).
+  2: {
+    symmetry.
+    rewrite comp_assoc_sym.
+    rewrite comp_assoc_sym.
+    rewrite comp_assoc_sym.
+    apply compose_respects.
+    1: reflexivity.
+    etransitivity.
+    { apply compose_respects.
+      1: reflexivity.
+      etransitivity.
+      { apply compose_respects.
+        1: reflexivity.
+        rewrite <- bimap_comp.
+        apply bimap_respects.
+        - apply bimap_id_left_right.
+        - apply id_left.
+      }
+      rewrite <- bimap_comp.
+      apply bimap_respects.
+      - apply id_left.
+      - apply id_right.
+    }
+    rewrite <- bimap_comp.
+    apply bimap_respects.
+    - apply id_left.
+    - apply bimap_id_left_right.
+  }
   rewrite from_tensor_assoc_natural.
   rewrite <- !comp_assoc.
   rewrite <- to_tensor_assoc_natural.
-  normal.
-  comp_right.
   comp_left.
-  normal.
+  comp_right.
+  transitivity (g ⨂ (i ⨂ h ⨂ j ∘ tensor_assoc ∘ twist ⨂ id{C} ∘ tensor_assoc⁻¹)).
+  { rewrite <- bimap_comp.
+    etransitivity.
+    { apply bimap_respects.
+      - apply id_right.
+      - reflexivity.
+    }
+    apply bimap_respects.
+    1: reflexivity.
+    normal.
+    reflexivity.
+  }
+  transitivity (g ⨂ (tensor_assoc ∘ twist ⨂ id{C} ∘ tensor_assoc⁻¹ ∘ h ⨂ i ⨂ j)).
+  2: {
+    normal.
+    reflexivity.
+  }
   bimap_left.
   rewrite to_tensor_assoc_natural.
   rewrite <- !comp_assoc.
   rewrite <- from_tensor_assoc_natural.
   comp_left.
   comp_right.
-  normal.
-  bimap_right.
-  spose (fst twist_natural _ _ h _ _ i) as X.
-  normal; assumption.
+  rewrite <- !bimap_comp.
+  apply bimap_respects.
+  - apply bimap_twist.
+  - cat.
 Qed.
 
 End RelevantMonoidal.

--- a/Theory/Morphisms.v
+++ b/Theory/Morphisms.v
@@ -104,7 +104,10 @@ Proof.
   rewrite <- id_right.
   symmetry.
   rewrite <- id_right.
-  rewrite <- retract_comp0.
+  transitivity (g2 ∘ (f ∘ retract0));
+  [ apply compose_respects; [reflexivity|symmetry;assumption] |];
+  transitivity (g1 ∘ (f ∘ retract0));
+  [|apply compose_respects; [reflexivity|assumption]].
   reassociate_right.
 Qed.
 


### PR DESCRIPTION
The proof-automation was very slow in the files I changed here. By providing some terms manually and being more explicit where the "respects" statements go, which simplify the goal, I could speed it up. Especially the `normal` tactic (in Relevant.v) was slow and the `Local Obligation Tactic` in Product.v. But I don't recall the precise circumstances of the latter.

The only time measurements I currently have (but not written down) are from stepping through the proofs and from running make. I could do some proper measurements if you want.

Stilistically, it isn't very pretty. I'm open to suggestions.