### PR TITLE
Allow rewrites to be performed over structure only

### DIFF
--- a/Lib/IList.v
+++ b/Lib/IList.v
@@ -85,3 +85,13 @@ Equations isplit `(xs : ilist (l ++ l')) : ilist l * ilist l'  :=
   }.
 
 End ilist.
+
+Equations imap `(f : A → C) `(k : ∀ (a : A), B a → D (f a))
+  `(xs : @ilist A B l) : @ilist C D (map f l) :=
+  imap f k (l:=[]) tt := tt;
+  imap f k (l:=j :: js) (x, xs) := (k j x, imap f k xs).
+
+Equations imap' `(k : ∀ (a : A), B a → C a)
+  `(xs : @ilist A B l) : @ilist A C l :=
+  imap' k (l:=[]) tt := tt;
+  imap' k (l:=j :: js) (x, xs) := (k j x, imap' k xs).

--- a/Solver/Decide.v
+++ b/Solver/Decide.v
@@ -140,13 +140,13 @@ Example ex_categorical (C : Category) (x y z w : C)
   f ∘ (id ∘ g ∘ h) ≈ (f ∘ g) ∘ h.
 Proof.
   intros.
-  Succeed categorical.
+  (* categorical. *)
   normalize.
-  categorify.
-  assert (Comp (Morph 2) (Comp (Morph 1) (Morph 0)) ≈
-            Comp (Comp (Morph 2) (Morph 1)) (Morph 0)). {
-    now vm_compute.
-  }
-  rewrite X.
+  (* categorify. *)
+  (* assert (Comp (Morph 2) (Comp (Morph 1) (Morph 0)) ≈ *)
+  (*           Comp (Comp (Morph 2) (Morph 1)) (Morph 0)). { *)
+  (*   now vm_compute. *)
+  (* } *)
+  (* rewrite X. *)
   now vm_compute.
 Qed.

--- a/Solver/Decide.v
+++ b/Solver/Decide.v
@@ -4,15 +4,12 @@ Set Equations With UIP.
 Require Import Category.Lib.
 Require Import Category.Lib.IList.
 Require Import Category.Theory.Category.
-Require Import Category.Theory.Functor.
 Require Import Category.Solver.Expr.
 Require Import Category.Solver.Denote.
 Require Import Category.Solver.Reify.
 Require Import Category.Solver.Normal.
 
 Section Decide.
-
-#[local] Set Transparent Obligations.
 
 Context `{Arrows}.
 
@@ -140,13 +137,13 @@ Example ex_categorical (C : Category) (x y z w : C)
   f ∘ (id ∘ g ∘ h) ≈ (f ∘ g) ∘ h.
 Proof.
   intros.
-  (* categorical. *)
-  normalize.
+  categorical.
+  (* normalize. *)
   (* categorify. *)
   (* assert (Comp (Morph 2) (Comp (Morph 1) (Morph 0)) ≈ *)
   (*           Comp (Comp (Morph 2) (Morph 1)) (Morph 0)). { *)
   (*   now vm_compute. *)
   (* } *)
   (* rewrite X. *)
-  now vm_compute.
+  (* now vm_compute. *)
 Qed.

--- a/Solver/Denote.v
+++ b/Solver/Denote.v
@@ -1,5 +1,4 @@
 Require Import Coq.Lists.List.
-(* Require Import Coq.Arith.Arith. *)
 
 From Equations Require Import Equations.
 Set Equations With UIP.
@@ -7,7 +6,6 @@ Set Equations With UIP.
 Require Import Category.Lib.
 Require Import Category.Lib.IList.
 Require Import Category.Theory.Category.
-Require Import Category.Structure.Cartesian.
 Require Import Category.Solver.Expr.
 
 Generalizable All Variables.
@@ -22,19 +20,19 @@ Import ListNotations.
 Open Scope nat_scope.
 
 Definition helper {f} :
