### PR TITLE
Simpler speed-up and cosmetics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 .nia.cache
 .nra.cache
 /.Makefile.d
+/.Makefile.coq.d
 /.coqdeps.d
 /Book.aux
 /Book.bbl
@@ -30,5 +31,4 @@
 /coqdoc.sty
 /html/
 log_*.txt
-/.Makefile.coq.d
 /build.log

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.glob
 *.v.d
 *.v.tex
+*.v.timing
 *.vio
 *.vo
 *.vok

--- a/Adjunction/README.md
+++ b/Adjunction/README.md
@@ -4,7 +4,7 @@ There are at least four ways to specify an adjunction F ⊣ G:
 
 1. A bijective mapping between hom-sets `F a ~> b` and `a ~> U b`, natural in
    `a` and `b`. This is the definition given in `Category.Theory.Adjunction`.
-   
+
 2. A pair of `unit` and `counit` natural transformations, and that they
    compose to the identity functor in certain ways. This is given in
    `Category.Adjunction.Natural.Transformation`.

--- a/Construction/Comma.v
+++ b/Construction/Comma.v
@@ -28,6 +28,8 @@ Context {T : B ⟶ C}.
    the notation originally used by Lawvere, which involved the comma
    punctuation mark." *)
 
+#[local] Obligation Tactic := idtac.
+
 Program Definition Comma : Category := {|
   obj     := ∃ p : A ∏ B, S (fst p) ~{C}~> T (snd p);
   hom     := fun x y =>
@@ -39,7 +41,18 @@ Program Definition Comma : Category := {|
   compose := fun _ _ _ f g => ((fst `1 f ∘ fst `1 g, snd `1 f ∘ snd `1 g); _)
 |}.
 Next Obligation.
-  simpl in *.
+  intros [[]] [[]]; simpl in *; equivalence.
+Qed.
+Next Obligation.
+  intros.
+  simpl.
+  rewrite !fmap_id.
+  rewrite id_left, id_right.
+  reflexivity.
+Qed.
+Next Obligation.
+  intros ? ? ?; simpl.
+  intros [[]] [[]]; simpl in *.
   rewrite !fmap_comp.
   rewrite comp_assoc.
   rewrites.
@@ -47,19 +60,76 @@ Next Obligation.
   rewrites.
   reflexivity.
 Qed.
+Next Obligation.
+  intros ? ? ? ? ? [e0 e1] ? ? [e2 e3].
+  split.
+  - simpl. rewrite e0, e2.
+    reflexivity.
+  - simpl. rewrite e1, e3.
+    reflexivity.
+Qed.
+Next Obligation.
+  intros. simpl.
+  split; rewrite id_left; reflexivity.
+Qed.
+Next Obligation.
+  intros. simpl.
+  split; rewrite id_right; reflexivity.
+Qed.
+Next Obligation.
+  intros.
+  simpl.
+  split; apply comp_assoc.
+Qed.
+Next Obligation.
+  intros. simpl.
+  split; apply comp_assoc_sym.
+Qed.
 
 Program Instance comma_proj  : Comma ⟶ A ∏ B := {|
   fobj := fun x => ``x;
   fmap := fun _ _ f => ``f
 |}.
+Next Obligation.
+  intros ? ? ? ? [e0 e1].
+  split; assumption.
+Qed.
+Next Obligation.
+  intros ?. simpl. split; reflexivity.
+Qed.
+Next Obligation.
+  intros ? ? ? ? ?. simpl. split; reflexivity.
+Qed.
+
 Program Instance comma_proj1 : Comma ⟶ A := {|
   fobj := fun x => fst ``x;
   fmap := fun _ _ f => fst ``f
 |}.
+Next Obligation.
+  intros ? ? ? ? [e0 e1]. assumption.
+Qed.
+Next Obligation.
+  intros ?. simpl. reflexivity.
+Qed.
+Next Obligation.
+  intros ? ? ? ? ?. simpl. reflexivity.
+Qed.
+
 Program Instance comma_proj2 : Comma ⟶ B := {|
   fobj := fun x => snd ``x;
   fmap := fun _ _ f => snd ``f
 |}.
+Next Obligation.
+  intros ? ? ? ? [e0 e1]. assumption.
+Qed.
+Next Obligation.
+  intros ?. simpl. reflexivity.
+Qed.
+Next Obligation.
+  intros ? ? ? ? ?. simpl. reflexivity.
+Qed.
+
+#[local] Obligation Tactic := cat_simpl.
 
 Program Instance comma_proj_nat : S ◯ comma_proj1 ⟹ T ◯ comma_proj2.
 

--- a/Construction/Comma/Isomorphism.v
+++ b/Construction/Comma/Isomorphism.v
@@ -37,9 +37,16 @@ Next Obligation.
   rewrite comp_assoc.
   reflexivity.
 Defined.
-Next Obligation. proper. Qed.
-Next Obligation. cat. Qed.
-Next Obligation. cat. Qed.
+Next Obligation.
+  repeat intro; simpl.
+  assumption.
+Qed.
+Next Obligation.
+  split; reflexivity.
+Qed.
+Next Obligation.
+  split; reflexivity.
+Qed.
 
 #[global]
 Program Instance Comma_Iso_from_Left {A : Category} {B : Category} {C : Category}
@@ -53,14 +60,21 @@ Next Obligation.
   exists ``f; simpl.
   rewrite comp_assoc.
   rewrite <- (`2 f).
-  rewrite <- comp_assoc.
+  do 2 rewrite <- comp_assoc.
+  apply compose_respects; try reflexivity.
   rewrite <- naturality.
-  rewrite comp_assoc.
   reflexivity.
 Defined.
-Next Obligation. proper. Qed.
-Next Obligation. cat. Qed.
-Next Obligation. cat. Qed.
+Next Obligation.
+  repeat intro; simpl.
+  assumption.
+Qed.
+Next Obligation.
+  split; reflexivity.
+Qed.
+Next Obligation.
+  split; reflexivity.
+Qed.
 
 #[global]
 Program Instance Comma_Iso_to_Right {A : Category} {B : Category} {C : Category}
@@ -79,9 +93,16 @@ Next Obligation.
   rewrite comp_assoc.
   reflexivity.
 Defined.
-Next Obligation. proper. Qed.
-Next Obligation. cat. Qed.
-Next Obligation. cat. Qed.
+Next Obligation.
+  repeat intro. simpl.
+  assumption.
+Qed.
+Next Obligation.
+  split; reflexivity.
+Qed.
+Next Obligation.
+  split; reflexivity.
+Qed.
 
 #[global]
 Program Instance Comma_Iso_from_Right {A : Category} {B : Category} {C : Category}
@@ -100,9 +121,15 @@ Next Obligation.
   rewrite comp_assoc.
   reflexivity.
 Defined.
-Next Obligation. proper. Qed.
-Next Obligation. cat. Qed.
-Next Obligation. cat. Qed.
+Next Obligation.
+  repeat intro; simpl; assumption.
+Qed.
+Next Obligation.
+  split; reflexivity.
+Qed.
+Next Obligation.
+  split; reflexivity.
+Qed.
 
 #[global]
 Program Instance Comma_Iso {A : Category} {B : Category} {C : Category} :
@@ -123,7 +150,14 @@ Next Obligation.
         srewrite (iso_to_from X); cat.
       + clear; simpl; cat.
       + clear; simpl; cat.
-      + clear; simpl; split; cat.
+      + clear; simpl.
+        split.
+        * symmetry.
+          rewrite id_right.
+          apply id_left.
+        * symmetry.
+          rewrite id_right.
+          apply id_left.
     - constructive; simpl.
       + exists (id, id); cat.
         rewrite <- comp_assoc; simpl;
@@ -131,9 +165,12 @@ Next Obligation.
       + exists (id, id); cat.
         rewrite <- comp_assoc; simpl;
         srewrite (iso_from_to X); cat.
-      + clear; simpl; cat.
-      + clear; simpl; cat.
-      + clear; simpl; split; cat.
+      + clear; simpl.
+        split; apply id_left.
+      + clear; simpl.
+        split; apply id_left.
+      + clear; simpl.
+        split; rewrite id_right; symmetry; apply id_left.
   }
   isomorphism; simpl.
   - apply Comma_Iso_to_Right; assumption.
@@ -147,7 +184,8 @@ Next Obligation.
       srewrite (iso_to_from X0); cat.
     + clear; simpl; cat.
     + clear; simpl; cat.
-    + clear; simpl; split; cat.
+    + clear; simpl.
+      split; symmetry; rewrite id_right; apply id_left.
   - constructive; simpl.
     + exists (id, id); cat.
       rewrite comp_assoc; simpl;
@@ -155,7 +193,10 @@ Next Obligation.
     + exists (id, id); cat.
       rewrite comp_assoc; simpl;
       srewrite (iso_from_to X0); cat.
-    + clear; simpl; cat.
-    + clear; simpl; cat.
-    + clear; simpl; split; cat.
+    + clear; simpl.
+      split; apply id_left.
+    + clear; simpl.
+      split; apply id_left.
+    + clear; simpl.
+      split; symmetry; rewrite id_right; apply id_left.
 Qed.

--- a/Construction/Slice/Pullback.v
+++ b/Construction/Slice/Pullback.v
@@ -44,7 +44,7 @@ Program Definition Star_Functor `(f : c ~> a) :
                     (pullback_snd x f xpb)
                     ltac:(rewrite comp_assoc, H;
                           exact (pullback_commutes x f xpb)) in
-            (unique_morphism uniq; snd (unique_property uniq))
+            (unique_obj uniq; snd (unique_property uniq))
 |}.
 Next Obligation.
   proper; simpl in *.

--- a/Instance/Cat.v
+++ b/Instance/Cat.v
@@ -14,7 +14,11 @@ Set Transparent Obligations.
     arrows                Functors
     arrow equivalence     Natural Isomorphisms
     identity              Identity Functor
-    composition           Horizontal composition of Functors *)
+    composition           Horizontal composition of Functors
+
+    isomorphisms          Equivalences of Categories (caused by the definition
+                          of [Functor_Setoid]).
+*)
 
 #[global]
 Program Instance Cat : Category := {

--- a/Instance/Cones/Limit.v
+++ b/Instance/Cones/Limit.v
@@ -13,7 +13,7 @@ Program Definition Limit_Cones `(F : J ⟶ C) `{T : @Terminal (Cones F)} :
   Limit F := {|
   limit_cone := @terminal_obj _ T;
   ump_limits := fun N =>
-    {| unique_morphism := `1 @one _ T N
+    {| unique_obj := `1 @one _ T N
      ; unique_property := `2 @one _ T N
      ; uniqueness       := fun v H => @one_unique _ T N (@one _ T N) (v; H) |}
 |}.

--- a/Instance/Rel.v
+++ b/Instance/Rel.v
@@ -62,6 +62,7 @@ Program Instance Rel_Initial : @Initial Rel := {
   terminal_obj := False;
   one := fun _ _ => False_rect _ _
 }.
+Next Obligation. contradiction. Qed.
 
 (*
 Program Instance Rel_Cartesian : @Cartesian Rel := {
@@ -133,7 +134,6 @@ Program Instance Relation_Functor : Coq ⟶ Rel := {
   fobj := fun x => x;
   fmap := fun x y (f : x ~{Coq}~> y) x y => In _ (Singleton _ (f x)) y
 }.
-Next Obligation. proper; congruence. Qed.
 Next Obligation. proper; congruence. Qed.
 Next Obligation.
   simplify; firstorder.

--- a/Instance/Rel.v
+++ b/Instance/Rel.v
@@ -20,10 +20,16 @@ Unset Transparent Obligations.
 (* The category of heterogenous relations on Coq objects. *)
 
 Program Definition Rel : Category := {|
+  (* i.e. each object is an element of [Type] *)
   obj     := @obj Coq;
+  (* each morphism (from [A : Type] to [B : Type]) is of type
+     [A -> B -> Prop]. So a heterogenous relation. *)
   hom     := fun A B => A ~> Ensemble B;
+  (* morphisms are equal, if they are (provably) equivalent *)
   homset  := fun P Q =>
                {| equiv := fun f g => forall x y, f x y ↔ g x y |};
+  (* the identity morphism is (equivalent to) the relation
+     [fun x y => x = y] *)
   id      := Singleton;
   compose := fun x y z f g a b =>
                (exists e : y, In y (g a) e ∧ In z (f e) b)%type

--- a/Lib/Setoid.v
+++ b/Lib/Setoid.v
@@ -97,3 +97,16 @@ Next Obligation.
     now apply X.
   - now rewrite X, X0.
 Qed.
+
+Class Unique `{S : Setoid A} (P : A -> Type) := {
+  unique_obj : A;
+  unique_property : P unique_obj;
+  uniqueness      : ∀ v : A, P v -> unique_obj ≈ v;
+}.
+
+Arguments unique_obj {_ _ _} _.
+Arguments unique_property {_ _ _} _.
+Arguments uniqueness {_ _ _} _.
+
+Notation "∃! x .. y , P" := (Unique (fun x => .. (Unique (fun y => P)) ..))
+  (at level 200, x binder, y binder, right associativity) : category_theory_scope.

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,10 @@ install: _CoqProject Makefile.coq
 
 fullclean: clean
 	rm -f Makefile.coq Makefile.coq.conf .Makefile.d
+
+force _CoqProject Makefile: ;
+
+%: Makefile.coq force
+	@+$(MAKE) -f Makefile.coq $@
+
+.PHONY: all clean force

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ avoid repetition when stating the dual of whole structures.
 As a result, the definition of comonads, for example, is reduced to one line:
 
     Definition Comonad `{M : C ⟶ C} := @Monad (C^op) (M^op).
-    
+
 Most dual constructions are similarly defined, with the exception of `Initial`
 and `Cocartesian` structures. Although the core classes are indeed defined in
 terms of their dual construction, an alternate surface syntax and set of

--- a/Structure/Cartesian.v
+++ b/Structure/Cartesian.v
@@ -93,6 +93,38 @@ Qed.
 
 #[local] Hint Rewrite @exr_fork : categories.
 
+Corollary exl_fork_assoc {x y z w} (f : x ~> z) (g : z ~> w) (h : x ~> y) :
+  g ∘ exl ∘ (f △ h) ≈ g ∘ f.
+Proof.
+  rewrite <- comp_assoc.
+  apply compose_respects; try reflexivity.
+  apply exl_fork.
+Qed.
+
+Corollary exr_fork_assoc {x y z w} (f : x ~> z) (g : y ~> w) (h : x ~> y) :
+  g ∘ exr ∘ (f △ h) ≈ g ∘ h.
+Proof.
+  rewrite <- comp_assoc.
+  apply compose_respects; try reflexivity.
+  apply exr_fork.
+Qed.
+
+Corollary exl_fork_comp {x y z w} (f : x ~> y) (g : x ~> z) (h : w ~> x) :
+  exl ∘ ((f △ g) ∘ h) ≈ f ∘ h.
+Proof.
+  rewrite comp_assoc.
+  rewrite exl_fork.
+  reflexivity.
+Qed.
+
+Corollary exr_fork_comp {x y z w} (f : x ~> y) (g : x ~> z) (h : w ~> x) :
+  exr ∘ ((f △ g) ∘ h) ≈ g ∘ h.
+Proof.
+  rewrite comp_assoc.
+  rewrite exr_fork.
+  reflexivity.
+Qed.
+
 Corollary fork_exl_exr {x y : C} :
   exl △ exr ≈ @id C (x × y).
 Proof.

--- a/Structure/End.v
+++ b/Structure/End.v
@@ -1,7 +1,6 @@
 Set Warnings "-notation-overridden".
 
 Require Import Category.Lib.
-Require Export Category.Theory.Unique.
 Require Export Category.Structure.Wedge.
 
 Generalizable All Variables.

--- a/Structure/Limit.v
+++ b/Structure/Limit.v
@@ -1,7 +1,6 @@
 Set Warnings "-notation-overridden".
 
 Require Import Category.Lib.
-Require Export Category.Theory.Unique.
 Require Export Category.Structure.Cone.
 
 Generalizable All Variables.

--- a/Structure/Limit/Kan/Extension.v
+++ b/Structure/Limit/Kan/Extension.v
@@ -34,7 +34,7 @@ Proof.
   pose (to (@adj _ _ _ _ ran_adjoint (Δ(Lim)) F) nat)
     as adj_to; simpl in adj_to.
 
-  assert (to_from : adj_to () ∘ unique_morphism (ump_limits cone) ≈ id). {
+  assert (to_from : adj_to () ∘ unique_obj (ump_limits cone) ≈ id). {
     simpl.
     spose (iso_to_from
              ((@adj _ _ _ _ ran_adjoint
@@ -46,7 +46,7 @@ Proof.
     given (from_ran : Ran (Erase J) F ⟹ Δ(Lim)). {
       transform; simpl; intros.
       + destruct x.
-        apply (unique_morphism (ump_limits cone)).
+        apply (unique_obj (ump_limits cone)).
       + abstract cat.
       + abstract cat.
     }
@@ -70,7 +70,7 @@ Proof.
 
   isomorphism; simpl.
   - apply adj_to.
-  - apply (unique_morphism (ump_limits cone)).
+  - apply (unique_obj (ump_limits cone)).
   - apply to_from.
   - simpl in *.
     (* Since half of the isomorphism has already been proven in [to_from], it
@@ -83,8 +83,8 @@ Proof.
     assert (∀ (f g : Lim ~{ C }~> Lim),
               (∀ x, vertex_map[Lim] ∘ f ≈ @vertex_map _ _ _ Lim x) ->
               (∀ x, vertex_map[Lim] ∘ g ≈ @vertex_map _ _ _ Lim x) ->
-              f ∘ unique_morphism (ump_limits cone) ≈
-              g ∘ unique_morphism (ump_limits cone) -> f ≈ g) as HA.
+              f ∘ unique_obj (ump_limits cone) ≈
+              g ∘ unique_obj (ump_limits cone) -> f ≈ g) as HA.
       intros; clear adj_to to_from nat.
       rewrite <- (uniqueness (ump_limits Lim) _ X).
       rewrite <- (uniqueness (ump_limits Lim) _ X0).

--- a/Structure/Monoidal.v
+++ b/Structure/Monoidal.v
@@ -3,7 +3,6 @@ Set Warnings "-notation-overridden".
 Require Import Category.Lib.
 Require Export Category.Theory.Morphisms.
 Require Export Category.Theory.Isomorphism.
-Require Export Category.Theory.Naturality.
 Require Export Category.Functor.Bifunctor.
 Require Export Category.Construction.Product.
 

--- a/Structure/Monoidal/Internal/Product.v
+++ b/Structure/Monoidal/Internal/Product.v
@@ -21,9 +21,7 @@ Context {C : Category}.
 Context `{@Cartesian C}.
 Context `{@Terminal C}.
 
-#[local] Obligation Tactic :=
-  unfold proj_left, proj_right; simpl;
-  cat_simpl; try split; intros; unfork; cat.
+#[local] Obligation Tactic := idtac.
 
 (* Every cartesian category with terminal objects gives rise to a monoidal
    category taking the terminal object as unit, and the tensor as product. *)
@@ -32,6 +30,145 @@ Program Definition InternalProduct_Monoidal : @Monoidal C := {|
   tensor := InternalProductFunctor C;
   I := 1
 |}.
+Next Obligation.
+  intros.
+  symmetry.
+  apply exr_fork.
+Qed.
+Next Obligation.
+  intros.
+  simpl.
+  rewrite <- !fork_comp.
+  apply fork_respects.
+  - rewrite id_left.
+    rewrite exl_fork.
+    cat.
+  - rewrite id_left.
+    rewrite exr_fork_assoc.
+    apply id_right.
+Qed.
+Next Obligation.
+  intros. simpl.
+  symmetry.
+  apply exl_fork.
+Qed.
+Next Obligation.
+  intros. simpl.
+  rewrite <- !fork_comp.
+  apply fork_respects.
+  - rewrite exl_fork_assoc.
+    cat.
+  - cat.
+Qed.
+Next Obligation.
+  intros. simpl.
+  rewrite <- fork_comp.
+  symmetry.
+  rewrite <- fork_comp.
+  rewrite !exl_fork_assoc.
+  apply fork_respects.
+  { rewrite exl_fork_comp.
+    apply comp_assoc_sym.
+  }
+  rewrite <- fork_comp.
+  symmetry.
+  rewrite <- fork_comp.
+  rewrite <- fork_comp.
+  apply fork_respects.
+  - rewrite exr_fork_assoc.
+    rewrite !exl_fork_assoc.
+    rewrite !exr_fork_comp.
+    apply comp_assoc.
+  - rewrite !exr_fork_assoc.
+    symmetry.
+    apply exr_fork.
+Qed.
+Next Obligation.
+  intros. simpl.
+  do 5 rewrite <- fork_comp.
+  repeat apply fork_respects.
+  - rewrite !exl_fork_assoc.
+    symmetry.
+    apply exl_fork.
+  - rewrite !exl_fork_assoc.
+    rewrite !exr_fork_assoc.
+    rewrite exl_fork_comp.
+    apply comp_assoc.
+  - rewrite !exr_fork_assoc.
+    rewrite !exr_fork_comp.
+    apply comp_assoc.
+Qed.
+Next Obligation.
+  intros. simpl.
+  rewrite <- fork_comp.
+  apply fork_respects.
+  - rewrite id_left.
+    symmetry.
+    apply exl_fork.
+  - rewrite id_left.
+    rewrite exr_fork_assoc.
+    symmetry. apply exr_fork.
+Qed.
+Next Obligation.
+  intros. simpl.
+  rewrite <- fork_comp.
+  rewrite <- fork_comp.
+  symmetry.
+  rewrite <- fork_comp.
+  apply fork_respects.
+  { rewrite id_left.
+    rewrite exl_fork_assoc.
+    rewrite exl_fork.
+    rewrite exl_fork_assoc.
+    rewrite exl_fork_comp.
+    apply comp_assoc.
+  }
+  rewrite exr_fork_assoc.
+  do 3 rewrite <- fork_comp.
+  rewrite exl_fork_assoc.
+  rewrite exl_fork_assoc.
+  apply fork_respects.
+  { symmetry.
+    etransitivity.
+    { rewrite <- comp_assoc.
+      apply compose_respects; [reflexivity|].
+      rewrite exl_fork_assoc.
+      apply exr_fork_comp.
+    }
+    rewrite exl_fork_comp.
+    apply comp_assoc_sym.
+  }
+  rewrite exr_fork.
+  rewrite <- fork_comp.
+  rewrite <- fork_comp.
+  apply fork_respects.
+  { rewrite exl_fork_assoc.
+    symmetry.
+    etransitivity.
+    { rewrite <- comp_assoc.
+      apply compose_respects; [reflexivity|].
+      rewrite exl_fork_assoc.
+      apply exr_fork_comp.
+    }
+    apply exr_fork_comp.
+  }
+  symmetry.
+  rewrite exr_fork.
+  rewrite exr_fork.
+  apply id_left.
+Qed.
+
+Lemma exl_swap {x y z w} :
+  (@exl x y z w) ∘ swap ≈ exr.
+Proof.
+  unfork. cat.
+Qed.
+
+Lemma exr_swap {x y z w} :
+  (@exr x y z w) ∘ swap ≈ exl.
+Proof.
+  unfork. cat.
+Qed.
 
 Program Definition InternalProduct_SymmetricMonoidal :
   @SymmetricMonoidal C InternalProduct_Monoidal := {|
@@ -42,6 +179,98 @@ Program Definition InternalProduct_SymmetricMonoidal :
      ; iso_from_to := swap_invol
     |}
 |}.
+Next Obligation.
+  simpl; split; intros.
+  - rewrite <- fork_comp.
+    rewrite <- fork_comp.
+    rewrite swap_fork.
+    rewrite <- fork_comp.
+    apply fork_respects.
+    + rewrite <- comp_assoc.
+      rewrite <- comp_assoc.
+      rewrite <- comp_assoc.
+      apply compose_respects; try reflexivity.
+      rewrite exl_fork_comp.
+      rewrite exr_fork.
+      rewrite !id_left.
+      apply exl_swap.
+    + rewrite id_left.
+      rewrite id_left.
+      rewrite id_left.
+      rewrite exr_fork.
+      rewrite exl_fork.
+      rewrite <- comp_assoc.
+      apply compose_respects; try reflexivity.
+      apply exr_swap.
+  - rewrite <- fork_comp.
+    rewrite <- fork_comp.
+    rewrite swap_fork.
+    rewrite <- fork_comp.
+    apply fork_respects.
+    + rewrite id_left.
+      rewrite exl_fork.
+      rewrite id_left.
+      rewrite exr_fork.
+      rewrite <- comp_assoc.
+      apply compose_respects; try reflexivity.
+      apply exl_swap.
+    + rewrite <- comp_assoc.
+      rewrite <- comp_assoc.
+      rewrite <- comp_assoc.
+      apply compose_respects; try reflexivity.
+      rewrite exr_fork_comp.
+      rewrite exl_fork.
+      rewrite !id_left.
+      apply exr_swap.
+Qed.
+Next Obligation.
+  intros. simpl.
+  apply swap_invol.
+Qed.
+Next Obligation.
+  intros. simpl.
+  rewrite <- fork_comp.
+  rewrite <- fork_comp.
+  symmetry.
+  rewrite <- fork_comp.
+  rewrite <- fork_comp.
+  apply fork_respects.
+  { rewrite exl_fork_assoc.
+    rewrite id_left.
+    rewrite exl_fork_assoc.
+    symmetry.
+    rewrite <- comp_assoc.
+    rewrite swap_fork.
+    rewrite exl_fork_assoc.
+    rewrite exl_fork.
+    unfold swap.
+    rewrite exl_fork_comp.
+    reflexivity.
+  }
+  rewrite exr_fork_assoc.
+  rewrite swap_fork.
+  rewrite <- comp_assoc.
+  rewrite <- fork_comp.
+  rewrite <- fork_comp.
+  apply fork_respects.
+  - rewrite exr_fork.
+    rewrite id_left.
+    rewrite swap_fork.
+    rewrite exl_fork_assoc.
+    rewrite exr_fork.
+    reflexivity.
+  - rewrite exl_fork_assoc.
+    rewrite comp_assoc.
+    rewrite exr_swap.
+    etransitivity.
+    2: {
+      apply compose_respects; [reflexivity|].
+      symmetry.
+      apply swap_fork.
+    }
+    symmetry.
+    apply exr_fork.
+Qed.
 
 Program Definition InternalProduct_CartesianMonoidal :
   @CartesianMonoidal C InternalProduct_Monoidal := {|
@@ -49,12 +278,131 @@ Program Definition InternalProduct_CartesianMonoidal :
   is_relevance := {| diagonal  := fun _ => id △ id |}
 |}.
 Next Obligation.
+  cat_simpl.
+Qed.
+Next Obligation.
   apply InternalProduct_SymmetricMonoidal.
 Defined.
 Next Obligation.
+  cat_simpl.
+  rewrite <- fork_comp.
+  rewrite <- fork_comp.
   apply fork_respects.
-    apply one_unique.
+  - rewrite exl_fork_assoc.
+    cat.
+  - rewrite exr_fork_assoc.
+    cat.
+Qed.
+Next Obligation.
+  cat_simpl. apply fork_respects; try reflexivity.
+  apply one_unique.
+Qed.
+Next Obligation.
+  simpl. intros.
+  rewrite <- fork_comp.
+  symmetry.
+  rewrite <- fork_comp.
+  rewrite <- fork_comp.
+  rewrite !exl_fork_assoc.
+  rewrite !exl_fork_comp.
+  apply fork_respects.
+  { cat. }
+  rewrite exr_fork_assoc.
+  rewrite id_right.
+  rewrite <- fork_comp.
+  rewrite <- fork_comp.
+  apply fork_respects.
+  - rewrite exl_fork_assoc.
+    rewrite exr_fork_comp.
+    cat_simpl.
+  - rewrite exr_fork.
+    cat_simpl.
+Qed.
+Next Obligation.
+  intros. simpl.
+  rewrite swap_fork.
   reflexivity.
+Qed.
+Next Obligation.
+  intros. simpl.
+  rewrite <- fork_comp.
+  rewrite <- fork_comp.
+  rewrite <- fork_comp.
+  apply fork_respects.
+  - rewrite <- fork_comp.
+    rewrite exl_fork.
+    rewrite id_left.
+    rewrite <- fork_comp.
+    rewrite <- fork_comp.
+    rewrite exl_fork.
+    rewrite exl_fork_assoc.
+    rewrite exl_fork_comp.
+    rewrite id_left.
+    rewrite <- fork_exl_exr.
+    apply fork_respects; try reflexivity.
+    rewrite exr_fork_assoc.
+    rewrite comp_assoc.
+    rewrite comp_assoc.
+    rewrite comp_assoc.
+    rewrite exl_fork.
+    rewrite exl_fork_assoc.
+    rewrite comp_assoc.
+    rewrite exl_swap.
+    rewrite exl_fork_assoc.
+    rewrite exr_fork.
+    rewrite !exr_fork_assoc.
+    rewrite exl_fork_comp.
+    cat_simpl.
+  - rewrite exr_fork_assoc.
+    rewrite comp_assoc.
+    rewrite comp_assoc.
+    rewrite comp_assoc.
+    rewrite exr_fork.
+    rewrite <- fork_comp.
+    rewrite exl_fork_assoc.
+    rewrite comp_assoc.
+    rewrite exr_swap.
+    rewrite <- fork_comp.
+    rewrite exl_fork_assoc.
+    rewrite exl_fork.
+    rewrite <- fork_comp.
+    rewrite <- fork_comp.
+    rewrite <- fork_comp.
+    rewrite <- fork_exl_exr.
+    apply fork_respects.
+    + rewrite exr_fork_assoc.
+      rewrite exl_fork.
+      rewrite exl_fork_assoc.
+      rewrite exr_fork_comp.
+      cat_simpl.
+    + rewrite exr_fork.
+      rewrite id_left.
+      rewrite exr_fork.
+      rewrite !exr_fork_assoc.
+      rewrite exr_fork_comp.
+      cat_simpl.
+Qed.
+Next Obligation.
+  intros. simpl.
+  unfold proj_left.
+  simpl.
+  rewrite exl_fork.
+  rewrite exl_fork_assoc.
+  cat_simpl.
+Qed.
+Next Obligation.
+  intros. unfold proj_right. simpl.
+  rewrite exr_fork.
+  rewrite exr_fork_assoc.
+  cat_simpl.
+Qed.
+Next Obligation.
+  intros. simpl.
+  apply exr_swap.
+Qed.
+Next Obligation.
+  intros. simpl.
+  apply exl_swap.
 Qed.
 
 End InternalProduct.

--- a/Structure/Pullback.v
+++ b/Structure/Pullback.v
@@ -2,7 +2,6 @@ Set Warnings "-notation-overridden".
 
 Require Import Category.Lib.
 Require Export Category.Theory.Category.
-Require Export Category.Theory.Unique.
 
 Generalizable All Variables.
 Set Primitive Projections.

--- a/Structure/Pullback/Limit.v
+++ b/Structure/Pullback/Limit.v
@@ -39,7 +39,7 @@ Next Obligation.
     rewrite (RoofHom_inv _ _ f); cat.
   }
   destruct P, limit_cone; simpl in *.
-  exists (unique_morphism (ump_limits cone)). {
+  exists (unique_obj (ump_limits cone)). {
     split;
     [ pose proof (unique_property (ump_limits cone) RNeg)
     | pose proof (unique_property (ump_limits cone) RPos) ];

--- a/Theory/Adjunction.v
+++ b/Theory/Adjunction.v
@@ -2,7 +2,6 @@ Set Warnings "-notation-overridden".
 
 Require Import Category.Lib.
 Require Export Category.Theory.Isomorphism.
-Require Export Category.Theory.Naturality.
 Require Export Category.Theory.Natural.Transformation.
 Require Export Category.Instance.Sets.
 

--- a/Theory/Functor.v
+++ b/Theory/Functor.v
@@ -66,6 +66,12 @@ Notation "fmap[ F ]" := (@fmap _ _ F%functor _ _)
 
 #[global]
 Program Instance Functor_Setoid {C D : Category} : Setoid (C ⟶ D) := {
+(* Note that it doesn’t make much sense (with our definition of [Category]) to
+   ask that [∀ x : C, F x = G x] and
+   [∀ (x y :C) (f : x ~> y), fmap[F] f ≈ fmap[G] f] because the second
+   condition is hard to work with in the type-system, because it needs lots of
+   equality proofs.
+*)
   equiv := fun F G =>
     (* Equality of objects in a category is taken to be isomorphism *)
     { iso : ∀ x : C, F x ≅ G x

--- a/Theory/Kan/Extension.v
+++ b/Theory/Kan/Extension.v
@@ -3,7 +3,6 @@ Set Warnings "-unexpected-implicit-declaration".
 
 Require Import Category.Lib.
 Require Export Category.Theory.Adjunction.
-Require Export Category.Theory.Unique.
 Require Export Category.Instance.Fun.
 Require Import Category.Instance.Cat.
 
@@ -40,7 +39,7 @@ Class LocalRightKan (X : A ⟶ C) := {
   ran_transform : LocalRan ◯ F ⟹ X;
 
   ump_ran (M : B ⟶ C) (μ : M ◯ F ⟹ X) :
-    @Unique Fun _ _ (fun δ => μ ≈ ran_transform ∙ δ ⊲ F)
+    (∃! δ, μ ≈ ran_transform ∙ δ ⊲ F);
 }.
 
 (* Wikipedia: "There is also a local definition of 'the Kan extension of a
@@ -109,7 +108,7 @@ Class LocalLeftKan (X : A ⟶ C) := {
   lan_transform : X ⟹ LocalLan ◯ F;
 
   ump_lan (M : B ⟶ C) (ε : X ⟹ M ◯ F) :
-    @Unique Fun _ _  (fun δ => ε ≈ δ ⊲ F ∙ lan_transform)
+    ∃! δ, ε ≈ δ ⊲ F ∙ lan_transform;
 }.
 
 #[global] Program Instance LeftKan_to_LocalLeftKan {R : LeftKan} (X : A ⟶ C) :

--- a/Theory/Natural/Transformation.v
+++ b/Theory/Natural/Transformation.v
@@ -29,7 +29,13 @@ Class Transform := {
     transform ∘ fmap[F] f ≈ fmap[G] f ∘ transform
 }.
 
-#[global] Program Instance Transform_Setoid : Setoid Transform.
+#[global] Program Instance Transform_Setoid : Setoid Transform :=
+  {| equiv N0 N1 :=
+       forall x, (@transform N0 x) ≈ (@transform N1 x); |}.
+Next Obligation.
+  equivalence.
+  transitivity (@transform y x0); auto.
+Qed.
 
 End Transform.
 

--- a/Theory/Natural/Transformation.v
+++ b/Theory/Natural/Transformation.v
@@ -2,7 +2,6 @@ Set Warnings "-notation-overridden".
 
 Require Import Category.Lib.
 Require Export Category.Theory.Functor.
-Require Export Category.Theory.Naturality.
 
 Generalizable All Variables.
 Set Primitive Projections.

--- a/Theory/Universal/Arrow.v
+++ b/Theory/Universal/Arrow.v
@@ -2,7 +2,6 @@ Set Warnings "-notation-overridden".
 
 Require Import Category.Lib.
 Require Export Category.Theory.Functor.
-Require Export Category.Theory.Unique.
 Require Import Category.Structure.Initial.
 Require Import Category.Construction.Comma.
 Require Import Category.Functor.Diagonal.

--- a/_CoqProject
+++ b/_CoqProject
@@ -202,7 +202,6 @@ Theory/Morphisms.v
 Theory/Natural/Transformation.v
 Theory/Naturality.v
 Theory/Sheaf.v
-Theory/Unique.v
 Theory/Universal/Arrow.v
 Tools/Abstraction.v
 Tools/Represented.v


### PR DESCRIPTION
I found some simpler ways to speed-up Structure/Monoidal/Internal/Product.v and some other files, which I'd like to share. The resulting proofs are still quite long, but compilation is a *lot* quicker. The proofs could probably be generated by sufficiently clever Ltac...

I also recovered some comments and minor clean-up work from the previous branch. Besides the comments, I included a "forward" in the Makefile which would make it easier for me to build (and time) single files. And the definition of equivalence for natural transformations is wrongly generated. Coq used strict equality instead of pointwise equivalence. It doesn't really matter, because it is never used.

Last, I recovered the generalized definition of `Unique` so it works for arbitrary `Setoid` and not just for hom-sets. This makes it possible to write "an object exists, uniquely up to isomorphism" etc.

Because some changes are quite small, I bundled them together in a single PR. (Edit: please veto on any part which you don't want.) I'll keep back most of the new definitions I added last time until they are necessary for *some* greater theorem, whatever that may be. Until then they can collect dust in my repo.