### PR TITLE
Use #[export] rather than #[global] in almost all modules

### DIFF
--- a/Adjunction/Diagonal/Product.v
+++ b/Adjunction/Diagonal/Product.v
@@ -17,7 +17,7 @@ Set Universe Polymorphism.
    on C. *)
 (* jww (2021-08-04): Is it right to use Diagonal_Product here? *)
 
-#[global]
+#[export]
 Program Instance Diagonal_Product_Adjunction (C : Category) `{@Cartesian C} :
   Diagonal_Product C ⊣ ×(C) := {
   adj := fun _ _ =>

--- a/Algebra/Monoid.v
+++ b/Algebra/Monoid.v
@@ -27,7 +27,7 @@ Class Monoid (A : Type) `{Setoid A} := {
   mon_assoc (x y z : A) : mappend (mappend x y) z ≈ mappend x (mappend y z)
 }.
 
-#[global]
+#[export]
 Program Instance Classical_Monoid (A : Type) `{Setoid A} `{Monoid A} :
   @MonoidObject Sets InternalProduct_Monoidal {| carrier := A |} := {
   mempty  := {| morphism := fun _ => mempty |};

--- a/Construction/Cayley.v
+++ b/Construction/Cayley.v
@@ -219,10 +219,10 @@ End Cayley.
 
 Require Import Category.Functor.Structure.Cartesian.
 
-#[global]
+#[export]
 Program Instance To_Cayley_CartesianFunctor `{@Cartesian C} :
   @CartesianFunctor _ _ To_Cayley _ Cayley_Cartesian.
 
-#[global]
+#[export]
 Program Instance From_Cayley_CartesianFunctor `{@Cartesian C} :
   @CartesianFunctor _ _ From_Cayley Cayley_Cartesian _.

--- a/Construction/Comma/Isomorphism.v
+++ b/Construction/Comma/Isomorphism.v
@@ -22,7 +22,7 @@ Ltac reduce :=
 
 #[local] Obligation Tactic := simpl; intros.
 
-#[global]
+#[export]
 Program Instance Comma_Iso_to_Left {A : Category} {B : Category} {C : Category}
         (x y : A ⟶ C) (iso : x ≅[Fun] y) (z : B ⟶ C) :
   (x ↓ z) ⟶ (y ↓ z).
@@ -43,7 +43,7 @@ Next Obligation. now repeat intro. Qed.
 Next Obligation. now split. Qed.
 Next Obligation. now split. Qed.
 
-#[global]
+#[export]
 Program Instance Comma_Iso_from_Left {A : Category} {B : Category} {C : Category}
         (x y : A ⟶ C) (iso : x ≅[Fun] y) (z : B ⟶ C) :
   (y ↓ z) ⟶ (x ↓ z).
@@ -63,7 +63,7 @@ Next Obligation. now repeat intro. Qed.
 Next Obligation. now split. Qed.
 Next Obligation. now split. Qed.
 
-#[global]
+#[export]
 Program Instance Comma_Iso_to_Right {A : Category} {B : Category} {C : Category}
         (x y : B ⟶ C) (iso : x ≅[Fun] y) (z : A ⟶ C) :
   (z ↓ x) ⟶ (z ↓ y).
@@ -84,7 +84,7 @@ Next Obligation. now repeat intro. Qed.
 Next Obligation. now split. Qed.
 Next Obligation. now split. Qed.
 
-#[global]
+#[export]
 Program Instance Comma_Iso_from_Right {A : Category} {B : Category} {C : Category}
         (x y : B ⟶ C) (iso : x ≅[Fun] y) (z : A ⟶ C) :
   (z ↓ y) ⟶ (z ↓ x).
@@ -105,7 +105,7 @@ Next Obligation. now repeat intro. Qed.
 Next Obligation. now split. Qed.
 Next Obligation. now split. Qed.
 
-#[global]
+#[export]
 Program Instance Comma_Iso {A : Category} {B : Category} {C : Category} :
   Proper (@Isomorphism Fun ==> @Isomorphism Fun ==> @Isomorphism Cat)
          (@Comma A B C).

--- a/Construction/Opposite.v
+++ b/Construction/Opposite.v
@@ -46,7 +46,7 @@ Definition unop {C : Category} {x y} (f : x ~{C^op}~> y) : y ~{C}~> x := f.
 
 Require Import Category.Theory.Isomorphism.
 
-#[global]
+#[export]
 Program Instance Isomorphism_Opposite {C : Category} {x y : C}
        (iso : @Isomorphism C x y) :
   @Isomorphism (C^op) x y := {

--- a/Construction/Product.v
+++ b/Construction/Product.v
@@ -64,13 +64,13 @@ Notation "C ∏ D" := (@Product C D) (at level 90) : category_scope.
 
 Require Import Category.Theory.Functor.
 
-#[global]
+#[export]
 Program Instance Fst {C D : Category} : C ∏ D ⟶ C := {
   fobj := fst;
   fmap := fun _ _ => fst
 }.
 
-#[global]
+#[export]
 Program Instance Snd {C D : Category} : C ∏ D ⟶ D := {
   fobj := snd;
   fmap := fun _ _ => snd

--- a/Construction/Slice.v
+++ b/Construction/Slice.v
@@ -26,7 +26,7 @@ Notation "C  ̸ c" := (@Slice C c) (at level 90) : category_scope.
 (* Although the encoding of Slice above is more convenient, theoretically it's
    the comma category (Id[C] ↓ Δ(c)). *)
 
-#[global]
+#[export]
 Program Instance Comma_Slice `(C : Category) `(c : C) :
   C ̸ c ≅[Cat] (Id ↓ =(c)) := {
   to   := {| fobj := _; fmap := _ |};
@@ -51,7 +51,7 @@ Next Obligation. rewrite <- comp_assoc; rewrites; reflexivity. Defined.
 
 Notation "c  ̸co C" := (@Coslice C c) (at level 90) : category_scope.
 
-#[global]
+#[export]
 Program Instance Comma_Coslice `(C : Category) `(c : C) :
   c ̸co C ≅[Cat] (=(c) ↓ Id) := {
   to   := {| fobj := _; fmap := _ |};

--- a/Functor/Bifunctor.v
+++ b/Functor/Bifunctor.v
@@ -32,7 +32,7 @@ Corollary bimap_fmap {F : C ∏ D ⟶ E} {x w : C} {y z : D}
   @fmap (C ∏ D) E F (x, y) (w, z) (f, g) = bimap f g.
 Proof. reflexivity. Defined.
 
-#[global] Program Instance bimap_respects {F : C ∏ D ⟶ E} {x w : C} {y z : D} :
+#[export] Program Instance bimap_respects {F : C ∏ D ⟶ E} {x w : C} {y z : D} :
   Proper (equiv ==> equiv ==> equiv) (@bimap F x w y z).
 Next Obligation.
   proper.
@@ -99,7 +99,7 @@ Proof.
   split; simpl; cat.
 Qed.
 
-#[global] Program Instance bifunctor_respects {F : C ∏ D ⟶ E} :
+#[export] Program Instance bifunctor_respects {F : C ∏ D ⟶ E} :
   Proper ((fun p q => Isomorphism (fst p) (fst q) ∧
                       Isomorphism (snd p) (snd q))
             ==> Isomorphism) F.

--- a/Functor/Construction/Product.v
+++ b/Functor/Construction/Product.v
@@ -13,7 +13,7 @@ Unset Transparent Obligations.
 
 (* ProductFunctor is a mapping between product categories. *)
 
-#[global]
+#[export]
 Program Instance ProductFunctor
         {C : Category} {D : Category} {F : C ⟶ D}
         {J : Category} {K : Category} {G : J ⟶ K} :

--- a/Functor/Construction/Product/Strong.v
+++ b/Functor/Construction/Product/Strong.v
@@ -9,10 +9,11 @@ Require Import Category.Functor.Strong.
 Require Import Category.Functor.Construction.Product.
 Require Import Category.Functor.Construction.Product.Monoidal.
 Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Monoidal.Product.
 Require Import Category.Structure.Monoidal.Braided.
 Require Import Category.Structure.Monoidal.Balanced.
-Require Import Category.Structure.Monoidal.Relevance.
 Require Import Category.Structure.Monoidal.Symmetric.
+Require Import Category.Structure.Monoidal.Relevance.
 Require Import Category.Structure.Monoidal.Cartesian.
 
 Generalizable All Variables.
@@ -26,12 +27,9 @@ Context `{@CartesianMonoidal C}.
 Context {F : C ⟶ C}.
 Context {G : C ⟶ C}.
 
-#[local] Obligation Tactic := program_simpl.
-
-Program Definition ProductFunctor_Strong :
-  StrongFunctor F → StrongFunctor G
-    → StrongFunctor (F ∏⟶ G) := fun O P => {|
-  strength := fun _ _ => (strength, strength);
+Program Definition ProductFunctor_Strong
+  `{!StrongFunctor F} `{!StrongFunctor G} : StrongFunctor (F ∏⟶ G) := {|
+  strength := fun _ _ => (strength[F], strength[G]);
   strength_id_left := _;
   strength_assoc := _
 |}.

--- a/Functor/Coproduct.v
+++ b/Functor/Coproduct.v
@@ -9,7 +9,7 @@ Generalizable All Variables.
 Set Primitive Projections.
 Set Universe Polymorphism.
 
-#[global]
+#[export]
 Program Instance CoproductFunctor `(C : Category) `{@Cocartesian C} :
   C ∐ C ⟶ C := {
   fobj := fun p => sum_rect (λ _, C) (λ a, a) (λ b, b) p;

--- a/Functor/Diagonal.v
+++ b/Functor/Diagonal.v
@@ -12,7 +12,7 @@ Generalizable All Variables.
 Set Primitive Projections.
 Set Universe Polymorphism.
 
-#[global]
+#[export]
 Program Instance Diagonal {C : Category} (J : Category) : C ⟶ [J, C] := {
   fobj := fun x =>
     {| fobj := fun _ => x
@@ -21,7 +21,7 @@ Program Instance Diagonal {C : Category} (J : Category) : C ⟶ [J, C] := {
     {| transform := fun _ => f |}
 }.
 
-#[global]
+#[export]
 Program Instance Diagonal_Product `(C : Category) : C ⟶ C ∏ C.
 
 Notation "Δ[ J ]( c )" := (Diagonal J c) (at level 90, format "Δ[ J ]( c )") : functor_scope.
@@ -63,6 +63,6 @@ Proof.
   reflexivity.
 Qed.
 
-#[global]
+#[export]
 Instance Transform_Const `(x ~{C}~> y) : Δ(x) ⟹ Δ(y).
 Proof. construct; auto; cat_simpl. Qed.

--- a/Functor/Hom/Yoneda.v
+++ b/Functor/Hom/Yoneda.v
@@ -41,7 +41,7 @@ Unset Transparent Obligations.
    easier, which become more difficult when restricted to the fully abstract
    nature of `C`. *)
 
-#[global]
+#[export]
 Program Instance Yoneda_Lemma `(C : Category) `(F : C^op ⟶ Sets) :
   ∀ A : C, Presheaves [Hom ─,A] F ≅ F A := {
   to   := {| morphism := fun x => transform[x] A id |};
@@ -90,7 +90,7 @@ Next Obligation.
   apply transform; cat.
 Qed.
 
-#[global]
+#[export]
 Program Instance Covariant_Yoneda_Lemma `(C : Category) `(F : C ⟶ Sets) :
   ∀ A : C, Copresheaves [Hom A,─] F ≅ F A := {
   to   := {| morphism := fun x => transform[x] A id |};
@@ -139,7 +139,7 @@ Next Obligation.
   apply transform; cat.
 Qed.
 
-#[global]
+#[export]
 Program Instance Yoneda_Embedding `(C : Category) :
   ∀ A B : C, Presheaves [Hom ─,A] [Hom ─,B] ≊ A ~> B.
 Next Obligation. morphism. Defined.
@@ -162,7 +162,7 @@ Next Obligation.
   apply proper_morphism; cat.
 Qed.
 
-#[global]
+#[export]
 Program Instance Covariant_Yoneda_Embedding `(C : Category) :
   ∀ A B : C, Copresheaves [Hom B,─] [Hom A,─] ≊ A ~> B.
 Next Obligation. morphism. Defined.

--- a/Functor/Product.v
+++ b/Functor/Product.v
@@ -13,7 +13,7 @@ Unset Transparent Obligations.
 
 (* A product of functors over some object in a monoidal category. *)
 
-#[global]
+#[export]
 Program Instance Product
         {C : Category} {D : Category} `{@Monoidal D}
         {F : C ⟶ D} {G : C ⟶ D} : C ⟶ D := {

--- a/Functor/Product/Internal.v
+++ b/Functor/Product/Internal.v
@@ -11,7 +11,7 @@ Set Primitive Projections.
 Set Universe Polymorphism.
 Unset Transparent Obligations.
 
-#[global]
+#[export]
 Program Instance InternalProductFunctor `(C : Category) `{@Cartesian C} :
   C ∏ C ⟶ C := {
   fobj := fun p => fst p × snd p;

--- a/Functor/Strong.v
+++ b/Functor/Strong.v
@@ -4,6 +4,7 @@ Require Import Category.Lib.
 Require Import Category.Theory.Category.
 Require Import Category.Theory.Isomorphism.
 Require Import Category.Theory.Functor.
+Require Import Category.Theory.Functor.Endo.
 Require Import Category.Theory.Naturality.
 Require Import Category.Theory.Natural.Transformation.
 Require Import Category.Functor.Bifunctor.
@@ -48,13 +49,13 @@ Section Strong.
 Context `{@Monoidal C}.
 Context {F : C ⟶ C}.
 
-#[global] Program Instance Id_StrongFunctor : StrongFunctor Id[C] := {
+#[export] Program Instance Id_StrongFunctor : StrongFunctor Id[C] := {
   strength := fun _ _ => id
 }.
 
 #[local] Obligation Tactic := program_simpl.
 
-#[global] Program Instance Compose_StrongFunctor (F G : C ⟶ C) :
+#[export] Program Instance Compose_StrongFunctor (F G : C ⟶ C) :
   StrongFunctor F → StrongFunctor G → StrongFunctor (F ◯ G) := {
   strength := fun _ _ => fmap[F] strength ∘ strength
 }.

--- a/Functor/Structure/Monoidal/Compose.v
+++ b/Functor/Structure/Monoidal/Compose.v
@@ -30,7 +30,7 @@ Context {F : D ⟶ E}.
 (* Any two monoidal functors compose to create a monoidal functor. This is
    composition in the groupoid of categories with monoidal structure. *)
 
-#[global] Program Instance Compose_MonoidalFunctor
+#[export] Program Instance Compose_MonoidalFunctor
        `(M : @MonoidalFunctor D E _ _ F)
        `(N : @MonoidalFunctor C D _ _ G) :
   `{@MonoidalFunctor C E _ _ (F ◯ G)} := {
@@ -260,7 +260,7 @@ Qed.
    functor. This is composition in the category of categories with monoidal
    structure. *)
 
-#[global] Program Instance Compose_LaxMonoidalFunctor
+#[export] Program Instance Compose_LaxMonoidalFunctor
        `(M : @LaxMonoidalFunctor D E _ _ F)
        `(N : @LaxMonoidalFunctor C D _ _ G) :
   `{@LaxMonoidalFunctor C E _ _ (F ◯ G)} := {

--- a/Functor/Structure/Monoidal/Id.v
+++ b/Functor/Structure/Monoidal/Id.v
@@ -28,7 +28,7 @@ Context {F : D ⟶ E}.
 
 #[local] Obligation Tactic := program_simpl.
 
-#[global] Program Instance Id_MonoidalFunctor :
+#[export] Program Instance Id_MonoidalFunctor :
   @MonoidalFunctor C C _ _ Id[C] := {
   pure_iso := iso_id;
   ap_functor_iso := {| to   := {| transform := fun _ => _ |}
@@ -55,7 +55,7 @@ Next Obligation. rewrite bimap_id_id; cat. Qed.
 Next Obligation. rewrite bimap_id_id; cat. Qed.
 Next Obligation. rewrite !bimap_id_id; cat. Qed.
 
-#[global] Program Instance Id_LaxMonoidalFunctor :
+#[export] Program Instance Id_LaxMonoidalFunctor :
   @LaxMonoidalFunctor C C _ _ Id[C] := {
   lax_pure := id;
   ap_functor_nat := {| transform := fun _ => _ |}

--- a/Functor/Structure/Monoidal/Pure.v
+++ b/Functor/Structure/Monoidal/Pure.v
@@ -4,6 +4,7 @@ Require Import Category.Lib.
 Require Import Category.Theory.Category.
 Require Import Category.Theory.Isomorphism.
 Require Import Category.Theory.Functor.
+Require Import Category.Theory.Functor.Endo.
 Require Import Category.Theory.Naturality.
 Require Import Category.Structure.Monoidal.
 Require Import Category.Functor.Bifunctor.

--- a/Functor/Traversable.v
+++ b/Functor/Traversable.v
@@ -74,7 +74,7 @@ End Traversable.
 
 Arguments Traversable {_ _ _ _} F.
 
-#[global]
+#[export]
 Program Instance Id_Traversable {C : Category}
         `{@Cartesian C} `{@Terminal C} `{@Closed C _} (x : C) :
   Traversable (@Id C) := {
@@ -83,7 +83,7 @@ Program Instance Id_Traversable {C : Category}
 
 Require Import Category.Functor.Diagonal.
 
-#[global]
+#[export]
 Program Instance Diagonal_Traversable {C J : Category}
         `{@Cartesian C} `{@Terminal C} `{@Closed C _} (x : C) :
   Traversable (Diagonal C x) := {

--- a/Instance/AST.v
+++ b/Instance/AST.v
@@ -87,7 +87,7 @@ Program Fixpoint interp `(c : Hom a b) :
   | Merge f g   => merge (interp f) (interp g)
   end.
 
-#[global]
+#[export]
 Program Instance AST : Category := {
   obj     := Obj;
   hom     := Hom;
@@ -108,13 +108,13 @@ Next Obligation.
   transitivity (interp y); auto.
 Qed.
 
-#[global]
+#[export]
 Program Instance Hom_Terminal : @Terminal AST := {
   terminal_obj := One_;
   one := @One'
 }.
 
-#[global]
+#[export]
 Program Instance Hom_Cartesian : @Cartesian AST := {
   product_obj := Prod_;
   fork := @Fork;
@@ -131,7 +131,7 @@ Next Obligation.
   rewrite fork_comp; cat.
 Qed.
 
-#[global]
+#[export]
 Program Instance Hom_Closed : @Closed AST _ := {
   exponent_obj := Exp_;
   exp_iso := fun x y z =>
@@ -141,13 +141,13 @@ Program Instance Hom_Closed : @Closed AST _ := {
 Next Obligation. proper; rewrite X; reflexivity. Qed.
 Next Obligation. proper; rewrite X; reflexivity. Qed.
 
-#[global]
+#[export]
 Program Instance Hom_Initial : @Initial AST := {
   terminal_obj := Zero_;
   one := @Zero'
 }.
 
-#[global]
+#[export]
 Program Instance Hom_Cocartesian : @Cocartesian AST := {
   product_obj := Coprod_;
   fork := @Merge;
@@ -164,7 +164,7 @@ Next Obligation.
   rewrite merge_comp; cat.
 Qed.
 
-#[global]
+#[export]
 Program Instance interp_proper {x y : Obj}
         {C : Category} {A : @Cartesian C}
         `{@Closed C A} `{@Cocartesian C}
@@ -186,28 +186,28 @@ Context `{@Cocartesian C}.
 Context `{@Terminal C}.
 Context `{@Initial C}.
 
-#[global] Program Instance AST_Functor : AST ⟶ C := {
+#[export] Program Instance AST_Functor : AST ⟶ C := {
   fobj := fun x => denote x;
   fmap := fun _ _ f => interp f
 }.
 
-#[global] Program Instance Hom_TerminalFunctor : TerminalFunctor := {
+#[export] Program Instance Hom_TerminalFunctor : TerminalFunctor := {
   fobj_one_iso := _
 }.
 
-#[global] Program Instance Hom_CartesianFunctor : CartesianFunctor := {
+#[export] Program Instance Hom_CartesianFunctor : CartesianFunctor := {
   fobj_prod_iso := _
 }.
 
-#[global] Program Instance Hom_ClosedFunctor : ClosedFunctor := {
+#[export] Program Instance Hom_ClosedFunctor : ClosedFunctor := {
   fobj_exp_iso := _
 }.
 
-#[global] Program Instance Hom_InitialFunctor : InitialFunctor AST_Functor := {
+#[export] Program Instance Hom_InitialFunctor : InitialFunctor AST_Functor := {
   fobj_one_iso := _
 }.
 
-#[global] Program Instance Hom_CocartesianFunctor : CocartesianFunctor AST_Functor := {
+#[export] Program Instance Hom_CocartesianFunctor : CocartesianFunctor AST_Functor := {
   fobj_prod_iso := _
 }.
 

--- a/Instance/Adjoints.v
+++ b/Instance/Adjoints.v
@@ -14,7 +14,7 @@ Set Primitive Projections.
 Set Universe Polymorphism.
 Unset Transparent Obligations.
 
-#[global]
+#[export]
 Program Instance adj_id {C : Category} : Id ⊣ Id := {
   adj := fun _ _ =>
     {| to   := {| morphism := _ |}
@@ -54,7 +54,7 @@ Record adj_morphism {C : Category} {D : Category} := {
   adjunction : free_functor ⊣ forgetful_functor
 }.
 
-#[global]
+#[export]
 Program Instance adj_morphism_setoid {C : Category} {D : Category} :
   Setoid (@adj_morphism C D) := {
   equiv := fun f g =>

--- a/Instance/Cat.v
+++ b/Instance/Cat.v
@@ -22,7 +22,7 @@ Set Transparent Obligations.
                           of [Functor_Setoid]).
 *)
 
-#[global]
+#[export]
 Instance Cat : Category := {
   obj     := Category;
   hom     := @Functor;
@@ -45,7 +45,7 @@ Record Isomorphism_FullyFaithful `(iso : C ≅ D) := {
   from_faithful : Faithful (from iso)
 }.
 
-#[global]
+#[export]
 Instance Cat_Iso_to_Faithful `(iso : C ≅ D) : Faithful (to iso).
 Proof.
   construct.
@@ -83,7 +83,7 @@ Proof.
   now apply (@fmap_respects D C iso⁻¹).
 Qed.
 
-#[global]
+#[export]
 Instance Cat_Iso_from_Faithful `(iso : C ≅ D) : Faithful (from iso).
 Proof.
   apply (Cat_Iso_to_Faithful (iso_sym iso)).

--- a/Instance/Cat/Cartesian.v
+++ b/Instance/Cat/Cartesian.v
@@ -13,7 +13,7 @@ Set Primitive Projections.
 Set Universe Polymorphism.
 Unset Transparent Obligations.
 
-#[global]
+#[export]
 Program Instance Cat_Cartesian : @Cartesian Cat := {
   product_obj := @Product;
   fork := fun _ _ _ F G =>

--- a/Instance/Cat/Cartesian/Closed.v
+++ b/Instance/Cat/Cartesian/Closed.v
@@ -19,7 +19,7 @@ Set Universe Polymorphism.
 Definition pairing {A B : Type} (p : A * B) : p = (fst p, snd p) :=
   match p with (x, y) => eq_refl end.
 
-#[global]
+#[export]
 Program Instance Cat_Closed : @Closed Cat Cat_Cartesian := {
   exponent_obj := @Fun;         (* the internal hom is a functor category *)
   exp_iso := fun A B C =>

--- a/Instance/Cat/Cocartesian.v
+++ b/Instance/Cat/Cocartesian.v
@@ -13,7 +13,7 @@ Unset Transparent Obligations.
 
 (* Another way of reading this is that we're proving Cat^op is Cartesian. *)
 
-#[global]
+#[export]
 Program Instance Cat_Cocartesian : @Cocartesian Cat := {
   product_obj := @Coproduct;
   fork := fun _ _ _ F G =>

--- a/Instance/Comp.v
+++ b/Instance/Comp.v
@@ -57,7 +57,7 @@ Record AlgHom {S : OpSignature} (A : OpAlgebra S) (B : OpAlgebra S) := {
 
 Arguments map {_ _ _} _.
 
-#[global] Program Instance AlgHom_Setoid
+#[export] Program Instance AlgHom_Setoid
     {S : OpSignature} (A : OpAlgebra S) (B : OpAlgebra S) :
   Setoid (AlgHom A B) := {|
   equiv := fun f g : AlgHom A B => ∀ x : A, f x = g x
@@ -436,7 +436,7 @@ Record Interface := {
 Definition Component (required provided : Interface) : Type :=
   { f : Interface → Interface & f required = provided }.
 
-#[global] Program Instance Component_Setoid {req prov : Interface} :
+#[export] Program Instance Component_Setoid {req prov : Interface} :
   Setoid (Component req prov) := {|
   equiv := fun f g : Component req prov => f = g
 |}.
@@ -444,7 +444,7 @@ Definition Component (required provided : Interface) : Type :=
 (** Now we may reason about the category of software components, which are
     simply morphisms between algebras, but not necessarily homomorphic. *)
 
-#[global]
+#[export]
 Program Instance Comp : Category := {
   obj     := Interface;
   hom     := Component;

--- a/Instance/Coq.v
+++ b/Instance/Coq.v
@@ -21,7 +21,7 @@ Set Primitive Projections.
 Set Universe Polymorphism.
 Unset Transparent Obligations.
 
-#[global]
+#[export]
 Program Instance Coq : Category := {
   obj     := Type;
   hom     := λ A B : Type, A → B;
@@ -32,14 +32,14 @@ Program Instance Coq : Category := {
 Next Obligation. equivalence; congruence. Qed.
 Next Obligation. proper; congruence. Qed.
 
-#[global]
+#[export]
 Program Instance Coq_Terminal : @Terminal Coq := {
   terminal_obj := unit : Type;
   one := λ _ a, tt
 }.
 Next Obligation. destruct (f x0), (g x0); reflexivity. Qed.
 
-#[global]
+#[export]
 Program Instance Coq_Cartesian : @Cartesian Coq := {
   product_obj := λ x y, x * y : Type;
   fork := λ _ _ _ f g x, (f x, g x);
@@ -56,7 +56,7 @@ Next Obligation.
     rewrite <- surjective_pairing; reflexivity.
 Qed.
 
-#[global]
+#[export]
 Program Instance Coq_Closed : @Closed Coq _ := {
   exponent_obj := Basics.arrow;
   exp_iso := λ _ _ _,
@@ -66,14 +66,14 @@ Program Instance Coq_Closed : @Closed Coq _ := {
 Next Obligation. proper; extensionality X0; congruence. Qed.
 Next Obligation. proper; congruence. Qed.
 
-#[global]
+#[export]
 Program Instance Coq_Initial : Initial Coq := {
   terminal_obj := False;
   one := λ _ _, False_rect _ _
 }.
 Next Obligation. contradiction. Qed.
 
-#[global]
+#[export]
 Program Instance Coq_Cocartesian : @Cocartesian Coq := {
   product_obj := sum;
   fork := λ _ _ _ f g x,
@@ -150,11 +150,11 @@ Qed.
 Next Obligation. now destruct x0. Qed.
 Next Obligation. now destruct x0. Qed.
 
-#[global]
+#[export]
 Program Instance optionF : EndoFunctor option :=
   Functor_EndoFunctor (F:=option_Functor).
 
-#[global] Program Instance option_Monad : @Monad Coq option_Functor := {
+#[export] Program Instance option_Monad : @Monad Coq option_Functor := {
   ret := @Some;
   join := λ _ x,
     match x with
@@ -195,6 +195,6 @@ Next Obligation.
   now rewrite IHx0.
 Qed.
 
-#[global]
+#[export]
 Program Instance listF : EndoFunctor list :=
   Functor_EndoFunctor (F:=list_Functor).

--- a/Instance/Fun.v
+++ b/Instance/Fun.v
@@ -20,7 +20,7 @@ Context {D : Category}.
 (* Fun is the category whose morphisms are natural transformations between
    Functors from C ⟶ D. *)
 
-#[global] Program Definition Fun : Category := {|
+Program Definition Fun : Category := {|
   obj     := C ⟶ D;
   hom     := @Transform C D;
   id      := @nat_id C D;

--- a/Instance/Lambda/Sub.v
+++ b/Instance/Lambda/Sub.v
@@ -16,8 +16,8 @@ Inductive Sub (Γ : Env) : Env → Type :=
   | NoSub : Sub Γ []
   | Push {Γ' τ} : Exp Γ τ → Sub Γ Γ' → Sub Γ (τ :: Γ').
 
-#[global] Arguments NoSub {Γ}.
-#[global] Arguments Push {Γ Γ' τ} _ _.
+Arguments NoSub {Γ}.
+Arguments Push {Γ Γ' τ} _ _.
 
 Derive Signature NoConfusion EqDec for Sub.
 
@@ -376,5 +376,8 @@ Proof.
 Defined.
 
 End Sub.
+
+Arguments NoSub {Γ}.
+Arguments Push {Γ Γ' τ} _ _.
 
 Notation "{|| e ; .. ; f ||}" := (Push e .. (Push f idSub) ..).

--- a/Instance/One.v
+++ b/Instance/One.v
@@ -24,13 +24,13 @@ Notation "1" := _1 : category_scope.
 Notation "one[ C ]" := (@one Cat _ C)
   (at level 9, format "one[ C ]") : object_scope.
 
-#[global]
+#[export]
 Program Instance Erase `(C : Category) : C ⟶ 1 := {
   fobj := fun _ => ();
   fmap := fun _ _ _ => id
 }.
 
-#[global]
+#[export]
 Program Instance Cat_Terminal : @Terminal Cat := {
   terminal_obj := _1;
   one := Erase

--- a/Instance/One/Diagonal.v
+++ b/Instance/One/Diagonal.v
@@ -7,6 +7,7 @@ Require Import Category.Theory.Functor.
 Require Import Category.Functor.Diagonal.
 Require Import Category.Structure.Terminal.
 Require Import Category.Instance.Cat.
+Require Import Category.Instance.One.
 
 Generalizable All Variables.
 Set Primitive Projections.

--- a/Instance/Props.v
+++ b/Instance/Props.v
@@ -27,19 +27,19 @@ Program Definition Props : Category := {|
   compose := fun _ _ _ g f x => g (f x)
 |}.
 
-#[global]
+#[export]
 Program Instance Props_Terminal : @Terminal Props := {
   terminal_obj := True;
   one := fun _ _ => I
 }.
 
-#[global]
+#[export]
 Program Instance Props_Initial : @Initial Props := {
   terminal_obj := False;
   one := fun _ _ => False_rect _ _
 }.
 
-#[global]
+#[export]
 Program Instance Props_Cartesian : @Cartesian Props := {
   product_obj := and;
   fork := fun _ _ _ f g x => conj (f x) (g x);
@@ -47,7 +47,7 @@ Program Instance Props_Cartesian : @Cartesian Props := {
   exr  := fun _ _ p => proj2 p
 }.
 
-#[global]
+#[export]
 Program Instance Props_Cocartesian : @Cocartesian Props := {
   product_obj := or;
   fork := fun _ _ _ f g x =>
@@ -59,7 +59,7 @@ Program Instance Props_Cocartesian : @Cocartesian Props := {
   exr  := fun _ _ p => or_intror p
 }.
 
-#[global]
+#[export]
 Program Instance Props_Closed : @Closed Props _ := {
   exponent_obj := Basics.impl;
   exp_iso := fun _ _ _ =>

--- a/Instance/Rel.v
+++ b/Instance/Rel.v
@@ -58,7 +58,7 @@ Qed.
 Next Obligation. firstorder. Qed.
 Next Obligation. firstorder. Qed.
 
-#[global]
+#[export]
 Program Instance Rel_Initial : @Initial Rel := {
   terminal_obj := False;
   one := fun _ _ => False_rect _ _
@@ -130,7 +130,7 @@ Next Obligation. autounfold in *; apply proof_irrelevance. Qed.
 
 Definition some_number : nat ~{Rel}~> nat := fun x y => (x < y)%nat.
 
-#[global]
+#[export]
 Program Instance Relation_Functor : Coq ⟶ Rel := {
   fobj := fun x => x;
   fmap := fun x y (f : x ~{Coq}~> y) x y => In _ (Singleton _ (f x)) y

--- a/Instance/Sets.v
+++ b/Instance/Sets.v
@@ -22,7 +22,7 @@ Record SetoidMorphism `{Setoid x} `{Setoid y} := {
 Arguments SetoidMorphism {_} _ {_} _.
 Arguments morphism {_ _ _ _ _} _.
 
-#[global]
+#[export]
 Program Instance SetoidMorphism_Setoid {x y : SetoidObject} :
   Setoid (SetoidMorphism x y) := {|
   equiv := fun f g => ∀ x, @equiv _ y (f x) (g x)
@@ -88,7 +88,7 @@ Require Import Category.Theory.Isomorphism.
 Notation "x ≊ y" := ({| carrier := x |} ≅[Sets] {| carrier := y |})
   (at level 99) : category_scope.
 
-#[global]
+#[export]
 Program Instance isomorphism_to_sets_respects
         `{Setoid x} `{Setoid y}
         (iso : @Isomorphism Sets {| carrier := x |} {| carrier := y |}) :
@@ -100,7 +100,7 @@ Next Obligation.
   rewrite X; reflexivity.
 Qed.
 
-#[global]
+#[export]
 Program Instance isomorphism_from_sets_respects
         `{Setoid x} `{Setoid y}
         (iso : @Isomorphism Sets {| carrier := x |} {| carrier := y |}) :
@@ -117,12 +117,12 @@ Ltac morphism :=
 
 Require Import Category.Structure.Terminal.
 
-#[global]
+#[export]
 Program Instance Unit_Setoid : Setoid (unit : Type) := {
   equiv := fun x y => x = y
 }.
 
-#[global]
+#[export]
 Program Instance Sets_Terminal : @Terminal Sets := {
   terminal_obj := {| carrier := unit : Type |};
   one := fun _ => {| morphism := fun _ => tt |};
@@ -132,10 +132,10 @@ Next Obligation. destruct (f x0), (g x0); reflexivity. Qed.
 
 Require Import Category.Structure.Initial.
 
-#[global]
+#[export]
 Program Instance False_Setoid : Setoid False.
 
-#[global]
+#[export]
 Program Instance Sets_Initial : @Initial Sets := {
   terminal_obj := {| carrier := False |};
   one := _
@@ -145,7 +145,7 @@ Next Obligation. contradiction. Qed.
 
 Require Import Category.Structure.Monoidal.
 
-#[global]
+#[export]
 Program Instance Sets_Product_Monoidal : @Monoidal Sets := {
   I      := {| carrier := unit : Type |};
   tensor := {|

--- a/Instance/Sets/Cartesian.v
+++ b/Instance/Sets/Cartesian.v
@@ -9,7 +9,7 @@ Set Primitive Projections.
 Set Universe Polymorphism.
 Unset Transparent Obligations.
 
-#[global]
+#[export]
 Program Instance Sets_Cartesian : @Cartesian Sets := {
   product_obj := fun x y =>
     {| carrier := (carrier x * carrier y)%type

--- a/Instance/Sets/Cartesian/Closed.v
+++ b/Instance/Sets/Cartesian/Closed.v
@@ -14,7 +14,7 @@ Unset Transparent Obligations.
 (* This instance must appear in a separate file, because the Closed structure
    makes use of isomorphisms in [Sets]. *)
 
-#[global]
+#[export]
 Program Instance Sets_Closed : @Closed Sets _ := {
   exponent_obj := fun x y =>
     {| carrier := SetoidMorphism x y

--- a/Instance/Sets/Cocartesian.v
+++ b/Instance/Sets/Cocartesian.v
@@ -9,7 +9,7 @@ Set Primitive Projections.
 Set Universe Polymorphism.
 Unset Transparent Obligations.
 
-#[global]
+#[export]
 Program Instance Sets_Cocartesian : @Cocartesian Sets := {
   product_obj := fun x y =>
     {| carrier := (carrier x + carrier y)%type

--- a/Instance/Sets/Part.v
+++ b/Instance/Sets/Part.v
@@ -88,7 +88,7 @@ Require Import Category.Structure.Cartesian.
 Arguments option_setoid A {_}.
 Arguments sum_setoid A B {_ _}.
 
-#[global]
+#[export]
 Program Instance Part_Cartesian : @Cartesian Part := {
   product_obj := fun x y =>
     {| carrier := sum (carrier x) (sum (carrier y) (carrier x * carrier y)) |}

--- a/Instance/Shapes.v
+++ b/Instance/Shapes.v
@@ -103,7 +103,7 @@ Fixpoint unsize (n : nat) : Shape :=
 Theorem size_unsize n : size (unsize n) = n.
 Proof. now induction n; simpl; auto. Qed.
 
-#[global]
+#[export]
 Program Instance Shape_Setoid : Setoid Shape := {|
   equiv := λ x y, size x = size y
 |}.
@@ -167,7 +167,7 @@ Definition Trie_equiv {s : Shape} {a : Type} (x y : Trie a s) : Type :=
 
 Arguments Trie_equiv {s a} x y /.
 
-#[global]
+#[export]
 Program Instance Trie_Setoid {s : Shape} {a : Type} : Setoid (Trie a s) := {|
   equiv := Trie_equiv
 |}.
@@ -177,7 +177,7 @@ Next Obligation.
   now rewrite H, H0.
 Qed.
 
-#[global]
+#[export]
 Program Instance vec_Proper {a : Type} {s : Shape} :
   Proper (equiv ==> eq) (@vec a s).
 
@@ -206,7 +206,7 @@ Proof.
     now rewrite Trie_map_flatten.
 Qed.
 
-#[global]
+#[export]
 Program Instance Trie_map_Proper {s : Shape} `{f : a → b} :
   Proper (equiv ==> equiv) (@Trie_map s a b f).
 Next Obligation.
@@ -217,7 +217,7 @@ Qed.
 
 (**************************************************************************)
 
-#[global]
+#[export]
 Program Instance Trie_Functor (s : Shape) : Coq ⟶ Sets := {|
   fobj := λ a,     {| carrier   := Trie a s
                     ; is_setoid := Trie_Setoid |};

--- a/Instance/Zero.v
+++ b/Instance/Zero.v
@@ -22,14 +22,14 @@ Program Definition _0 : Category := {|
 
 Notation "0" := _0 : category_scope.
 
-#[global]
+#[export]
 Program Instance From_0 `(C : Category) : 0 ⟶ C.
 Next Obligation. destruct H. Defined.
 Next Obligation. destruct x. Defined.
 Next Obligation. destruct x. Qed.
 Next Obligation. destruct x. Qed.
 
-#[global]
+#[export]
 Program Instance Cat_Initial : @Initial Cat := {
   terminal_obj := _0;
   one := From_0

--- a/Lib/FMapExt.v
+++ b/Lib/FMapExt.v
@@ -84,7 +84,7 @@ Ltac simplify_maps :=
       apply F.empty_mapsto_iff in H; contradiction
   end : core.
 
-#[global] Program Instance MapsTo_Proper {elt} :
+#[export] Program Instance MapsTo_Proper {elt} :
   Proper (E.eq ==> eq ==> M.Equal ==> iff) (@M.MapsTo elt) :=
   (@F.MapsTo_m_Proper elt).
 
@@ -95,7 +95,7 @@ Ltac relational :=
   | [ |- iff _ _ ] => split; intro
   end; subst; auto.
 
-#[global] Program Instance find_Proper {elt} :
+#[export] Program Instance find_Proper {elt} :
   Proper (E.eq ==> eq ==> M.Equal ==> iff)
          (fun k e m => @M.find elt k m = Some e).
 Obligation 1.
@@ -104,7 +104,7 @@ Obligation 1.
   rewrite H, H1; assumption.
 Qed.
 
-#[global] Program Instance fold_Proper {elt A} : ∀ f (eqA : relation A),
+#[export] Program Instance fold_Proper {elt A} : ∀ f (eqA : relation A),
   Equivalence eqA
     → Proper (E.eq ==> eq ==> eqA ==> eqA) f
     → P.transpose_neqkey eqA f
@@ -119,7 +119,7 @@ Proof.
   congruence.
 Qed.
 
-#[global] Program Instance filter_Proper {elt} : ∀ P,
+#[export] Program Instance filter_Proper {elt} : ∀ P,
   Proper (E.eq ==> eq ==> eq) P
     → Proper (M.Equal (elt:=elt) ==> M.Equal) (@P.filter elt P).
 Obligation 1.
@@ -459,7 +459,7 @@ Proof.
   assumption.
 Qed.
 
-#[global] Instance add_Proper {elt} :
+#[export] Instance add_Proper {elt} :
   Proper (E.eq ==> eq ==> M.Equal ==> M.Equal) (M.add (elt:=elt)) :=
   (@F.add_m_Proper elt).
 
@@ -500,7 +500,7 @@ Variable elt : Type.
 Variable P : M.key → elt → bool.
 Variable P_Proper : Proper (E.eq ==> eq ==> eq) P.
 
-#[global] Program Instance for_all_Proper :
+#[export] Program Instance for_all_Proper :
   Proper (M.Equal ==> eq) (@P.for_all elt P).
 Obligation 1.
   relational.
@@ -631,7 +631,7 @@ Definition optionP {A} (P : relation A) : relation (option A) :=
              | _, _ => False
              end.
 
-#[global]
+#[export]
 Program Instance optionP_Equivalence {A} (P : relation A) :
   Equivalence P → Equivalence (optionP P).
 Obligation 1.
@@ -655,7 +655,7 @@ Definition pairP {A B} (P : relation A) (Q : relation B) : relation (A * B) :=
               | (x, y), (x', y') => P x x' /\ Q y y'
               end.
 
-#[global]
+#[export]
 Program Instance pairP_Equivalence {A B} (P : relation A) (Q : relation B) :
   Equivalence P → Equivalence Q → Equivalence (pairP P Q).
 Obligation 1.
@@ -674,7 +674,7 @@ Obligation 3.
   firstorder.
 Qed.
 
-#[global]
+#[export]
 Program Instance take_first_Proper {elt} :
   Proper ((E.eq ==> eq ==> eq)
             ==> E.eq
@@ -743,7 +743,7 @@ Ltac apply_for_all :=
 Definition keep_keys {elt} (P : M.key → bool) : M.t elt → M.t elt :=
   P.filter (fun k _ => P k).
 
-#[global] Program Instance update_Proper {elt} :
+#[export] Program Instance update_Proper {elt} :
   Proper (M.Equal (elt:=elt) ==> M.Equal (elt:=elt) ==> M.Equal)
          (@P.update elt).
 Obligation 1.

--- a/Lib/MapDecide.v
+++ b/Lib/MapDecide.v
@@ -570,7 +570,7 @@ Ltac reify :=
 
 Ltac solve_map := reify; apply formula_sound; vm_compute; auto.
 
-#[global]
+#[export]
 Program Instance sigT_proper {A : Type} :
   Proper (pointwise_relation A Basics.arrow ==> Basics.arrow) (@sigT A).
 Next Obligation.

--- a/Lib/NETList.v
+++ b/Lib/NETList.v
@@ -205,7 +205,7 @@ Equations netlist_equiv {i j : A} (x y : netlist B i j) : Type :=
       | right _ => False
     }.
 
-#[global] Program Instance netlist_equiv_Equivalence {i j} :
+#[export] Program Instance netlist_equiv_Equivalence {i j} :
   Equivalence (@netlist_equiv i j).
 Next Obligation.
   repeat intro.
@@ -256,12 +256,12 @@ Next Obligation.
   eapply IHx; eauto.
 Qed.
 
-#[global] Program Instance netlist_Setoid {i j} : Setoid (netlist B i j) := {
+#[export] Program Instance netlist_Setoid {i j} : Setoid (netlist B i j) := {
   equiv := netlist_equiv;
   setoid_equiv := netlist_equiv_Equivalence;
 }.
 
-#[global] Program Instance netlist_cons_respects {i j k} :
+#[export] Program Instance netlist_cons_respects {i j k} :
   Proper (equiv ==> equiv ==> equiv) (@tadd A B i j k).
 Next Obligation.
   repeat intro.
@@ -270,7 +270,7 @@ Next Obligation.
   now rewrite EqDec.peq_dec_refl.
 Qed.
 
-#[global] Program Instance netlist_app_respects {i j k} :
+#[export] Program Instance netlist_app_respects {i j k} :
   Proper (equiv ==> equiv ==> equiv) (@netlist_app i j k).
 Next Obligation.
   repeat intro.
@@ -293,7 +293,7 @@ Next Obligation.
     exact X0.
 Qed.
 
-#[global] Program Instance netlist_EqDec {i j} : @EqDec (netlist B i j) := {
+#[export] Program Instance netlist_EqDec {i j} : @EqDec (netlist B i j) := {
   eq_dec := netlist_eq_dec
 }.
 
@@ -628,7 +628,7 @@ Class ISemigroup {A : Type} (B : A → A → Type) := {
 
 Infix "<+>" := isappend (at level 42, right associativity).
 
-#[global]
+#[export]
 Instance netlist_ISemigroup {A} {B : A → A → Type} : ISemigroup (netlist B) := {
   isappend := @netlist_app A B;
   isappend_assoc := @netlist_app_assoc A B

--- a/Lib/Setoid.v
+++ b/Lib/Setoid.v
@@ -15,26 +15,6 @@ Class Setoid A := {
 
 Notation "f ≈ g" := (equiv f g) (at level 79) : category_theory_scope.
 
-#[global]
-Program Instance setoid_refl `(sa : Setoid A) :
-  Reflexive equiv.
-Obligation 1. apply setoid_equiv. Qed.
-
-#[global]
-Program Instance setoid_sym `(sa : Setoid A) :
-  Symmetric equiv.
-Obligation 1. apply setoid_equiv; auto. Qed.
-
-#[global]
-Program Instance setoid_trans `(sa : Setoid A) :
-  Transitive equiv.
-Obligation 1.
-  apply setoid_equiv.
-  destruct sa; simpl in *.
-  destruct setoid_equiv0.
-  eapply Equivalence_Transitive; eauto.
-Qed.
-
 Delimit Scope signature_scope with signature.
 
 Notation "f ++> g" := (respectful f g)%signature

--- a/Lib/TList.v
+++ b/Lib/TList.v
@@ -152,7 +152,7 @@ Next Obligation.
   assumption.
 Defined.
 
-#[global] Program Instance tlist_EqDec {i j} : @EqDec (tlist B i j) := {
+#[export] Program Instance tlist_EqDec {i j} : @EqDec (tlist B i j) := {
   eq_dec := tlist_eq_dec
 }.
 
@@ -191,7 +191,7 @@ Equations tlist_equiv {i j : A} (x y : tlist B i j) : Type :=
       | right _ => False
     }.
 
-#[global] Program Instance tlist_equiv_Equivalence {i j} :
+#[export] Program Instance tlist_equiv_Equivalence {i j} :
   Equivalence (@tlist_equiv i j).
 Next Obligation.
   repeat intro.
@@ -236,12 +236,12 @@ Next Obligation.
   eapply IHx; eauto.
 Qed.
 
-#[global] Program Instance tlist_Setoid {i j} : Setoid (tlist B i j) := {
+#[export] Program Instance tlist_Setoid {i j} : Setoid (tlist B i j) := {
   equiv := tlist_equiv;
   setoid_equiv := tlist_equiv_Equivalence;
 }.
 
-#[global] Program Instance tlist_cons_respects {i j k} :
+#[export] Program Instance tlist_cons_respects {i j k} :
   Proper (equiv ==> equiv ==> equiv) (@tcons A B i j k).
 Next Obligation.
   repeat intro.
@@ -250,7 +250,7 @@ Next Obligation.
   now rewrite EqDec.peq_dec_refl.
 Qed.
 
-#[global] Program Instance tlist_app_respects {i j k} :
+#[export] Program Instance tlist_app_respects {i j k} :
   Proper (equiv ==> equiv ==> equiv) (@tlist_app i j k).
 Next Obligation.
   repeat intro.

--- a/Monad/Adjunction.v
+++ b/Monad/Adjunction.v
@@ -8,6 +8,7 @@ Require Import Category.Theory.Natural.Transformation.
 Require Import Category.Theory.Monad.
 Require Import Category.Theory.Adjunction.
 Require Import Category.Adjunction.Natural.Transformation.
+Require Import Category.Instance.Sets.
 
 Generalizable All Variables.
 Set Primitive Projections.

--- a/Monad/Composition.v
+++ b/Monad/Composition.v
@@ -23,7 +23,7 @@ Section MonadComposition.
 
 #[local] Obligation Tactic := idtac.
 
-#[global] Program Instance Monad_Composition `{Monad_Distributive} :
+#[export] Program Instance Monad_Composition `{Monad_Distributive} :
   @Monad _ (M ◯ N) := {
   ret  := fun _ => ret[M] ∘ pure[N];
   join := fun _ => join[M] ∘ fmap[M] prod

--- a/Monad/Transformer.v
+++ b/Monad/Transformer.v
@@ -51,7 +51,7 @@ Next Obligation. destruct H; intuition. Qed.
 Next Obligation. destruct H; intuition. Qed.
 Next Obligation. destruct H; intuition. Qed.
 
-#[global]
+#[export]
 Program Instance IdentityT_MonadTransformer {C : Category} (M : C ⟶ C) `{@Monad C M} :
   @MonadTransformer C M _ (@IdentityT C) (IdentityT_Monad M) := {
   lift := fun _ => id

--- a/Structure/BiCCC.v
+++ b/Structure/BiCCC.v
@@ -22,7 +22,7 @@ Context `{@Cartesian C}.
 Context `{@Cocartesian C}.
 Context `{@Closed C _}.
 
-#[global] Program Instance prod_coprod_l {x y z : C} :
+#[export] Program Instance prod_coprod_l {x y z : C} :
   (* Products distribute over coproducts in every bicartesian closed
      category. *)
   (y + z) × x ≅ y × x + z × x := {
@@ -66,7 +66,7 @@ Proof.
   rewrite iso_to_from; cat.
 Qed.
 
-#[global] Program Instance prod_coprod_r {x y z : C} :
+#[export] Program Instance prod_coprod_r {x y z : C} :
   (* Products distribute over coproducts in every bicartesian closed
      category. *)
   x × (y + z) ≅ x × y + x × z := {
@@ -109,7 +109,7 @@ Qed.
 
 #[local] Hint Rewrite @prod_coprod_r : isos.
 
-#[global] Program Instance exp_coprod {x y z : C} :
+#[export] Program Instance exp_coprod {x y z : C} :
   x^(y + z) ≅ x^y × x^z := {
   to   := curry (eval ∘ second inl) △ curry (eval ∘ second inr);
   from := curry (uncurry exl ▽ uncurry exr ∘ to prod_coprod_r)
@@ -181,7 +181,7 @@ Qed.
 
 Context `{@Initial C}.
 
-#[global] Program Instance prod_zero_l {x : C} :
+#[export] Program Instance prod_zero_l {x : C} :
   0 × x ≅ 0 := {
   to   := uncurry zero;
   from := zero
@@ -190,7 +190,7 @@ Next Obligation. apply curry_inj; simpl; cat. Qed.
 
 #[local] Hint Rewrite @prod_zero_l : isos.
 
-#[global] Program Instance prod_zero_r {x : C} :
+#[export] Program Instance prod_zero_r {x : C} :
   x × 0 ≅ 0 := {
   to   := uncurry zero ∘ swap;
   from := zero
@@ -201,7 +201,7 @@ Next Obligation. apply swap_inj_r, curry_inj; simpl; cat. Qed.
 
 Context `{@Terminal C}.
 
-#[global] Program Instance exp_zero {x : C} :
+#[export] Program Instance exp_zero {x : C} :
   x^0 ≅ 1 := {
   to   := one;
   from := curry (zero ∘ to prod_zero_r)
@@ -214,7 +214,7 @@ Qed.
 
 End BiCCC.
 
-#[global]
+#[export]
 Program Instance BiCCC_Distributive {C : Category}
         `{@Cartesian C} `{@Cocartesian C} `{@Closed C _} `{@Initial C} :
   @Distributive C _ _ _.

--- a/Structure/Cartesian.v
+++ b/Structure/Cartesian.v
@@ -48,7 +48,7 @@ Definition split  {x y z w : C} (f : x ~> y) (g : z ~> w) :
   x × z ~> y × w :=
   (f ∘ exl) △ (g ∘ exr).
 
-#[global] Program Instance first_respects {a b c : C} :
+#[export] Program Instance first_respects {a b c : C} :
   Proper (equiv ==> equiv) (@first a b c).
 Next Obligation.
   proper.
@@ -57,7 +57,7 @@ Next Obligation.
   reflexivity.
 Qed.
 
-#[global] Program Instance second_respects {a b c : C} :
+#[export] Program Instance second_respects {a b c : C} :
   Proper (equiv ==> equiv) (@second a b c).
 Next Obligation.
   proper.
@@ -66,7 +66,7 @@ Next Obligation.
   reflexivity.
 Qed.
 
-#[global] Program Instance split_respects {a b c d : C} :
+#[export] Program Instance split_respects {a b c d : C} :
   Proper (equiv ==> equiv ==> equiv) (@split a b c d).
 Next Obligation.
   proper.
@@ -304,7 +304,7 @@ Theorem split_fork {x y z w v : C}
   split f h ∘ g △ i ≈ (f ∘ g) △ (h ∘ i).
 Proof. unfork. Qed.
 
-#[global] Program Instance prod_respects_iso :
+#[export] Program Instance prod_respects_iso :
   Proper (Isomorphism ==> Isomorphism ==> Isomorphism) product_obj.
 Next Obligation.
   proper.
@@ -317,7 +317,7 @@ Defined.
 
 Context `{@Terminal C}.
 
-#[global] Program Instance prod_one_l  {x : C} :
+#[export] Program Instance prod_one_l  {x : C} :
   1 × x ≅ x := {
   to   := exr;
   from := one △ id
@@ -330,7 +330,7 @@ Qed.
 
 #[local] Hint Rewrite @prod_one_l : isos.
 
-#[global] Program Instance prod_one_r  {x : C} :
+#[export] Program Instance prod_one_r  {x : C} :
   x × 1 ≅ x := {
   to   := exl;
   from := id △ one
@@ -343,13 +343,13 @@ Qed.
 
 #[local] Hint Rewrite @prod_one_r : isos.
 
-#[global] Program Instance prod_comm  {x y : C} :
+#[export] Program Instance prod_comm  {x y : C} :
   x × y ≅ y × x := {
   to   := swap;
   from := swap
 }.
 
-#[global] Program Instance prod_assoc  {x y z : C} :
+#[export] Program Instance prod_assoc  {x y z : C} :
   (x × y) × z ≅ x × (y × z) := {
   to   := (exl ∘ exl) △ ((exr ∘ exl) △ exr);
   from := (exl △ (exl ∘ exr)) △ (exr ∘ exr)

--- a/Structure/Cartesian/Closed.v
+++ b/Structure/Cartesian/Closed.v
@@ -48,7 +48,7 @@ Arguments eval' {_ _ _} /.
 Definition ump_exponents {x y z} (f : x × y ~> z) :
   eval ∘ first (curry f) ≈ f := @ump_exponents' _ x y z f.
 
-#[global] Program Instance curry_respects (a b c : C) :
+#[export] Program Instance curry_respects (a b c : C) :
   Proper (equiv ==> equiv) (@curry a b c).
 Next Obligation.
   proper.
@@ -58,7 +58,7 @@ Next Obligation.
   rewrites; reflexivity.
 Qed.
 
-#[global] Program Instance uncurry_respects (a b c : C) :
+#[export] Program Instance uncurry_respects (a b c : C) :
   Proper (equiv ==> equiv) (@uncurry a b c).
 Next Obligation.
   proper.
@@ -176,7 +176,7 @@ Proof.
   apply uncurry_inj; cat.
 Qed.
 
-#[global] Program Instance exp_respects_iso {x y z : C} :
+#[export] Program Instance exp_respects_iso {x y z : C} :
   Proper (Isomorphism ==> Isomorphism ==> Isomorphism) exponent_obj.
 Next Obligation.
   proper.
@@ -224,7 +224,7 @@ Next Obligation.
     reflexivity.
 Qed.
 
-#[global] Program Instance exp_prod_l {x y z : C} :
+#[export] Program Instance exp_prod_l {x y z : C} :
   z^(x × y) ≅ (z^y)^x := {
   to   := curry (curry (eval ∘ to prod_assoc));
   from := curry (uncurry eval ∘ from prod_assoc)
@@ -277,7 +277,7 @@ Qed.
 
 #[local] Hint Rewrite @exp_prod_l : isos.
 
-#[global] Program Instance exp_prod_r {x y z : C} :
+#[export] Program Instance exp_prod_r {x y z : C} :
   (y × z)^x ≅ y^x × z^x := {
   to   := curry (exl ∘ eval) △ curry (exr ∘ eval);
   from := curry (uncurry exl △ uncurry exr)
@@ -306,7 +306,7 @@ Qed.
 
 #[local] Obligation Tactic := program_simpl.
 
-#[global] Program Instance exp_swap {x y z : C} :
+#[export] Program Instance exp_swap {x y z : C} :
   (z^y)^x ≅ (z^x)^y := {
   to   := to exp_prod_l
         ∘ to (@exp_respects_iso x y z _ _ (@prod_comm _ _ x y) z z iso_id)
@@ -356,7 +356,7 @@ Qed.
 
 Context `{@Terminal C}.
 
-#[global] Program Instance exp_one {x : C} :
+#[export] Program Instance exp_one {x : C} :
   x^1 ≅ x := {
   to   := eval ∘ id △ one;
   from := curry exl
@@ -381,7 +381,7 @@ Qed.
 
 #[local] Hint Rewrite @exp_one : isos.
 
-#[global] Program Instance one_exp {x : C} :
+#[export] Program Instance one_exp {x : C} :
   1^x ≅ 1 := {
   to   := one;
   from := curry one

--- a/Structure/Cocartesian.v
+++ b/Structure/Cocartesian.v
@@ -34,7 +34,7 @@ Definition merge {x y z : C} (f : y ~> x) (g : z ~> x) : y + z ~{C}~> x :=
 
 Infix "▽" := merge (at level 26) : morphism_scope.
 
-#[global] Program Instance merge_respects {x y z} :
+#[export] Program Instance merge_respects {x y z} :
   Proper (equiv ==> equiv ==> equiv) (@merge x y z).
 Next Obligation. apply (@fork_respects _ O). Qed.
 
@@ -51,15 +51,15 @@ Definition cover  {x y z w : C} (f : x ~> y) (g : z ~> w) :
   x + z ~{C}~> y + w :=
   (inl ∘ f) ▽ (inr ∘ g).
 
-#[global] Program Instance left_respects {a b c : C} :
+#[export] Program Instance left_respects {a b c : C} :
   Proper (equiv ==> equiv) (@left a b c).
 Next Obligation. apply (@first_respects _ O). Qed.
 
-#[global] Program Instance right_respects {a b c : C} :
+#[export] Program Instance right_respects {a b c : C} :
   Proper (equiv ==> equiv) (@right a b c).
 Next Obligation. apply (@second_respects _ O). Qed.
 
-#[global] Program Instance cover_respects {a b c d : C} :
+#[export] Program Instance cover_respects {a b c d : C} :
   Proper (equiv ==> equiv ==> equiv) (@cover a b c d).
 Next Obligation.
   proper.
@@ -254,7 +254,7 @@ Theorem cover_inr {x y z w : C} (f : x ~> y) (g : z ~> w):
   cover f g ∘ inr ≈ inr ∘ g.
 Proof. unmerge; cat. Qed.
 
-#[global] Program Instance coprod_respects_iso :
+#[export] Program Instance coprod_respects_iso :
   Proper (Isomorphism ==> Isomorphism ==> Isomorphism) Coprod.
 Next Obligation.
   proper.
@@ -267,7 +267,7 @@ Defined.
 
 Context `{I : @Initial C}.
 
-#[global] Program Instance coprod_zero_l {x : C} :
+#[export] Program Instance coprod_zero_l {x : C} :
   0 + x ≅ x := {
   to   := zero ▽ id;
   from := inr
@@ -276,7 +276,7 @@ Next Obligation. apply (@prod_one_l _ _ I). Qed.
 
 #[local] Hint Rewrite @coprod_zero_l : isos.
 
-#[global] Program Instance coprod_zero_r {x : C} :
+#[export] Program Instance coprod_zero_r {x : C} :
   x + 0 ≅ x := {
   to   := id ▽ zero;
   from := inl
@@ -285,13 +285,13 @@ Next Obligation. apply (@prod_one_r _ _ I). Qed.
 
 #[local] Hint Rewrite @coprod_zero_r : isos.
 
-#[global] Program Instance coprod_comm  {x y : C} :
+#[export] Program Instance coprod_comm  {x y : C} :
   x + y ≅ y + x := {
   to   := paws;
   from := paws
 }.
 
-#[global] Program Instance coprod_assoc  {x y z : C} :
+#[export] Program Instance coprod_assoc  {x y z : C} :
   (x + y) + z ≅ x + (y + z) := {
   to   := (inl ▽ (inr ∘ inl)) ▽ (inr ∘ inr);
   from := (inl ∘ inl) ▽ ((inl ∘ inr) ▽ inr)

--- a/Structure/Group/Proofs.v
+++ b/Structure/Group/Proofs.v
@@ -6,6 +6,7 @@ Require Import Category.Theory.Isomorphism.
 Require Import Category.Theory.Functor.Endo.
 Require Import Category.Functor.Bifunctor.
 Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Monoidal.Naturality.
 Require Import Category.Structure.Monoidal.Proofs.
 Require Import Category.Structure.Monoidal.Braided.
 Require Import Category.Structure.Monoidal.Balanced.
@@ -105,7 +106,8 @@ Proof.
   rewrite !comp_assoc; rewrite <- 2!(comp_assoc _ inverse[grp] f).
   rewrite bimap_comp.
   rewrite <- (comp_assoc _ _ ∆X).
-  assert ((inverse[grp] ∘ f) ⨂ (inverse[grp] ∘ f) ≈ map (inverse[grp] ∘ f)) as R by reflexivity; rewrite R; clear R.
+  assert ((inverse[grp] ∘ f) ⨂ (inverse[grp] ∘ f) ≈ map (inverse[grp] ∘ f)) as R
+    by reflexivity; rewrite R; clear R.
   rewrite <- (comp_assoc _ _ ∆X).
   rewrite (diagonal_natural _ _ (inverse[grp] ∘ f)).
   simpl.

--- a/Structure/Monoid.v
+++ b/Structure/Monoid.v
@@ -63,7 +63,7 @@ Context `{@Terminal C}.
     in the usual sense (i.e., mappend reducing two objects to one). *)
 Definition Monoid := @MonoidObject C InternalProduct_Monoidal.
 
-#[global] Program Instance Product_Monoid `(X : Monoid x) `(Y : Monoid y) :
+#[export] Program Instance Product_Monoid `(X : Monoid x) `(Y : Monoid y) :
   @MonoidObject C InternalProduct_Monoidal (x × y) := {|
   mempty  := @mempty _ _ _ X △ @mempty _ _ _ Y;
   mappend := split (@mappend _ _ _ X) (@mappend _ _ _ Y) ∘ toggle
@@ -164,7 +164,7 @@ Proof.
   now rewrite !eval_first.
 Qed.
 
-#[global] Program Instance Hom_Monoid {x} `(Y : Monoid y) :
+#[export] Program Instance Hom_Monoid {x} `(Y : Monoid y) :
   @MonoidObject C InternalProduct_Monoidal (y ^ x) := {
   mempty  := curry (@mempty _ _ _ Y ∘ exl);
   mappend := curry (@mappend _ _ _ Y ∘ uncurry exl △ uncurry exr)

--- a/Structure/Monoidal/Balanced.v
+++ b/Structure/Monoidal/Balanced.v
@@ -4,6 +4,7 @@ Require Import Category.Lib.
 Require Import Category.Theory.Category.
 Require Import Category.Theory.Isomorphism.
 Require Import Category.Theory.Functor.
+Require Import Category.Theory.Functor.Endo.
 Require Import Category.Theory.Naturality.
 Require Import Category.Structure.Monoidal.
 Require Import Category.Structure.Monoidal.Braided.

--- a/Structure/Monoidal/Braided.v
+++ b/Structure/Monoidal/Braided.v
@@ -4,6 +4,7 @@ Require Import Category.Lib.
 Require Import Category.Theory.Category.
 Require Import Category.Theory.Isomorphism.
 Require Import Category.Theory.Functor.
+Require Import Category.Theory.Functor.Endo.
 Require Import Category.Theory.Naturality.
 Require Import Category.Functor.Bifunctor.
 Require Import Category.Structure.Monoidal.

--- a/Structure/Monoidal/Cartesian.v
+++ b/Structure/Monoidal/Cartesian.v
@@ -56,7 +56,7 @@ Definition split  {x y z w : C} (f : x ~> y) (g : z ~> w) :
   x ⨂ z ~> y ⨂ w :=
   (f ∘ proj_left) △ (g ∘ proj_right).
 
-#[global] Program Instance first_respects {a b c : C} :
+#[export] Program Instance first_respects {a b c : C} :
   Proper (equiv ==> equiv) (@first a b c).
 Next Obligation.
   proper.
@@ -65,7 +65,7 @@ Next Obligation.
   reflexivity.
 Qed.
 
-#[global] Program Instance second_respects {a b c : C} :
+#[export] Program Instance second_respects {a b c : C} :
   Proper (equiv ==> equiv) (@second a b c).
 Next Obligation.
   proper.
@@ -74,7 +74,7 @@ Next Obligation.
   reflexivity.
 Qed.
 
-#[global] Program Instance split_respects {a b c d : C} :
+#[export] Program Instance split_respects {a b c d : C} :
   Proper (equiv ==> equiv ==> equiv) (@split a b c d).
 Next Obligation.
   proper.

--- a/Structure/Monoidal/Cartesian/Cartesian.v
+++ b/Structure/Monoidal/Cartesian/Cartesian.v
@@ -26,7 +26,7 @@ Section CartesianMonoidalCartesian.
 
 Context `{@CartesianMonoidal C}.
 
-#[global] Program Definition CartesianMonoidal_Cartesian : @Cartesian C := {|
+Program Definition CartesianMonoidal_Cartesian : @Cartesian C := {|
   product_obj := fun x y => (x ⨂ y)%object;
   Cartesian.fork := @fork _ _;
   exl  := fun _ _ => proj_left;

--- a/Structure/Monoidal/Closed.v
+++ b/Structure/Monoidal/Closed.v
@@ -77,7 +77,7 @@ Remove Hints Sets_Product_Monoidal : typeclass_instances.
 Definition ump_exponents {x y z} (f : x ⨂ y ~> z) :
   ∃! h : x ~> y ⇒ z, f ≈ eval' ∘ (h ⨂ id) := @ump_exponents' _ x y z f.
 
-#[global] Program Instance curry_respects (a b c : C) :
+#[export] Program Instance curry_respects (a b c : C) :
   Proper (equiv ==> equiv) (@curry a b c).
 Next Obligation.
   proper.
@@ -87,7 +87,7 @@ Next Obligation.
   rewrites; reflexivity.
 Qed.
 
-#[global] Program Instance uncurry_respects (a b c : C) :
+#[export] Program Instance uncurry_respects (a b c : C) :
   Proper (equiv ==> equiv) (@uncurry a b c).
 Next Obligation.
   proper.

--- a/Structure/Monoidal/Naturality.v
+++ b/Structure/Monoidal/Naturality.v
@@ -2,6 +2,7 @@ Set Warnings "-notation-overridden".
 
 Require Import Category.Lib.
 Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
 Require Import Category.Theory.Functor.
 Require Import Category.Theory.Functor.Endo.
 Require Import Category.Theory.Naturality.
@@ -16,7 +17,7 @@ Section MonoidalNaturality.
 
 Context `{M : @Monoidal C}.
 
-#[global] Program Definition Tensor_Left {F : C ⟶ C} {y : C} : C ⟶ C := {|
+Program Definition Tensor_Left {F : C ⟶ C} {y : C} : C ⟶ C := {|
   fobj := fun x => (F x ⨂ y)%object;
   fmap := fun _ _ f => fmap[F] f ⨂[M] id
 |}.
@@ -25,7 +26,7 @@ Next Obligation.
 Defined.
 Next Obligation. normal; reflexivity. Qed.
 
-#[global] Program Instance Tensor_Left_Map `{@EndoFunctor C P} {y : C} :
+#[export] Program Instance Tensor_Left_Map `{@EndoFunctor C P} {y : C} :
   @EndoFunctor C (fun x => P x ⨂ y)%object := {
   map := fun _ _ f => map f ⨂ id;
   endo_is_functor := @Tensor_Left endo_is_functor _
@@ -43,7 +44,7 @@ Next Obligation.
   normal; reflexivity.
 Qed.
 
-#[global] Program Instance Tensor_Right {F : C ⟶ C} {x : C} : C ⟶ C := {
+#[export] Program Instance Tensor_Right {F : C ⟶ C} {x : C} : C ⟶ C := {
   fobj := fun y => (x ⨂ F y)%object;
   fmap := fun _ _ f => id ⨂[M] fmap[F] f
 }.
@@ -53,7 +54,7 @@ Next Obligation.
 Qed.
 Next Obligation. normal; reflexivity. Qed.
 
-#[global] Program Instance Tensor_Right_Map `{@EndoFunctor C P} {x : C} :
+#[export] Program Instance Tensor_Right_Map `{@EndoFunctor C P} {x : C} :
   @EndoFunctor C (fun y => x ⨂ P y)%object := {
   map := fun _ _ f => id ⨂ map f;
   endo_is_functor := @Tensor_Right endo_is_functor _
@@ -71,7 +72,7 @@ Next Obligation.
   normal; reflexivity.
 Qed.
 
-#[global] Program Definition Tensor_Both `{F : C ⟶ C} : C ⟶ C := {|
+Program Definition Tensor_Both `{F : C ⟶ C} : C ⟶ C := {|
   fobj := fun x => (F x ⨂ F x)%object;
   fmap := fun _ _ f => fmap[F] f ⨂[M] fmap[F] f
 |}.
@@ -81,7 +82,7 @@ Next Obligation.
 Qed.
 Next Obligation. normal; reflexivity. Qed.
 
-#[global] Program Instance Tensor_Both_Map `{@EndoFunctor C P} :
+#[export] Program Instance Tensor_Both_Map `{@EndoFunctor C P} :
   @EndoFunctor C (fun x => P x ⨂ P x)%object := {
   map := fun _ _ f => map f ⨂ map f;
   endo_is_functor := @Tensor_Both endo_is_functor

--- a/Structure/Monoidal/Product.v
+++ b/Structure/Monoidal/Product.v
@@ -15,7 +15,7 @@ Unset Transparent Obligations.
 
 #[local] Obligation Tactic := simpl; intros; simplify; simpl in *.
 
-#[global]
+#[export]
 Program Instance Product_Monoidal `{@Monoidal C} `{@Monoidal D} :
   @Monoidal (C ∏ D) := {
   tensor :=

--- a/Structure/Monoidal/Relevance.v
+++ b/Structure/Monoidal/Relevance.v
@@ -4,9 +4,11 @@ Require Import Category.Lib.
 Require Import Category.Theory.Category.
 Require Import Category.Theory.Isomorphism.
 Require Import Category.Theory.Functor.
+Require Import Category.Theory.Functor.Endo.
 Require Import Category.Theory.Naturality.
 Require Import Category.Functor.Bifunctor.
 Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Monoidal.Naturality.
 Require Import Category.Structure.Monoidal.Braided.
 Require Import Category.Structure.Monoidal.Balanced.
 Require Import Category.Structure.Monoidal.Symmetric.
@@ -77,7 +79,7 @@ Notation "∆ x" := (@diagonal _ x)
 Definition fork {x y z} (f : x ~> y) (g : x ~> z) :
   x ~> y ⨂ z := f ⨂ g ∘ ∆x.
 
-#[global] Program Instance fork_respects {x y z : C} :
+#[export] Program Instance fork_respects {x y z : C} :
   Proper (equiv ==> equiv ==> equiv) (@fork x y z).
 Next Obligation.
   proper.

--- a/Structure/Monoidal/Semicartesian/Terminal.v
+++ b/Structure/Monoidal/Semicartesian/Terminal.v
@@ -15,7 +15,7 @@ Section SemicartesianMonoidalTerminal.
 Context `{@Monoidal C}.
 Context `{@SemicartesianMonoidal C _}.
 
-#[global] Program Definition SemicartesianMonoidal_Terminal : @Terminal C := {|
+Program Definition SemicartesianMonoidal_Terminal : @Terminal C := {|
   terminal_obj := I;
   one := @eliminate _ _ _;
   one_unique := @unit_terminal _ _ _

--- a/Theory/Category.v
+++ b/Theory/Category.v
@@ -193,7 +193,7 @@ Arguments id_right {_%category _%object _%object} _%morphism.
 Arguments comp_assoc {_%category _%object _%object _%object _%object}
   _%morphism _%morphism _%morphism.
 
-#[global]
+#[export]
 Program Instance hom_preorder {C : Category} : PreOrder (@hom C) := {
   PreOrder_Reflexive  := fun _ => id;
   PreOrder_Transitive := fun _ _ _ f g => g ∘ f

--- a/Theory/Dinatural.v
+++ b/Theory/Dinatural.v
@@ -34,7 +34,7 @@ Class Dinatural := {
         ≈ fmap[G] (id ⋆⋆⋆ f) ∘ ditransform ∘ fmap[F] (op f ⋆⋆⋆ id)
 }.
 
-#[global] Program Instance Dinatural_Setoid : Setoid Dinatural.
+#[export] Program Instance Dinatural_Setoid : Setoid Dinatural.
 
 End Dinatural.
 

--- a/Theory/Functor.v
+++ b/Theory/Functor.v
@@ -64,7 +64,7 @@ Notation "fmap[ F ]" := (@fmap _ _ F%functor _ _)
 
 #[export] Hint Rewrite @fmap_id : categories.
 
-#[global]
+#[export]
 Program Instance Functor_Setoid {C D : Category} : Setoid (C ⟶ D) := {
   (* Note that it doesn't make much sense (with our definition of [Category])
      to ask that [∀ x : C, F x = G x] and
@@ -143,7 +143,7 @@ Ltac constructive :=
                      | exists iso; intros ]
   end.
 
-#[global]
+#[export]
 Program Instance fobj_iso `(F : C ⟶ D) :
   Proper (Isomorphism ==> Isomorphism) (fobj[F]).
 Next Obligation.
@@ -156,7 +156,7 @@ Next Obligation.
   rewrite iso_from_to; cat.
 Defined.
 
-#[global]
+#[export]
 Instance fobj_respects `(F : C ⟶ D) :
   Proper (equiv ==> equiv) (@fobj C D F) := @fobj_iso C D F.
 
@@ -184,7 +184,7 @@ Next Obligation. intros; rewrite !fmap_comp; reflexivity. Qed.
 Notation "F ◯ G" := (Compose F%functor G%functor)
   (at level 40, left associativity) : category_scope.
 
-#[global]
+#[export]
 Program Instance Compose_respects {C D E : Category} :
   Proper (equiv ==> equiv ==> equiv) (@Compose C D E).
 Next Obligation.

--- a/Theory/Functor/Endo.v
+++ b/Theory/Functor/Endo.v
@@ -30,28 +30,28 @@ Coercion endo_is_functor : EndoFunctor >-> Functor.
 Notation "map[ F ]" := (@map _ _ F _ _)
   (at level 9, format "map[ F ]") : morphism_scope.
 
-#[global]
+#[export]
 Program Instance Identity_EndoFunctor {C : Category} :
   EndoFunctor (fun x => x) | 9 := {
   map := fun _ _ f => f;
   endo_is_functor := Id
 }.
 
-#[global]
+#[export]
 Program Instance Functor_EndoFunctor {C : Category} {F : C ⟶ C} :
   EndoFunctor F := {
   map := fun _ _ f => fmap[F] f;
   endo_is_functor := F
 }.
 
-#[global]
+#[export]
 Program Instance Functor_Eta_EndoFunctor {C : Category} {F : C ⟶ C} :
   EndoFunctor (fun x => F x) := {
   map := fun _ _ f => fmap[F] f;
   endo_is_functor := F
 }.
 
-#[global]
+#[export]
 Program Instance Functor_Map_EndoFunctor {C : Category}
         `{G : @EndoFunctor C P} {F : C ⟶ C} :
   EndoFunctor (fun x => F (P x)) := {

--- a/Theory/Isomorphism.v
+++ b/Theory/Isomorphism.v
@@ -39,12 +39,12 @@ Arguments iso_from_to {x y} _.
 
 Infix "≅" := Isomorphism (at level 91) : category_scope.
 
-#[global] Program Instance iso_id {x : C} : x ≅ x := {
+#[export] Program Instance iso_id {x : C} : x ≅ x := {
   to   := id;
   from := id
 }.
 
-#[global] Program Definition iso_sym {x y : C} `(f : x ≅ y) : y ≅ x := {|
+Program Definition iso_sym {x y : C} `(f : x ≅ y) : y ≅ x := {|
   to   := from f;
   from := to f;
 
@@ -52,7 +52,7 @@ Infix "≅" := Isomorphism (at level 91) : category_scope.
   iso_from_to := iso_to_from f
 |}.
 
-#[global] Program Definition iso_compose {x y z : C} `(f : y ≅ z) `(g : x ≅ y) :
+Program Definition iso_compose {x y z : C} `(f : y ≅ z) `(g : x ≅ y) :
   x ≅ z := {|
   to   := to f ∘ to g;
   from := from g ∘ from f
@@ -70,7 +70,7 @@ Next Obligation.
   apply iso_from_to.
 Defined.
 
-#[global] Program Instance iso_equivalence : Equivalence Isomorphism := {
+#[export] Program Instance iso_equivalence : Equivalence Isomorphism := {
   Equivalence_Reflexive  := @iso_id;
   Equivalence_Symmetric  := @iso_sym;
   Equivalence_Transitive := fun _ _ _ g f => iso_compose f g
@@ -78,14 +78,14 @@ Defined.
 
 Definition ob_equiv : crelation C := Isomorphism.
 
-#[global] Instance ob_setoid : Setoid C :=
+#[export] Instance ob_setoid : Setoid C :=
   {| equiv := Isomorphism
    ; setoid_equiv := iso_equivalence |}.
 
 Definition iso_equiv {x y : C} : crelation (x ≅ y) :=
   fun f g => (to f ≈ to g) * (from f ≈ from g).
 
-#[global] Program Instance iso_equiv_equivalence {x y : C} :
+#[export] Program Instance iso_equiv_equivalence {x y : C} :
   Equivalence (@iso_equiv x y).
 Next Obligation. now firstorder. Qed.
 Next Obligation. now firstorder. Qed.
@@ -95,14 +95,14 @@ Next Obligation.
             | now transitivity (from y0) ].
 Qed.
 
-#[global] Instance iso_setoid {x y : C} : Setoid (x ≅ y) := {
+#[export] Instance iso_setoid {x y : C} : Setoid (x ≅ y) := {
   equiv := iso_equiv;
   setoid_equiv := iso_equiv_equivalence
 }.
 
 #[local] Obligation Tactic := program_simpl.
 
-#[global] Program Instance Iso_Proper :
+#[export] Program Instance Iso_Proper :
   Proper (Isomorphism ==> Isomorphism ==> iffT) Isomorphism.
 Next Obligation.
   proper.
@@ -146,7 +146,7 @@ Notation "f '⁻¹'" := (from f) (at level 9, format "f '⁻¹'") : morphism_sco
 Ltac isomorphism :=
   unshelve (refine {| to := _; from := _ |}; simpl; intros).
 
-#[global]
+#[export]
 Program Instance iso_to_monic {C : Category} {x y} (iso : @Isomorphism C x y) :
   Monic iso.
 Next Obligation.
@@ -157,7 +157,7 @@ Next Obligation.
   rewrites; reflexivity.
 Qed.
 
-#[global]
+#[export]
 Program Instance iso_from_monic {C : Category} {x y} (iso : @Isomorphism C x y) :
   Monic (iso⁻¹).
 Next Obligation.
@@ -168,7 +168,7 @@ Next Obligation.
   rewrites; reflexivity.
 Qed.
 
-#[global]
+#[export]
 Program Instance iso_to_epic {C : Category} {x y} (iso : @Isomorphism C x y) :
   Epic iso.
 Next Obligation.
@@ -179,7 +179,7 @@ Next Obligation.
   rewrites; reflexivity.
 Qed.
 
-#[global]
+#[export]
 Program Instance iso_from_epic {C : Category} {x y} (iso : @Isomorphism C x y) :
   Epic (iso⁻¹).
 Next Obligation.
@@ -190,7 +190,7 @@ Next Obligation.
   rewrites; reflexivity.
 Qed.
 
-#[global]
+#[export]
 Program Instance Monic_Retraction_Iso
         {C : Category} {x y : C} `(r : @Retraction _ _ _ f) `(m : @Monic _ _ _ f) :
   x ≅ y := {
@@ -210,7 +210,7 @@ Next Obligation.
   rewrite retract_comp; cat.
 Qed.
 
-#[global]
+#[export]
 Program Instance Epic_Section_Iso
         {C : Category} {x y : C} `(s : @Section _ _ _ f) `(e : @Epic _ _ _ f) :
   x ≅ y := {

--- a/Theory/Kan/Extension.v
+++ b/Theory/Kan/Extension.v
@@ -57,7 +57,7 @@ Class LocalRightKan (X : A ⟶ C) := {
    extensions fit together to define a functor which is the global Kan
    extension." *)
 
-#[global] Program Instance RightKan_to_LocalRightKan {R : RightKan} (X : A ⟶ C) :
+#[export] Program Instance RightKan_to_LocalRightKan {R : RightKan} (X : A ⟶ C) :
   LocalRightKan X := {|
   LocalRan := Ran X;
   ran_transform :=
@@ -115,7 +115,7 @@ Class LocalLeftKan (X : A ⟶ C) := {
     ∃! δ, ε ≈ δ ⊲ F ∙ lan_transform;
 }.
 
-#[global] Program Instance LeftKan_to_LocalLeftKan {R : LeftKan} (X : A ⟶ C) :
+#[export] Program Instance LeftKan_to_LocalLeftKan {R : LeftKan} (X : A ⟶ C) :
   LocalLeftKan X := {|
   LocalLan := Lan X;
   lan_transform :=

--- a/Theory/Metacategory.v
+++ b/Theory/Metacategory.v
@@ -145,7 +145,7 @@ Qed.
 
 #[local] Obligation Tactic := intros.
 
-#[global] Program Definition FromArrows (M : Metacategory) : Category := {|
+Program Definition FromArrows (M : Metacategory) : Category := {|
   (* The objects of the category are given by all the identity arrows of the
      arrows-only metacategory. *)
   obj := ∃ i : arr M, identity M i;

--- a/Theory/Metacategory/ArrowsOnly.v
+++ b/Theory/Metacategory/ArrowsOnly.v
@@ -109,12 +109,12 @@ Definition composition {x y z : object}
    ; mor_dom := composition_right (f:=f) (`2 fg) (mor_dom g)
    ; mor_cod := composition_left  (g:=g) (`2 fg) (mor_cod f) |}.
 
-#[global] Program Instance morphism_preorder : PreOrder morphism := {
+#[export] Program Instance morphism_preorder : PreOrder morphism := {
   PreOrder_Reflexive  := identity;
   PreOrder_Transitive := fun _ _ _ g f => composition f g
 }.
 
-#[global] Program Instance morphism_setoid (x y : object) :
+#[export] Program Instance morphism_setoid (x y : object) :
   Setoid (morphism x y) := {
   equiv := fun f g => mor_arr f = mor_arr g
 }.
@@ -480,7 +480,7 @@ Defined.
 
 Require Import Category.Instance.Cat.
 
-#[global]
+#[export]
 Program Instance Two_iso_2 : Category_from_Metacategory Two ≅ _2 := {
   to   := Two_to_Two;
   from := Two_from_Two

--- a/Theory/Natural/Transformation.v
+++ b/Theory/Natural/Transformation.v
@@ -30,7 +30,7 @@ Class Transform := {
     transform ∘ fmap[F] f ≈ fmap[G] f ∘ transform
 }.
 
-#[global] Program Instance Transform_Setoid : Setoid Transform :=
+#[export] Program Instance Transform_Setoid : Setoid Transform :=
   {| equiv N0 N1 := ∀ x, (@transform N0 x) ≈ (@transform N1 x); |}.
 Next Obligation.
   equivalence.
@@ -110,7 +110,7 @@ Lemma fun_comp_assoc_sym_and `(F : A ⟶ B) `(G : B ⟶ C) `(H : C ⟶ D) (x : A
   fun_comp_assoc_sym x ∘ fun_comp_assoc x ≈ fmap[H] (fmap[G] (fmap[F] id)).
 Proof. simpl; cat. Qed.
 
-#[global]
+#[export]
 Program Instance nat_Setoid `{F : C ⟶ D} {G : C ⟶ D} :
   Setoid (F ⟹ G) := Transform_Setoid.
 
@@ -146,7 +146,7 @@ Program Definition nat_compose_respects
   Proper (equiv ==> equiv ==> equiv) (@nat_compose C D F G K).
 Proof. proper. Qed.
 
-#[global]
+#[export]
 Program Instance Transform_PreOrder {C E : Category} :
   PreOrder (@Transform C E).
 Next Obligation.
@@ -156,7 +156,7 @@ Next Obligation.
   exact (λ _ _ _ f g, nat_compose g f).
 Defined.
 
-#[global]
+#[export]
 Program Instance Transform_respects {C D : Category} :
   Proper ((λ F G, G ⟹ F) ==> @Transform C D ==> Basics.arrow) (@Transform C D) :=
   λ _ _ F _ _ G H, nat_compose G (nat_compose H F).
@@ -187,7 +187,7 @@ Next Obligation.
   now apply nat_hcompose_obligation_1.
 Qed.
 
-#[global]
+#[export]
 Program Instance Compose_respects_Transform {C D E : Category} :
   Proper (@Transform D E ==> @Transform C D ==> @Transform C E)
          (@Compose C D E) :=

--- a/Theory/Naturality.v
+++ b/Theory/Naturality.v
@@ -12,8 +12,8 @@ Set Universe Polymorphism.
 Unset Transparent Obligations.
 
 Class Naturality (A : Type) : Type := {
-    natural (f : A) : Type
-  }.
+  natural (f : A) : Type
+}.
 
 Arguments natural {A _} _ /.
 
@@ -23,19 +23,19 @@ Ltac prove_naturality H tac :=
   split; simpl;
   intros; tac; intuition.
 
-#[global]
-  Program Instance Identity_Naturality {C : Category} :
+#[export]
+Program Instance Identity_Naturality {C : Category} :
   Naturality (∀ A, A ~> A) := {
-    natural := fun f => ∀ x y (g : x ~> y), g ∘ f x ≈ f y ∘ g
-  }.
+  natural := fun f => ∀ x y (g : x ~> y), g ∘ f x ≈ f y ∘ g
+}.
 
-#[global]
-  Program Instance Functor_Naturality
+#[export]
+Program Instance Functor_Naturality
   {C : Category} {D : Category} (F G : C ⟶ D) :
   Naturality (∀ A, F A ~> G A) := {
-    natural := fun f =>
-                 ∀ x y (g : x ~{C}~> y), fmap[G] g ∘ f x ≈ f y ∘ fmap[F] g
-  }.
+  natural := fun f =>
+               ∀ x y (g : x ~{C}~> y), fmap[G] g ∘ f x ≈ f y ∘ fmap[F] g
+}.
 
 (*
 Require Import Category.Functor.Constant.
@@ -101,7 +101,7 @@ Next Obligation.
 Qed.
  *)
 
-#[global]
+#[export]
 Program Instance ArityOne {C : Category}
   (P : C → C) {F : @EndoFunctor C P}
   (Q : C → C) {G : @EndoFunctor C Q} :
@@ -109,7 +109,7 @@ Program Instance ArityOne {C : Category}
   natural := fun f => ∀ x y (g : x ~> y), @map _ _ G _ _ g ∘ f x ≈ f y ∘ @map _ _ F _ _ g
 }.
 
-#[global]
+#[export]
 Program Instance ArityTwo {C : Category}
   (P : C → C → C)
   {FA : ∀ B, @EndoFunctor C (fun A => P A B)}
@@ -123,7 +123,7 @@ Program Instance ArityTwo {C : Category}
                    ≈ f y w ∘ @map _ _ (FB _) _ _ h ∘ @map _ _ (FA _) _ _ g
 }.
 
-#[global]
+#[export]
 Program Instance ArityThree {C : Category}
   (P : C → C → C → C)
   {FA : ∀ B D : C, @EndoFunctor C (fun A => P A B D)}
@@ -147,7 +147,7 @@ Program Instance ArityThree {C : Category}
                    ∘ @map _ _ (FA _ _) _ _ g
 }.
 
-#[global]
+#[export]
 Program Instance ArityFour {C : Category}
   (P : C → C → C → C → C)
   {FA : ∀ B D E : C, @EndoFunctor C (fun A => P A B D E)}
@@ -176,7 +176,7 @@ Program Instance ArityFour {C : Category}
                    ∘ @map _ _ (FA _ _ _) _ _ g
 }.
 
-#[global]
+#[export]
 Program Instance ArityFive {C : Category}
   (P : C → C → C → C → C → C)
   {FA : ∀ B D E F : C, @EndoFunctor C (fun A => P A B D E F)}
@@ -210,7 +210,7 @@ Program Instance ArityFive {C : Category}
                    ∘ @map _ _ (FA _ _ _ _) _ _ g
 }.
 
-#[global]
+#[export]
 Program Instance Transform_ArityOne {C : Category}
   (P : C → C) `{@EndoFunctor C P}
   (Q : C → C) `{@EndoFunctor C Q} :
@@ -219,7 +219,7 @@ Program Instance Transform_ArityOne {C : Category}
                         natural (fun A => from (f A))
 }.
 
-#[global]
+#[export]
 Program Instance Transform_ArityTwo {C : Category}
   (P : C → C → C)
   `{∀ B, @EndoFunctor C (fun A => P A B)}
@@ -232,7 +232,7 @@ Program Instance Transform_ArityTwo {C : Category}
                         natural (fun A B => from (f A B))
 }.
 
-#[global]
+#[export]
 Program Instance Transform_ArityThree {C : Category}
   (P : C → C → C → C)
   `{∀ B D : C, @EndoFunctor C (fun A => P A B D)}
@@ -247,7 +247,7 @@ Program Instance Transform_ArityThree {C : Category}
                         natural (fun A B D => from (f A B D))
 }.
 
-#[global]
+#[export]
 Program Instance Transform_ArityFour {C : Category}
   (P : C → C → C → C → C)
   `{∀ B D E : C, @EndoFunctor C (fun A => P A B D E)}
@@ -264,7 +264,7 @@ Program Instance Transform_ArityFour {C : Category}
                         natural (fun A B D E => from (f A B D E))
 }.
 
-#[global]
+#[export]
 Program Instance Transform_ArityFive {C : Category}
   (P : C → C → C → C → C → C)
   `{∀ B D E F : C, @EndoFunctor C (fun A => P A B D E F)}

--- a/Tools/Abstraction.v
+++ b/Tools/Abstraction.v
@@ -137,7 +137,7 @@ Class NumericalFunctor := {
 
 End NumericalFunctor.
 
-#[global]
+#[export]
 Instance Coq_Numerical : @Numerical Coq Coq_Cartesian := {
   numerical_obj := nat;
   add := Datatypes.uncurry Nat.add

--- a/Tools/Represented.v
+++ b/Tools/Represented.v
@@ -24,7 +24,7 @@ Class Repr (A : Type) := {
 Arguments Repr A : clear implicits.
 Arguments repr A {_}.
 
-#[global]
+#[export]
 Program Instance prod_Repr
         `{HA : @Repr A}
         `{HB : @Repr B} :
@@ -33,19 +33,19 @@ Program Instance prod_Repr
   convert := fun p => convert (fst p) △ convert (snd p)
 }.
 
-#[global]
+#[export]
 Program Instance unit_Repr : Repr (unit : Type) := {
   repr := One_;
   convert := fun _ => one
 }.
 
-#[global]
+#[export]
 Program Instance false_Repr : Repr False := {
   repr := Zero_;
   convert := fun _ => False_rect _ _
 }.
 
-#[global]
+#[export]
 Program Instance bool_Repr : Repr bool := {
   repr := Coprod_ One_ One_;
   convert := fun b => if b then inl else inr


### PR DESCRIPTION
Note that this change will require more imports in user code than previously, but since exports weren't well documented, the pain of this change should result in more future-proof user code.