-  (let '(dom, cod) := nth f tys (Ob 0, Ob 0)
+  (let '(dom, cod) := nth f tys (0, 0)
    in objD dom ~> objD cod)
-    → objD (fst (nth f tys (Ob 0, Ob 0))) ~>
-      objD (snd (nth f tys (Ob 0, Ob 0))).
-Proof. destruct (nth f tys (Ob 0, Ob 0)); auto. Defined.
+    → objD (fst (nth f tys (0, 0))) ~>
+      objD (snd (nth f tys (0, 0))).
+Proof. destruct (nth f tys (0, 0)); auto. Defined.
 
 Import EqNotations.
 
 Program Definition lookup_arr (f : nat) dom :
   option (∃ cod, objD dom ~> objD cod) :=
-  match eq_dec (fst (nth f tys (Ob 0, Ob 0))) dom with
+  match eq_dec (fst (nth f tys (0, 0))) dom with
   | left H =>
-      Some (snd (nth f tys (Ob 0, Ob 0));
+      Some (snd (nth f tys (0, 0));
             rew [fun x => objD x ~> _] H in
               helper (ith f arrs _))
   | _ => None
@@ -45,25 +43,6 @@ Fixpoint termD_work dom (e : Term) :
   match e with
   | Ident => Some (dom; id)
   | Morph a => lookup_arr a dom
-  | Fork f g =>
-    match termD_work dom f with
-    | Some (fcod; f) =>
-      match termD_work dom g with
-      | Some (gcod; g) => Some (Pair fcod gcod; f △ g)
-      | _ => None
-      end
-    | _ => None
-    end
-  | Exl =>
-      match dom with
-      | Pair x y => Some (x; exl)
-      | _ => None
-      end
-  | Exr =>
-      match dom with
-      | Pair x y => Some (y; exr)
-      | _ => None
-      end
   | Comp f g =>
     match termD_work dom g with
     | Some (mid; g) =>
@@ -110,43 +89,31 @@ Import ListNotations.
 Section DenoteExamples.
 
 Context (C : Category).
-Context `{H : @Cartesian C}.
 Variables x y z w : C.
 Variable f : z ~> w.
 Variable g : y ~> z.
 Variable h : x ~> y.
 Variable i : x ~> z.
 
-#[local] Instance sample_objects : Objects := {|
+Open Scope nat_scope.
+
+#[local] Instance sample_objects : Objects C := {|
   def_obj := y;
   objs    := [w; x; z; y; y];
 |}.
 
-#[local] Instance sample_arrows : Arrows := {|
+#[local] Instance sample_arrows : Arrows C := {|
   arrs :=
-    icons ((Ob 2), (Ob 0)) f
-      (icons ((Ob 1), (Ob 2)) i
-         (icons ((Ob 1), (Ob 3)) h
-            (icons ((Ob 3), (Ob 2)) g
-               (icons ((Ob 3), (Ob 2)) g
+    icons (2, 0) f
+      (icons (1, 2) i
+         (icons (1, 3) h
+            (icons (3, 2) g
+               (icons (3, 2) g
                   inil))))
 |}.
 
 Example termD_SIdent_Some :
-  termD (Ob 0) (Ob 0) Ident = Some id.
-Proof. reflexivity. Qed.
-
-Example termD_SExl_Some :
-  termD ((Pair (Ob 0) (Ob 1))) (Ob 0) Exl = Some exl.
-Proof. reflexivity. Qed.
-
-Example termD_SExr_Some :
-  termD (Pair (Ob 0) (Ob 1)) (Ob 1) Exr = Some exr.
-Proof. reflexivity. Qed.
-
-Example termD_SFork_Some :
-  termD (Ob 1) (Pair (Ob 3) (Ob 2)) (Fork (Morph 2) (Morph 1))
-    = Some (h △ i).
+  termD 0 0 Ident = Some id.
 Proof. reflexivity. Qed.
 
 End DenoteExamples.

--- a/Solver/Denote.v
+++ b/Solver/Denote.v
@@ -8,9 +8,6 @@ Require Import Category.Lib.IList.
 Require Import Category.Theory.Category.
 Require Import Category.Solver.Expr.
 
-Generalizable All Variables.
-Set Transparent Obligations.
-
 Section Denote.
 
 Context `{Arrows}.
@@ -81,41 +78,3 @@ Fixpoint exprD (e : Expr) : Type :=
   end.
 
 End Denote.
-
-Module DenoteExamples.
-
-Import ListNotations.
-
-Section DenoteExamples.
-
-Context (C : Category).
-Variables x y z w : C.
-Variable f : z ~> w.
-Variable g : y ~> z.
-Variable h : x ~> y.
-Variable i : x ~> z.
-
-Open Scope nat_scope.
-
-#[local] Instance sample_objects : Objects C := {|
-  def_obj := y;
-  objs    := [w; x; z; y; y];
-|}.
-
-#[local] Instance sample_arrows : Arrows C := {|
-  arrs :=
-    icons (2, 0) f
-      (icons (1, 2) i
-         (icons (1, 3) h
-            (icons (3, 2) g
-               (icons (3, 2) g
-                  inil))))
-|}.
-
-Example termD_SIdent_Some :
-  termD 0 0 Ident = Some id.
-Proof. reflexivity. Qed.
-
-End DenoteExamples.
-
-End DenoteExamples.

--- a/Solver/Expr.v
+++ b/Solver/Expr.v
@@ -1,48 +1,34 @@
-Require Import Coq.Lists.List.
-
-From Equations Require Import Equations.
-Set Equations With UIP.
-
 Require Import Category.Lib.
 Require Import Category.Lib.IList.
 Require Import Category.Theory.Category.
 
-Generalizable All Variables.
-Set Transparent Obligations.
-
 Definition Obj := nat.
 
-Definition objD' {C: Category} (d : C) (objs : list C) (n : Obj) :=
-  nth n objs d.
+Definition objD' {C : Category} (d : C) (objs : list C) (n : Obj) :=
+  List.nth n objs d.
 
-Definition arrD' {C: Category} (d : C) (objs : list C) '(dom, cod) :=
+Definition arrD' {C : Category} (d : C) (objs : list C) '(dom, cod) :=
   objD' d objs dom ~> objD' d objs cod.
 
 Class Objects (cat : Category) := {
-  (* Note that we one extra object here (doubling the last), just for the
-     convenience of always knowing by the type that there must be one more
-     than [num_objs] available. This saves us from having to maintain
-     [num_objs] as the "size minus one". *)
   def_obj : cat;
-  objs    : list cat;
-  objD   := objD' def_obj objs;
+  objs : list cat;
+  objD := objD' def_obj objs;
 }.
 
 Class Arrows (cat : Category) := {
   has_objects : Objects cat;
 
-  arrD  := arrD' def_obj objs;
-  tys    : list (Obj * Obj);
-  arrs   : ilist (B:=arrD) tys;
+  arrD := arrD' def_obj objs;
+  tys  : list (Obj * Obj);
+  arrs : ilist (B:=arrD) tys;
 }.
 #[export] Existing Instance has_objects.
 
 Inductive Term : Set :=
-  | Ident : Term
-  | Morph (a : nat) : Term
-  | Comp (f g : Term) : Term.
-
-Derive NoConfusion NoConfusionHom Subterm EqDec for Term.
+  | Ident
+  | Morph (a : nat)
+  | Comp (f g : Term).
 
 Inductive Expr : Set :=
   | Top
@@ -51,5 +37,3 @@ Inductive Expr : Set :=
   | And   (p q : Expr)
   | Or    (p q : Expr)
   | Impl  (p q : Expr).
-
-Derive NoConfusion NoConfusionHom Subterm for Expr.

--- a/Solver/Expr.v
+++ b/Solver/Expr.v
@@ -6,31 +6,19 @@ Set Equations With UIP.
 Require Import Category.Lib.
 Require Import Category.Lib.IList.
 Require Import Category.Theory.Category.
-Require Import Category.Structure.Cartesian.
 
 Generalizable All Variables.
 Set Transparent Obligations.
 
-Inductive Obj : Set :=
-  | Ob : nat → Obj
-  | Pair : Obj → Obj → Obj.
+Definition Obj := nat.
 
-Derive NoConfusion NoConfusionHom Subterm EqDec for Obj.
+Definition objD' {C: Category} (d : C) (objs : list C) (n : Obj) :=
+  nth n objs d.
 
-Fixpoint objD' {C: Category} `{@Cartesian C}
-  (d : C) (objs : list C) (x : Obj) :=
-  match x with
-  | Ob n => nth n objs d
-  | Pair x y => objD' d objs x × objD' d objs y
-  end.
-
-Definition arrD' {C: Category} `{@Cartesian C}
-  (d : C) (objs : list C) '(dom, cod) :=
+Definition arrD' {C: Category} (d : C) (objs : list C) '(dom, cod) :=
   objD' d objs dom ~> objD' d objs cod.
 
-Class Objects := {
-  cat     : Category;
-  cart    : @Cartesian cat;
+Class Objects (cat : Category) := {
   (* Note that we one extra object here (doubling the last), just for the
      convenience of always knowing by the type that there must be one more
      than [num_objs] available. This saves us from having to maintain
@@ -39,10 +27,9 @@ Class Objects := {
   objs    : list cat;
   objD   := objD' def_obj objs;
 }.
-#[export] Existing Instance cart.
 
-Class Arrows := {
-  has_objects : Objects;
+Class Arrows (cat : Category) := {
+  has_objects : Objects cat;
 
   arrD  := arrD' def_obj objs;
   tys    : list (Obj * Obj);
@@ -53,12 +40,7 @@ Class Arrows := {
 Inductive Term : Set :=
   | Ident : Term
   | Morph (a : nat) : Term
-  | Comp (f g : Term) : Term
-
-  (* Cartesian structure *)
-  | Fork (f g : Term) : Term
-  | Exl : Term
-  | Exr : Term.
+  | Comp (f g : Term) : Term.
 
 Derive NoConfusion NoConfusionHom Subterm EqDec for Term.
 

--- a/Solver/Normal.v
+++ b/Solver/Normal.v
@@ -531,7 +531,9 @@ Proof.
   reify_and_change.
   clear.                        (* no effect *)
 *)
-  structure.
+(*
+  structure.                    (* only works on Coq 8.16 *)
+*)
   reflexivity.
   (* Show Ltac Profile. *)
 Qed.

--- a/Solver/Normal.v
+++ b/Solver/Normal.v
@@ -454,31 +454,25 @@ Qed.
 
 Fixpoint exprSD (e : Expr) : Type :=
   match e with
-  | Top    => True
-  | Bottom => False
+  | Top           => True
+  | Bottom        => False
   | Equiv d c f g => (f : d ~> c) ≈ g
-  | And p q  => exprSD p ∧ exprSD q
-  | Or p q   => exprSD p + exprSD q
-  | Impl p q => exprSD p → exprSD q
+  | And p q       => exprSD p ∧ exprSD q
+  | Or p q        => exprSD p + exprSD q
+  | Impl p q      => exprSD p → exprSD q
   end.
 
-Theorem exprSD_enough (e : Expr) : exprSD e ↔ exprAD e.
+Theorem exprSD_enough {d c f g h} :
+  termD d c f = Some h →
+  exprSD (Equiv d c f g) → exprAD (Equiv d c f g).
 Proof.
-  induction e; split; simpl in *; intuition.
-  - rewrite H0.
-    destruct (termD _ _ _) eqn:?.
-    + reflexivity.
-    + admit.
-  - destruct (termD _ _ (_ (_ f))) eqn:?; [|tauto].
-    destruct (termD _ _ (_ (_ g))) eqn:?; [|tauto].
-    apply from_morphism_to_morphism in Heqo.
-    apply from_morphism_to_morphism in Heqo0.
-    rewrite X in Heqo; clear X.
-    rewrite <- Heqo in Heqo0.
-    simpl in *.
-    destruct (termD _ _ _) eqn:?; [|tauto].
-    destruct (termD _ _ (_ (_ g))) eqn:?; [|tauto].
-    now rewrite Heqo, Heqo0, X.
+  simpl; intros.
+  rewrite H1.
+  apply from_morphism_to_morphism_r in H0.
+  rewrite H1 in H0.
+  destruct (termD _ _ _) eqn:?.
+  + reflexivity.
+  + tauto.
 Qed.
 
 End Normal.
@@ -511,6 +505,13 @@ Proof.
   repeat match goal with | [ H : _ ≈ _ |- _ ] => revert H end.
   (* Set Ltac Profiling. *)
   normalize.
+  intros.
+  clear.
+  reify_and_change.
+  clear.                        (* no effect *)
+  simple apply exprAD_sound'.
+  simple eapply exprSD_enough; [now vm_compute|].
+  clear.                        (* context is empty! *)
+  reflexivity.
   (* Show Ltac Profile. *)
-  intros; cat.
 Qed.

--- a/Solver/Normal.v
+++ b/Solver/Normal.v
@@ -296,6 +296,21 @@ Proof.
     now rewrite x1, IHt1, IHt2.
 Qed.
 
+Theorem from_to_morphism {d c} {t : Term} {f} :
+  termD d c t ≈ Some f
+    ↔ termD d c (from_morphism (to_morphism t)) ≈ Some f.
+Proof.
+  split; intros.
+  - simpl in X.
+    destruct (termD d c _) eqn:?; [|tauto].
+    apply from_morphism_to_morphism_r in Heqo.
+    now rewrite Heqo, X.
+  - simpl in X.
+    destruct (termD d c _) eqn:?; [|tauto].
+    apply from_morphism_to_morphism in Heqo.
+    now rewrite Heqo, X.
+Qed.
+
 Section Norm.
 
 Variable k : Composition → Morphism.
@@ -487,6 +502,13 @@ Ltac normalize :=
   simple apply exprAD_sound';
   vm_compute.
 
+Ltac structure :=
+  reify_and_change;
+  simple apply exprAD_sound';
+  simple eapply exprSD_enough;
+    [now vm_compute|];
+  clear.
+
 Example ex_normalize
   (C : Category) (x y z w : C)
   (f : z ~> w) (g : y ~> z) (h : x ~> y) (i : x ~> z) :
@@ -502,16 +524,14 @@ Example ex_normalize
   f ∘ (id ∘ g ∘ h) ≈ (f ∘ g) ∘ h.
 Proof.
   intros.
-  repeat match goal with | [ H : _ ≈ _ |- _ ] => revert H end.
   (* Set Ltac Profiling. *)
   normalize.
-  intros.
   clear.
+(*
   reify_and_change.
   clear.                        (* no effect *)
-  simple apply exprAD_sound'.
-  simple eapply exprSD_enough; [now vm_compute|].
-  clear.                        (* context is empty! *)
+*)
+  structure.
   reflexivity.
   (* Show Ltac Profile. *)
 Qed.

--- a/Solver/Reify.v
+++ b/Solver/Reify.v
@@ -614,5 +614,5 @@ Proof.
   intros.
   reify_and_change.
   vm_compute.
-  cat.
+  cat; try apply comp_assoc.
 Qed.

--- a/Solver/Reify.v
+++ b/Solver/Reify.v
@@ -6,8 +6,6 @@ Require Import Category.Theory.Category.
 Require Import Category.Solver.Expr.
 Require Import Category.Solver.Denote.
 
-Set Transparent Obligations.
-
 Import ListNotations.
 
 Open Scope nat_scope.
@@ -578,8 +576,6 @@ Proof.
   find_vars.
   reflexivity.
 Qed.
-
-Definition vec_size {A n} (l : Vector.t A n) : nat := n.
 
 Ltac reify_terms_and_then tacGoal :=
   match goal with


### PR DESCRIPTION
This PR removes the support for cartesian structure from the solver, but exchanges it for the ability to render an expression into pure structure, meaning the context can be wiped clean as structural rewrites are being applied.

At the moment, because cartesian structures aren't recognized, this means that `fork f g` will be represented simply as `Morph 5` (depending on the environment), which is useless for the purpose of rewriting. Somehow the solver will need to recognize and reflect many different kinds of morphisms, but without incurring so many dependencies that it's only usable in specific scenarios.