### PR TITLE
Quiver

### DIFF
--- a/Construction/Free/Quiver.v
+++ b/Construction/Free/Quiver.v
@@ -1,0 +1,566 @@
+Require Import Category.Lib.
+Require Import Category.Lib.TList.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Theory.Adjunction.
+Require Import Category.Theory.Universal.Arrow.
+Require Import Category.Instance.StrictCat.
+Require Import Category.Construction.Groupoid.
+Require Import Category.Construction.Opposite.
+Require Import Category.Construction.Product.
+Require Import Category.Instance.Sets.
+
+Generalizable All Variables.
+
+Section Quiver.
+  Class Quiver@{o h p} := {
+      nodes : Type@{o};
+      uedges := Type@{h} : Type@{h+1};
+      edges : nodes → nodes → uedges;
+      edgeset : ∀ X Y, Setoid@{h p} (edges X Y)
+    }.
+  Coercion nodes : Quiver >-> Sortclass.
+  Context (G : Quiver).
+  Existing Instance edgeset.
+
+  Fixpoint tlist'_quiver_equiv (k i j : G) 
+    (f : @tlist' _ edges k i) (g : @tlist' _ edges k j) ( p : i = j ) : Type :=
+    match f in (tlist' _ i_t) return (tlist' _ j) -> i_t = j -> Type with
+    | tnil => fun g' q => tnil = Logic.transport_r (fun z => @tlist' _ edges k z) q g'
+    | @tcons _ _ _ i0 i1 fhead ftail =>
+        fun g' : tlist' _ j  => 
+          match g' in tlist' _ j return @tlist' _ edges k i1 -> i0 = j -> Type with
+          | tnil => fun _ _ => False
+           | @tcons _ _ _ j0 j1 ghead gtail =>
+               fun ftail' p' =>
+                 { q : i1 = j1 &
+                      (Logic.transport (fun t => edges i0 t) q fhead ≈
+                         Logic.transport_r (fun t => edges t j1) p' ghead) &
+                      tlist'_quiver_equiv k i1 j1 ftail' gtail q }
+          end ftail
+    end g p.
+
+  Inductive tlist'_quiver_inductive (i : G) :
+    forall (j : G), (@tlist' _ edges i j) -> (@tlist' _ edges i j) -> Type :=
+  | tlist_both_empty : tlist'_quiver_inductive i tnil tnil
+  | tlist_both_cons (k : G) :
+    forall (j : G) (ftail gtail : @tlist' _ edges i j) (fhead ghead : edges k j),
+           (tlist'_quiver_inductive j ftail gtail) ->
+           fhead ≈ ghead ->
+           tlist'_quiver_inductive k (tcons _ fhead ftail)
+                                   (tcons _ ghead gtail).
+
+  Proposition fixpoint_implies_inductive (i j : G) (f g : tlist edges i j) :
+    tlist'_quiver_equiv _ _ _ f g eq_refl -> (tlist'_quiver_inductive _ _ f g).
+  Proof.
+    revert g; induction f.
+    - intros g H. simpl in H; unfold Logic.transport_r in H; simpl in H; destruct H.
+      constructor.
+    - intro g; destruct g; [ now apply False_rect |].
+      intro H. simpl in H; destruct H as [q t t0].
+      destruct q.
+      constructor.
+      + apply IHf. assumption.
+      + unfold Logic.transport_r in t. simpl in t. exact t.
+  Defined.
+
+  Proposition inductive_implies_fixpoint (i j : G) (f g : tlist edges i j) :
+    (tlist'_quiver_inductive _ _ f g) -> tlist'_quiver_equiv _ _ _ f g eq_refl.
+  Proof.
+    intro H.
+    induction H; [ now simpl | simpl ].
+    exists eq_refl; assumption.
+  Defined.
+  
+  Lemma tlist'_equiv_lengths (i j k : G) (f : tlist' k i) (g : tlist' k j) (p : i = j) :
+    tlist'_quiver_equiv _ _ _ f g p -> tlist_length f = tlist_length g.
+    revert j g p; induction f.
+    - intros j g p H. destruct g; [ reflexivity | ].
+      simpl in H. destruct p. unfold Logic.transport_r in H; simpl in H;
+        now inversion H.
+    - intros j' g p; destruct g; [ now apply False_rect | simpl ].
+      intros [j_eq_j0 X]; apply eq_S; unshelve eapply IHf; [ exact j_eq_j0 | assumption ].
+  Defined.
+  
+  Proposition tlist'_quiver_equiv_reflexive (k i: G) :
+    forall f : tlist edges i k, tlist'_quiver_equiv k i i f f eq_refl.
+  Proof.
+    intro f; induction f; [ now constructor |].
+    unshelve econstructor; easy.
+  Defined.
+
+  Arguments Logic.transport_r /.
+
+  Proposition tlist'_quiver_equiv_transitive (k i1 i2 i3: G) :
+      forall (f : tlist edges i1 k) (g : tlist edges i2 k) (h : tlist edges i3 k)
+             (p : i1 = i2) (q : i2 = i3),
+        tlist'_quiver_equiv k i1 i2 f g p ->
+        tlist'_quiver_equiv k i2 i3 g h q->
+        tlist'_quiver_equiv k i1 i3 f h (eq_trans p q).
+  Proof.
+    intro f; revert i2 i3.
+    induction f as [ | i0 i1 fhead ftail ]; 
+      [ intros i2 i3 g h p q equiv1 equiv2;
+        destruct p, q;
+        simpl in *; destruct equiv1; now simpl in equiv2 |].
+ 
+      (* [ intros; destruct g; [ easy | now apply False_rect ] |]. *)
+    intros i2 i3 g h p q equiv1 equiv2.
+    destruct g as [ | j0 j1 ghead gtail ]; [ now apply False_rect |]. 
+    simpl in equiv1. destruct equiv1 as [j_eq_j0 fhead_eq_ghead].
+    destruct h as [ | k0 k1 hhead htail]; [ now apply False_rect |].
+    simpl; simpl in equiv2; destruct equiv2 as [j1_eq_k1 gtail_eq_htail].
+    unshelve esplit; [ exact (eq_trans j_eq_j0 j1_eq_k1) | |].
+    - destruct j1_eq_k1, p, q, j_eq_j0.
+      unfold Logic.transport_r in *.
+      simpl Logic.transport in *. now apply (@Equivalence_Transitive _ _ _ _ ghead).
+    - unshelve eapply IHftail; [ exact gtail | assumption | assumption ].
+  Defined.
+
+  Proposition tlist'_quiver_equiv_symmetric (k i j: G) (p : i = j) : 
+    forall (f : tlist edges i k) (g: tlist edges j k),
+      tlist'_quiver_equiv k i j f g p -> tlist'_quiver_equiv k j i g f (eq_sym p).
+  Proof.
+    intro f; revert j p; induction f as [| i0 i1 fhead ftail];
+      intros j p g; destruct g as [|j0 j1 ghead gtail].
+    - unfold tlist'_quiver_equiv. intro H.
+      rewrite H at 2. unfold Logic.transport_r. simpl.
+      clear H. destruct p. reflexivity.
+    - intro H; simpl in H. apply False_rect. destruct p; simpl in H.
+      inversion H.
+    - now apply False_rect.
+    - simpl. intros [q e t].
+      exists (eq_sym q).
+      + simpl. apply Equivalence_Symmetric. destruct p, q. simpl in *.
+        assumption.
+      + now apply IHftail, t.
+  Defined.
+
+  Definition tlist_quiver_equiv (i k : G) : crelation (tlist edges i k) :=
+    fun f g => tlist'_quiver_equiv _ _ _ f g eq_refl.
+
+#[export]
+  Instance tlist_quiver_equiv_is_equiv (i k : G) : Equivalence (tlist_quiver_equiv i k).
+  Proof.
+    unshelve eapply Build_Equivalence.
+    + intro; apply tlist'_quiver_equiv_reflexive.
+    + intros f g H;
+      unfold tlist_quiver_equiv; change (@eq_refl _ i) with (eq_sym (@eq_refl _ i));
+      apply tlist'_quiver_equiv_symmetric; exact H.
+    + intros f g h equiv1 equiv2. unfold tlist_quiver_equiv.
+      change (@eq_refl _ i) with (eq_trans (@eq_refl _ i) (@eq_refl _ i)).
+      unshelve eapply tlist'_quiver_equiv_transitive; [ exact g | |]; assumption.
+  Defined.
+End Quiver.
+
+Definition Build_Quiver_Standard_Eq ( node_type : Type )
+  ( edge_type : node_type -> node_type -> Type ) : Quiver :=
+  {|
+    nodes := node_type ;
+    edges := edge_type;
+    edgeset := fun _ _ => {| equiv := eq; setoid_equiv := eq_equivalence |}                       
+  |}.
+
+Class QuiverHomomorphism@{o1 h1 p1 o2 h2 p2}
+  (G : Quiver@{o1 h1 p1}) (G' : Quiver@{o2 h2 p2}) := {
+    fnodes : @nodes G -> @nodes G';
+    fedgemap : ∀ x y : @nodes G, edges x y -> edges (fnodes x) (fnodes y);
+    fedgemap_respects : ∀ x y,
+    Proper@{h2 p2} (respectful@{h1 p1 h2 p2 h2 p2}
+                      (@equiv@{h1 p1} _ (edgeset _ _))
+                      (@equiv@{h2 p2} _ (edgeset _ _))) (@fedgemap x y)
+  }.
+
+Coercion fnodes : QuiverHomomorphism >-> Funclass.
+Local Existing Instance edgeset.
+
+Section QuiverCategory.
+Definition QuiverHomomorphismEquivalence
+  (Q : Quiver) (Q' : Quiver) (F G : QuiverHomomorphism Q Q') : Type :=
+  { node_equiv : forall x : Q, (@fnodes _ _ F x) = (@fnodes _ _ G x)
+        & forall (x y : Q) (f : edges x y),
+          let eqx := node_equiv x in
+          let eqy := node_equiv y in
+          let Ff := @fedgemap _ _ F x y f in
+          let Gf := @fedgemap _ _ G x y f in
+          (Logic.transport (fun t => edges (F x) t) eqy Ff ≈
+             Logic.transport_r (fun t => edges t (G y)) eqx Gf) }.
+
+Proposition QuiverHomomorphismEquivalence_Reflexive (Q Q' : Quiver)
+  : Reflexive (QuiverHomomorphismEquivalence Q Q').
+Proof.
+  intro F. unfold QuiverHomomorphismEquivalence.
+  exists (fun _ => eq_refl). reflexivity.
+Qed.
+
+Proposition transport_id (C : Category) (c c' : C) (p : c = c') :
+  Logic.transport (hom c) p (@id C c) = Logic.transport_r (fun z => hom z c') p (@id C c').
+Proof.
+  now destruct p.
+Defined.
+
+Proposition transport_comp (C : Category) (c d e e' : C) (p : e = e')
+  (f : hom c d) (g : hom d e)
+  : Logic.transport (hom c) p (g ∘ f) = (Logic.transport (hom d) p g) ∘ f.
+Proof.
+  now destruct p.
+Defined.
+
+Proposition transport_r_comp (C : Category) (c c' d e : C) (p : c = c')
+  (f : hom c' d) (g : hom d e)
+  : Logic.transport_r (fun z => hom z e) p (g ∘ f) =
+      g ∘ (Logic.transport_r (fun z => hom z d) p f).
+Proof.
+  now destruct p.
+Defined.
+
+Proposition transport_comp_mid (C : Category) (c d d' e : C) (p : d = d')
+  (f : hom c d) (g : hom d' e)
+  : g ∘ (Logic.transport (hom c) p f) =
+      (Logic.transport_r (fun z => hom z e) p g) ∘ f.
+Proof.
+  now destruct p.
+Defined.
+
+Proposition QuiverHomomorphismEquivalence_Transitive (Q Q' : Quiver)
+  : Transitive (QuiverHomomorphismEquivalence Q Q').
+Proof.
+  intros F G H
+    [F_eq_G_on_obj FG_coherent_transport]
+    [G_eq_H_on_obj GH_coherent_transport].
+  unfold QuiverHomomorphismEquivalence in *.
+  exists (fun x => eq_trans (F_eq_G_on_obj x) (G_eq_H_on_obj x)).
+  intros c c' f.
+  unfold Logic.transport_r.
+  rewrite eq_trans_sym_distr.
+  rewrite <- 2! transport_trans.
+  rewrite (FG_coherent_transport c c' f).
+  unfold Logic.transport_r in *.
+  rewrite <- (GH_coherent_transport c c' f).
+  rewrite transport_relation_exchange.
+  reflexivity.
+Qed.
+
+Proposition QuiverHomomorphismEquivalence_Symmetric (Q Q' : Quiver)
+  : Symmetric (QuiverHomomorphismEquivalence Q Q').
+Proof.
+  intros F G [F_eq_G_on_obj FG_coherent_transport].
+  simpl in FG_coherent_transport.
+  exists (fun x => eq_sym (F_eq_G_on_obj x)).
+  simpl.
+  intros c c' f. unfold Logic.transport_r in *.
+  rewrite eq_sym_involutive.
+  specialize FG_coherent_transport with c c' f.
+  apply (proper_transport_dom Q' edges _ (F c) (G c) (G c') (F_eq_G_on_obj c)) in
+    FG_coherent_transport.
+  rewrite transport_trans, eq_trans_sym_inv_l
+    in FG_coherent_transport;
+    simpl in FG_coherent_transport.
+  apply (proper_transport_cod Q' edges _ (G c) (G c') (F c') (eq_sym (F_eq_G_on_obj c'))) in
+    FG_coherent_transport.
+  rewrite transport_relation_exchange, transport_trans,
+    eq_trans_sym_inv_r in FG_coherent_transport;
+    simpl in FG_coherent_transport.
+  symmetry; exact FG_coherent_transport.
+Defined.
+
+Program Definition QuiverId (Q : Quiver) : QuiverHomomorphism Q Q :=
+  {|
+    fnodes := Datatypes.id;
+    fedgemap := fun _ _ => Datatypes.id;
+    fedgemap_respects := _
+  |}.
+
+Arguments fedgemap {G G' QuiverHomomorphism x y}.
+
+Lemma transport_quiver_dom
+  (C D: Type) (ArrC : forall c c' : C, Type) (ArrD : forall d d' : D, Type)
+  (Fobj : C -> D) (Fmap : forall c c' : C, (ArrC c c') -> (ArrD (Fobj c) (Fobj c')))
+  (c c' d: C) (p : c = c') (f : ArrC c d)
+  : Fmap _ _ (Logic.transport (fun z => ArrC z d) p f) =
+      Logic.transport (fun z => ArrD z (Fobj d)) (f_equal (Fobj) p) (Fmap _ _ f).
+Proof.
+  destruct p. reflexivity.
+Defined.
+
+Lemma transport_quiver_cod
+  (C D: Type) (ArrC : forall c c' : C, Type) (ArrD : forall d d' : D, Type)
+  (Fobj : C -> D) (Fmap : forall c c' : C, (ArrC c c') -> (ArrD (Fobj c) (Fobj c')))
+  (c d d': C) (p : d = d') (f : ArrC c d)
+  : Fmap _ _ (Logic.transport (fun z => ArrC c z) p f) =
+      Logic.transport (fun z => ArrD (Fobj c) z) (f_equal (Fobj) p) (Fmap _ _ f).
+Proof.
+  destruct p. reflexivity.
+Defined.
+
+Local Notation "Q ⇨ Q'" := (QuiverHomomorphism Q Q') (at level 40).
+Definition QuiverComp {Q1 Q2 Q3: Quiver} (F : Q1 ⇨ Q2) (G : Q2 ⇨ Q3) : Q1 ⇨ Q3.
+Proof.
+  unshelve refine
+    (Build_QuiverHomomorphism Q1 Q3 (Basics.compose (@fnodes _ _ G) (@fnodes _ _ F)) _ _).
+  unshelve eapply Build_SetoidMorphism.
+  + exact (fun f => (fedgemap (fedgemap f))).
+  + cat_simpl.
+Defined.
+
+#[export] Instance QuiverHomomorphismEquivalence_IsEquivalence (Q Q': Quiver)
+  : @Equivalence (QuiverHomomorphism Q Q') (QuiverHomomorphismEquivalence Q Q') :=
+  {|
+    Equivalence_Reflexive := QuiverHomomorphismEquivalence_Reflexive Q Q';
+    Equivalence_Symmetric := QuiverHomomorphismEquivalence_Symmetric Q Q';
+    Equivalence_Transitive := QuiverHomomorphismEquivalence_Transitive Q Q'
+  |}.
+Local Existing Instance fedgemap_respects.
+#[export] Instance QuiverCategory : Category.
+Proof.
+  unshelve eapply
+    (Build_Category'
+       QuiverHomomorphism
+       QuiverId
+       (fun Q1 Q2 Q3 F G => @QuiverComp Q1 Q2 Q3 G F) ).
+  + exact (fun Q Q' =>
+             {| equiv := QuiverHomomorphismEquivalence Q Q';
+               setoid_equiv := QuiverHomomorphismEquivalence_IsEquivalence Q Q'
+             |}).
+  + intros Q1 Q2 Q3 G1 G2 [G_equiv_on_obj G_arrow_coher]
+      F1 F2 [F_equiv_on_obj F_arrow_coher].
+    exists (fun x => eq_trans (f_equal (@fnodes _ _ G1) (F_equiv_on_obj x))
+                       (G_equiv_on_obj (F2 x))).
+    intros x y f; simpl in *.
+    unfold Logic.transport_r in *.
+    rewrite eq_trans_sym_distr.
+    rewrite <- 2! transport_trans.
+    rewrite <- (G_arrow_coher _ _ (fedgemap f)).
+    rewrite <- transport_relation_exchange.
+    rewrite eq_sym_map_distr.
+    rewrite <- 2! transport_f_equal.
+    apply (proper_transport_cod _ edges _ (G1 (F1 x)) _ _ (G_equiv_on_obj (F2 y))).
+    rewrite transport_f_equal.
+    rewrite <- transport_quiver_cod.
+    rewrite (F_arrow_coher _ _ f).
+    rewrite (transport_f_equal _ _ (fun b => edges b (G1 (F2 y)))).
+    rewrite <- transport_quiver_dom.
+    apply fedgemap_respects.
+    reflexivity.
+  + intros x y f; now exists (fun x =>  eq_refl). 
+  + intros x y f; now exists (fun x =>  eq_refl). 
+  + intros w x y z f g h; now exists (fun x => eq_refl). 
+Defined.
+End QuiverCategory.
+
+Section Underlying.
+  Universes o h p.
+
+  Program Definition QuiverOfCat (C : Category@{o h p}) : Quiver@{o h p} :=
+    {|
+      nodes     := obj;
+      edges     := hom
+    |}.
+  Local Notation "Q ⇨ Q'" := (QuiverHomomorphism Q Q') (at level 40).
+  Program Definition QuiverHomomorphismOfFunctor
+    (C D: Category) (F : @Functor C D) : (QuiverOfCat C) ⇨ (QuiverOfCat D).
+  unshelve eapply Build_QuiverHomomorphism.
+  - exact fobj.
+  - exact (@fmap C D F).
+  - exact fmap_respects.
+  Defined.
+
+  Definition Forgetful : @Functor StrictCat QuiverCategory.
+  Proof.
+    unshelve eapply Build_Functor.
+    + exact QuiverOfCat.
+    + exact QuiverHomomorphismOfFunctor.
+    + intros x y f g f_eq_g. destruct f_eq_g as [fg_eq_on_obj arrow_coherence].
+      exists fg_eq_on_obj. simpl; intros c c' k.
+      apply arrow_coherence.
+    + intro C. exists (fun x => eq_refl). now trivial.
+    + intros x y z f g. exists (fun x => eq_refl). now trivial.
+  Defined.
+
+End Underlying.
+
+Section Free.
+  Universes o h p.
+  Context (G : Quiver@{o h p}).
+
+  Arguments Logic.transport_r /.
+  Program Definition FreeOnQuiver : Category@{o h p} :=
+    {|
+      obj     := @nodes G;
+      hom     := tlist edges;
+      homset  := fun i j => {| equiv := tlist_quiver_equiv _ _ _  ;
+                              setoid_equiv := tlist_quiver_equiv_is_equiv _ _ _ |};
+      id      := fun _ => tnil;
+      compose := fun _ _ _ f g => g +++ f
+|}.
+Next Obligation.
+  revert z x0 y0 X y1 X0.
+  induction x1.
+  - intros z f g f_eq_g ghead H.
+    unfold tlist_quiver_equiv in H.
+    unfold tlist'_quiver_equiv in H. simpl in H. destruct H.
+    destruct (eq_sym (tlist_app_tnil_l f)).
+    destruct (eq_sym (tlist_app_tnil_l g)).
+    assumption.
+  - intros z f g f_eq_g ghead H.
+    destruct (tlist_app_comm_cons b x1 f).
+    unfold tlist_quiver_equiv.
+    destruct ghead as [| i k e ghead]; [ now apply False_rect| ].
+    destruct (tlist_app_comm_cons e ghead g).
+    simpl tlist'_quiver_equiv. unfold tlist_quiver_equiv in H.
+    simpl in H. destruct H as [q tr t]; exists q; [ exact tr |].
+    unfold tlist_quiver_equiv in IHx1. destruct q.
+    apply IHx1; [ exact f_eq_g | exact t ].
+  Defined. 
+  Next Obligation. rewrite tlist_app_tnil_r. apply Equivalence_Reflexive. Qed.
+  Next Obligation. rewrite tlist_app_tnil_l. apply Equivalence_Reflexive. Qed.
+  Next Obligation. rewrite tlist_app_assoc. apply Equivalence_Reflexive.  Qed.
+  Next Obligation. rewrite tlist_app_assoc. apply Equivalence_Reflexive.  Qed.
+  
+  Definition InducedFunctor {C : Category} 
+    (F : QuiverHomomorphism G (QuiverOfCat C)) : @Functor (FreeOnQuiver) C.
+  Proof.
+    unshelve eapply Build_Functor. 
+    { change obj[C] with (@nodes (QuiverOfCat C)). exact fnodes. }
+    { intros c c'; simpl; intro f; unfold tlist in f.
+      induction f as [| c c_mid fhead ftail IHftail] ; [ exact id | ].
+      refine (compose IHftail _).
+      change _ with (@edges (QuiverOfCat C) (fnodes c) (fnodes c_mid)).
+      exact (fedgemap _ _ fhead). }
+    { intros c1 c2; simpl; intro f; induction f as [| c1 c_mid fhead ftail IHf].
+      - intros a H; simpl in H; unfold tlist_quiver_equiv, tlist'_quiver_equiv in H. 
+        simpl in H; destruct H; reflexivity.
+      - intros g H. unfold tlist_quiver_equiv in H.
+        destruct g; [ now apply False_rect |].
+        simpl in H. destruct H as [q t t0]. simpl.
+        set (zm := tlist'_rect G edges c2 _ _ _) in *; clearbody zm.
+        destruct q.
+        refine (@compose_respects C
+                  (@fnodes _ _ F i)
+                  (@fnodes _ _ F c_mid)
+                  (@fnodes _ _ F c2)
+                  (zm c_mid ftail)
+                  (zm c_mid g)
+                  _
+                  ((@fedgemap _ _ F) i c_mid fhead)
+                  ((@fedgemap _ _ F) i c_mid e)
+                  _   ).
+        + apply IHf. assumption.
+        + apply (@fedgemap_respects _ _ F). exact t.
+    }
+    { reflexivity. }
+    { intros c1 c2 c3 f g. simpl.
+      induction g.
+      + simpl. destruct (eq_sym (tlist_app_tnil_l f)).
+        apply Equivalence_Symmetric, id_right.
+      + destruct (tlist_app_comm_cons b g f); simpl.
+        set (zm := tlist'_rect _ _ _ _ _ _) in *.
+        rewrite comp_assoc; set (k := fedgemap _ _ _).
+        change (edges _  _ ) with (@hom _ ((@fnodes _ _ F) i) ((@fnodes _ _ F) j)) in k.
+        refine  (compose_respects _ _ _ k k _); [ apply IHg | reflexivity]. }
+  Defined.
+
+  Definition UnitQuiverCatAdjunction :
+    QuiverHomomorphism G (QuiverOfCat (FreeOnQuiver)).
+  Proof.
+    unshelve eapply Build_QuiverHomomorphism.
+    { exact Datatypes.id. }
+    { exact (fun x y f => tlist_singleton f). }
+    { intros x y p q; unfold tlist_singleton;
+        simpl; unfold tlist_quiver_equiv, tlist'_quiver_equiv;
+        intros ?; exists eq_refl; [assumption | reflexivity]. }
+  Defined.
+  
+  Definition UniversalArrowQuiverCat : @UniversalArrow QuiverCategory StrictCat  G Forgetful.
+    unshelve eapply universal_arrow_from_UMP.
+    - exact FreeOnQuiver.
+    - exact UnitQuiverCatAdjunction.
+    - intros C F; unshelve esplit.
+      + exact (InducedFunctor F).
+      + simpl. exists (fun z => eq_refl). simpl. intros; now rewrite id_left.
+      + intros S [FS_eq_on_obj FS_arrow_coherence]; simpl in FS_arrow_coherence.
+        exists FS_eq_on_obj.
+        intros x y f. induction f.
+        * change (@tnil _ _ y) with (@id FreeOnQuiver y).
+          simpl; rewrite fmap_id. rewrite transport_id; reflexivity.
+        * change (fmap[InducedFunctor F] (b ::: f)) with
+            ((fmap[InducedFunctor F] f) ∘ (@fedgemap _ _ F _ _ b)).
+          assert (RW : @equiv (@hom FreeOnQuiver i y) _ (b ::: f)
+                         (@compose FreeOnQuiver _ _ _ f (tlist_singleton b)))
+                   by 
+                   (unfold tlist_singleton; simpl; now rewrite <- tlist_app_cons);
+          rewrite RW, fmap_comp.
+          rewrite transport_comp.
+          rewrite IHf.
+          rewrite <- transport_comp_mid.
+          rewrite transport_r_comp.
+          apply compose_respects; [ reflexivity |].
+          apply FS_arrow_coherence.
+  Defined.
+End Free.
+
+Definition FreeCatFunctor : @Functor QuiverCategory StrictCat :=
+  (LeftAdjointFunctorFromUniversalArrows Forgetful
+     (fun _ => @UniversalArrowQuiverCat _ )).
+
+Definition FreeForgetfulAdjunction : Adjunction FreeCatFunctor Forgetful :=
+  AdjunctionFromUniversalArrows _ _ .
+
+Section FreeQuiverSyntax.
+Context {G : Quiver}.
+
+Inductive Mor : nodes → nodes → Type :=
+  | Ident {x} : Mor x x
+  | Morph {x y} (f : edges x y) : Mor x y
+  | Comp  {x y z} (f : Mor y z) (g : Mor x y) : Mor x z.
+
+Fixpoint morDA `(t : Mor x y) : tlist edges x y :=
+  match t with
+  | Ident => tnil
+  | Morph f => tcons _ f tnil
+  | Comp f g => morDA g +++ morDA f
+  end.
+
+Program Instance Mor_Setoid {x y} : Setoid (Mor x y) := {
+  equiv f g := morDA f = morDA g
+  }.
+Next Obligation. equivalence; congruence. Qed.
+
+Fixpoint tlistDA `(t : tlist edges x y) : Mor x y :=
+  match t with
+  | tnil => Ident
+  | tcons _ f fs => Comp (tlistDA fs) (Morph f)
+  end.
+
+Lemma morDA_tlistDA `{f : tlist edges x y} :
+  morDA (tlistDA f) = f.
+Proof.
+  induction f; simpl; auto.
+  rewrite <- tlist_app_cons.
+  now rewrite IHf.
+Qed.
+
+(* While this is merely an equivalence. Such is the essence of adjointness
+   between pseudocategories. *)
+Lemma tlistDA_morDA `{f : Mor x y} :
+  tlistDA (morDA f) ≈ f.
+Proof.
+  induction f; simpl; auto.
+  rewrite <- IHf1, <- IHf2.
+  now rewrite morDA_tlistDA.
+Qed.
+
+Program Definition FreeSyntax : Category := {|
+  obj     := nodes ;
+  hom     := Mor;
+  homset  := @Mor_Setoid;
+  id      := fun _ => Ident;
+  compose := fun _ _ _ => Comp
+|}.
+Next Obligation. simpl. congruence. Qed.
+Next Obligation. now apply tlist_app_tnil_r. Qed.
+Next Obligation. now apply tlist_app_assoc. Qed.
+Next Obligation. now symmetry; apply tlist_app_assoc. Qed.
+
+End FreeQuiverSyntax.

--- a/Instance/StrictCat.v
+++ b/Instance/StrictCat.v
@@ -1,0 +1,32 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+
+Generalizable All Variables.
+
+(* StrictCat is the category of categories, with setoid structure given by
+   objectwise equality.
+
+    objects               Categories
+    arrows                Functors
+    arrow equivalence     Pointwise equality of objects
+    identity              Identity Functor
+    composition           Horizontal composition of Functors
+ *)
+
+#[export]
+Instance StrictCat : Category := {
+  obj     := Category;
+  hom     := @Functor;
+  homset  := @Functor_StrictEq_Setoid;
+  id      := @Id;
+  compose := @Compose;
+
+  compose_respects := @Compose_respects_stricteq;
+  id_left          := @fun_strict_equiv_id_left;
+  id_right         := @fun_strict_equiv_id_right;
+  comp_assoc       := @fun_strict_equiv_comp_assoc;
+  comp_assoc_sym   := fun a b c d f g h =>
+    symmetry (@fun_strict_equiv_comp_assoc a b c d f g h)
+}.

--- a/Lib/TList.v
+++ b/Lib/TList.v
@@ -11,15 +11,18 @@ Open Scope lazy_bool_scope.
 
 Set Transparent Obligations.
 
-Inductive tlist {A : Type} (B : A → A → Type) : A → A → Type :=
-  | tnil : ∀ i : A, tlist i i
-  | tcons : ∀ i j k : A, B i j → tlist j k → tlist i k.
+Inductive tlist' {A :Type} {B : A → A → Type} (k : A) : A -> Type :=
+| tnil : tlist' k
+| tcons : ∀ i j : A, B i j -> tlist' j -> tlist' i.
 
-Derive Signature NoConfusion Subterm for tlist.
+Definition tlist {A : Type} (B : A → A → Type) (i j : A) := @tlist' A B j i.
+
+Derive Signature NoConfusion Subterm for tlist'.
 Next Obligation.
   apply Transitive_Closure.wf_clos_trans.
   intros a.
-  destruct a as [[] pr0].
+  destruct a as [? pr0].
+  (* destruct a as [[] pr0]. *)
   simpl in pr0.
   induction pr0.
   - (* tnil *)
@@ -27,15 +30,13 @@ Next Obligation.
     intros y H.
     inversion H; subst; clear H.
   - (* tcons *)
-    constructor.
-    intros [[l m] pr1] H.
-    simpl in *.
-    dependent induction H.
+    constructor. intros [ l m] pr1 . simpl in *.
+    dependent induction pr1.
     assumption.
 Defined.
 
-Arguments tnil {A B i}.
-Arguments tcons {A B i} j {k} x xs.
+Arguments tnil {A B k}.
+Arguments tcons {A B k} i {j} x xs.
 
 Notation "x ::: xs" := (tcons _ x xs) (at level 60, right associativity).
 
@@ -50,6 +51,12 @@ Fixpoint tlist_length {i j} (xs : tlist B i j) : nat :=
   | tcons x _ xs => 1 + tlist_length xs
   end.
 
+Definition tlist_singleton {i j} (x : B i j) : tlist B i j := x ::: tnil.
+
+Equations tlist_rcons {i j k} (xs : tlist B i j) (y : B j k) : tlist B i k :=
+  tlist_rcons tnil y := y ::: (@tnil _ B k);
+  tlist_rcons (@tcons _ _ _ _ _ x xs) y := x ::: tlist_rcons xs y.
+      
 Equations tlist_app {i j k} (xs : tlist B i j) (ys : tlist B j k) :
   tlist B i k :=
   tlist_app tnil ys := ys;
@@ -122,8 +129,8 @@ Equations tlist_eq_dec {i j : A} (x y : tlist B i j) : {x = y} + {x ≠ y} :=
   tlist_eq_dec tnil tnil := left eq_refl;
   tlist_eq_dec tnil _ := in_right;
   tlist_eq_dec _ tnil := in_right;
-  tlist_eq_dec (@tcons _ _ _ m _ x xs) (@tcons _ _ _ o _ y ys)
-    with @eq_dec _ AE m o := {
+  tlist_eq_dec (@tcons _ _ _ _ m x xs) (@tcons _ _ _ _ o y ys)
+  with @eq_dec _ AE m o := {
       | left H with @eq_dec _ (BE _ _) x (rew <- [fun x => B _ x] H in y) := {
           | left _ with tlist_eq_dec xs (rew <- [fun x => tlist B x _] H in ys) := {
              | left _ => left _;
@@ -137,9 +144,7 @@ Next Obligation.
   simpl_eq; intros.
   apply n.
   inv H.
-  apply Eqdep_dec.inj_pair2_eq_dec in H1; [|apply eq_dec].
-  apply Eqdep_dec.inj_pair2_eq_dec in H1; [|apply eq_dec].
-  assumption.
+  apply Eqdep_dec.inj_pair2_eq_dec in H1; [ assumption |apply eq_dec].
 Defined.
 Next Obligation.
   simpl_eq; intros.
@@ -181,7 +186,7 @@ Equations tlist_equiv {i j : A} (x y : tlist B i j) : Type :=
   tlist_equiv tnil tnil := True;
   tlist_equiv tnil _ := False;
   tlist_equiv _ tnil := False;
-  tlist_equiv (@tcons _ _ _ m _ x xs) (@tcons _ _ _ o _ y ys)
+  tlist_equiv (@tcons _ _ _ _ m x xs) (@tcons _ _ _ _ o y ys)
     with eq_dec m o := {
       | left H =>
          equiv x (rew <- [fun x => B _ x] H in y) *
@@ -203,12 +208,12 @@ Next Obligation.
     + apply IHx.
 Qed.
 Next Obligation.
-  repeat intro.
+  intros x y X.
   induction x; simpl.
   - dependent elimination y as [tnil]; auto.
   - dependent elimination y as [tcons _ y ys]; auto.
     rewrite tlist_equiv_equation_4 in *.
-    destruct (eq_dec j _); [|contradiction].
+    destruct (eq_dec j0 _); [|contradiction].
     subst.
     rewrite EqDec.peq_dec_refl.
     destruct X.
@@ -224,7 +229,7 @@ Next Obligation.
     simpl; intros.
     dependent elimination z as [tcons _ z zs]; auto.
     rewrite tlist_equiv_equation_4 in *.
-    destruct (eq_dec j _); [|contradiction].
+    destruct (eq_dec j0 _); [|contradiction].
     destruct (eq_dec _ _); [|contradiction].
     subst.
     rewrite EqDec.peq_dec_refl.
@@ -260,7 +265,7 @@ Next Obligation.
   - contradiction.
   - rewrite <- !tlist_app_comm_cons.
     rewrite tlist_equiv_equation_4 in *.
-    destruct (eq_dec j j0); [|contradiction].
+    destruct (eq_dec j0 j1); [|contradiction].
     subst.
     destruct X.
     split; auto.

--- a/Theory/Adjunction.v
+++ b/Theory/Adjunction.v
@@ -57,6 +57,40 @@ Class Adjunction@{o3 h3 p3 so sh sp} := {
     ⌈fmap[U] f ∘ g⌉ ≈ f ∘ ⌈g⌉
 }.
 
+Definition Build_Adjunction'
+  (adj : forall x y,
+    @Isomorphism Sets
+      {| carrier := @hom C (F x) y; is_setoid := @homset C (F x) y |}
+      {| carrier := @hom D x (U y); is_setoid := @homset D x (U y) |})
+  (to_adj_nat_l : forall x y z (f : F y ~> z) (g : x ~> y),
+      (to (adj _ _)  (f ∘ fmap[F] g) ≈ (to (adj _ _) f) ∘ g))
+  (to_adj_nat_r : forall x y z (f : y ~> z) (g : F x ~> y),
+      (to (adj _ _) (f ∘ g) ≈ fmap[U] f ∘ (to (adj _ _) g)))
+  : Adjunction.
+Proof.
+  unshelve eapply Build_Adjunction.
+  + apply to_adj_nat_l.
+  + apply to_adj_nat_r.
+  + intros x y z f g.
+    set (f' := from (adj y z) f).
+    apply ((snd (@injectivity_is_monic _ _ (adj x z))) _).
+    change (to (adj x z) (from (adj x z) _)) with
+      (((adj x z) ∘ (from (adj x z))) (f ∘ g)).
+    rewrite ((iso_to_from (adj x z)) (f ∘ g)); simpl;
+    rewrite to_adj_nat_l.
+    refine (compose_respects _ _ _ g _ (Equivalence_Reflexive _)).
+    unfold f'; symmetry.
+    exact ((iso_to_from (adj y z)) f).
+  + intros x y z f g.
+    set (g' :=  from (adj x y) g).
+    apply ((snd (@injectivity_is_monic _ _ (adj x z))) _).
+    rewrite (iso_to_from (adj x z) (fmap[U] f ∘ g)); simpl.
+    rewrite to_adj_nat_r.
+    apply (compose_respects (fmap[U] f) _ (Equivalence_Reflexive _)).
+    unfold g'; symmetry;
+      apply (iso_to_from (adj x y) g).
+Defined.
+
 Context `{@Adjunction}.
 
 Notation "⌊ f ⌋" := (to adj f).

--- a/Theory/Functor.v
+++ b/Theory/Functor.v
@@ -1,6 +1,7 @@
 Require Import Category.Lib.
 Require Import Category.Theory.Category.
 Require Import Category.Theory.Isomorphism.
+Require Import Equations.Prop.Logic.
 
 Generalizable All Variables.
 
@@ -317,3 +318,171 @@ Corollary ToAFunctor_FromAFunctor `{H : AFunctor F} :
 Proof. reflexivity. Qed.
 
 End AFunctor.
+
+Section StrictEq.
+ Lemma transport_adjunction (A : Type) (B : A -> Type) (R: forall a :A, crelation (B a)) :
+   forall (a a' : A) (p : a = a') (x : B a) (y : B a'),
+    ((R _ x (transport_r B p y) -> R _ (transport B p x) y)) *
+      (R _ (transport B p x) y -> (R _ x (transport_r B p y))).
+  intros a a' p x y. split.
+  - destruct p. now unfold transport_r.
+  - destruct p. now unfold transport_r.
+Defined.
+
+Lemma transport_relation_exchange (A : Type) (R : crelation A) :
+  forall (a a' b b': A) (p : a = b) (q : a' = b') (t : R a a'),
+    transport (fun z => R b z) q
+      (transport (fun k => R k a') p t) =
+      transport (fun k => R k b') p
+        (transport (fun z => R a z) q t).
+Proof.
+  intros a a' b b' p q t; destruct p, q; reflexivity.
+Defined.
+
+Lemma transport_trans (A : Type) (B : A -> Type) :
+  forall (a0 a1 a2 : A) (x : B a0) (p : a0 = a1) (q : a1 = a2),
+    transport B q (transport B p x) = transport B (eq_trans p q) x.
+Proof.
+  intros a0 a1 a2 x p q; destruct p, q; reflexivity.
+Defined.
+
+Lemma transport_r_trans (A : Type) (B : A -> Type) :
+  forall (a0 a1 a2 : A) (x : B a2) (p : a0 = a1) (q : a1 = a2),
+    transport_r B p (transport_r B q x) = transport_r B (eq_trans p q) x.
+Proof.
+  intros a0 a1 a2 x p q; destruct p, q; reflexivity.
+Defined.
+
+Global Instance proper_transport (A : Type) (B : A -> Type) (S : forall a : A, Setoid (B a)) :
+  forall (a a' : A) (p : a = a'), Proper (equiv ==> equiv) (transport B p).
+Proof.
+  intros a b p. destruct p. now unfold transport.
+Defined.
+
+Global Instance proper_transport_r (A : Type) (B : A -> Type) (S : forall a : A, Setoid (B a)) :
+  forall (a a' : A) (p : a = a'), Proper (equiv ==> equiv) (transport_r B p).
+Proof.
+  intros a b p. destruct p. now (unfold transport_r).
+Defined.
+
+(* Global Instance proper_transport_hom_cod (C : Category) (c d d': C) (p : d = d')  *)
+(*   : Proper (equiv ==> equiv) (transport (fun z => hom c z) p). *)
+(* Proof. *)
+(*   destruct p. now trivial. *)
+(* Defined. *)
+
+(* Global Instance proper_transport_hom_dom (C : Category) (c c' d: C) (p : c = c')  *)
+(*   : Proper (equiv ==> equiv) (transport (fun z => hom z d) p). *)
+(* Proof. *)
+(*   destruct p. now trivial. *)
+(* Defined. *)
+
+#[export] Instance proper_transport_dom (A: Type) (B : A -> A -> Type)
+  (S : forall i j, Setoid (B i j)) (c c' d : A) (p : c = c') :
+  Proper (equiv ==> equiv) (Logic.transport (fun z => B z d) p).
+Proof.
+  destruct p. now trivial.
+Defined.
+
+#[export] Instance proper_transport_cod (A: Type) (B : A -> A -> Type)
+  (S : forall i j, Setoid (B i j)) (c d d' : A) (p : d = d') :
+  Proper (equiv ==> equiv) (Logic.transport (fun z => B c z) p).
+Proof.
+  destruct p. now trivial.
+Defined.
+
+Program Instance Functor_StrictEq_Setoid {C D : Category} : Setoid (C ⟶ D) := {
+    equiv := fun F G =>
+      { eq_on_obj : ∀ x : C, F x = G x
+                  & ∀ (x y : C) (f : x ~> y),
+            transport (fun z => hom (fobj[ F ] x) z) (eq_on_obj y) (fmap[F] f) ≈ 
+                   (transport_r (fun z => hom z (fobj[G] y)) (eq_on_obj x) (fmap[G] f)) }
+}.
+Next Obligation.
+  equivalence.
+  - unfold transport_r. rewrite eq_sym_involutive.
+    fold (transport_r (λ z : obj[D], fobj[y] x1 ~{ D }~> z) (x0 y0)).
+    symmetry. 
+    rename x into F, y into G, x0 into eq_ob, x1 into x, y0 into y. 
+    refine ((snd
+               (transport_adjunction D (hom (fobj[G] x))
+                  (fun d t s => t ≈ s) _ _ _ _ _)) _).
+    rewrite transport_relation_exchange.
+    refine ((fst
+               (transport_adjunction D (fun d' => hom d' (fobj[G] y))
+                  (fun d t s => t ≈ s) _ _ _ _ _)) _).
+    exact (e _ _ _).
+  - exact(eq_trans (x1 x2) (x0 x2)).
+  - rename x into F, y into G, z into H, x1 into F_eq_ob_G,
+      e0 into F_eq_ob_G_resp_mor, x0 into G_eq_ob_H,
+      e into G_eq_ob_H_resp_mor, x2 into domf, y0 into codf.
+    simpl.
+    rewrite <- transport_trans, <- transport_r_trans.
+    rewrite F_eq_ob_G_resp_mor.
+    unfold transport_r at 1 2. rewrite transport_relation_exchange.
+    apply proper_transport_dom.
+    apply G_eq_ob_H_resp_mor.
+Defined.
+
+Lemma transport_f_equal (A B : Type) (C : B -> Type) (f : A -> B)
+  (x y : A) (p : x = y) (t : C (f x))
+  : transport (fun a => C (f a)) p t = transport (fun b => C b) (f_equal f p) t.
+Proof.
+  destruct p. reflexivity.
+Defined.
+
+Lemma transport_functorial_dom (C D: Category) (F : @Functor C D) (c c' d : C)
+  (p : c = c') (f : hom c d)
+  : fmap[F] (transport (fun z => hom z d) p f) =
+      transport (fun z => hom z (fobj[F] d)) (f_equal (fobj[F]) p) (fmap[F] f).
+Proof.
+  destruct p. reflexivity.
+Defined.
+
+Lemma transport_functorial_cod (C D: Category) (F : @Functor C D) (c d d': C)
+  (p : d = d') (f : hom c d)
+  : fmap[F] (transport (fun z => hom c z) p f) =
+      transport (fun z => hom (fobj[F] c) z) (f_equal (fobj[F]) p) (fmap[F] f).
+Proof.
+  destruct p. reflexivity.
+Defined.
+
+#[export]
+ Program Instance Compose_respects_stricteq {C D E : Category} :
+   Proper (equiv ==> equiv ==> equiv) (@Compose C D E).
+ Next Obligation.
+  intros F G [FG_eq_on_obj FG_morphismcoherence] H K [HK_eq_on_obj HK_morphismcoherence].
+  unshelve eapply (_ ; _).
+  - intro c; simpl. 
+      exact(eq_trans (f_equal (fobj[F]) (HK_eq_on_obj c)) (FG_eq_on_obj (fobj[K] c))).
+  - intros c c' f.
+    simpl.
+    rewrite <- transport_trans, <- transport_r_trans.
+    rewrite <- transport_functorial_cod.
+    rewrite HK_morphismcoherence.
+    unfold transport_r at 1 2.
+    rewrite transport_functorial_dom.
+    rewrite transport_relation_exchange.
+    rewrite <- eq_sym_map_distr.
+    apply proper_transport_dom.
+    now trivial.
+ Defined.
+    
+ Lemma fun_strict_equiv_id_right {A B} (F : A ⟶ B) : F ◯ Id ≈ F.
+ Proof. construct; cat. Qed.
+
+ Arguments fun_strict_equiv_id_right {A B} F.
+
+ Lemma fun_strict_equiv_id_left {A B} (F : A ⟶ B) : Id ◯ F ≈ F.
+ Proof. construct; cat. Qed.
+
+ Arguments fun_equiv_id_left {A B} F.
+
+ Lemma fun_strict_equiv_comp_assoc {A B C D} (F : C ⟶ D) (G : B ⟶ C) (H : A ⟶ B)  :
+   F ◯ (G ◯ H) ≈ (F ◯ G) ◯ H.
+ Proof. construct; cat. Qed.
+
+ Arguments fun_equiv_comp_assoc {A B C D} F G H.
+
+End StrictEq.
+

--- a/Theory/Universal/Arrow.v
+++ b/Theory/Universal/Arrow.v
@@ -1,6 +1,7 @@
 Require Import Category.Lib.
 Require Import Category.Theory.Category.
 Require Import Category.Theory.Functor.
+Require Import Category.Theory.Adjunction.
 Require Import Category.Structure.Initial.
 Require Import Category.Construction.Comma.
 Require Import Category.Functor.Diagonal.
@@ -39,5 +40,75 @@ Proof.
     exact (snd (@zero_unique _ arrow_initial ((ttt, d); h)
                              ((ttt, h1); e) ((ttt, v); X))).
 Qed.
+
+Definition universal_arrow_from_UMP (c : C) (F : D ⟶ C) (d : D) (η : c ~> fobj[F] d)
+  (u : ∀ (d' : D) (f : c ~> fobj[F] d'), ∃! g : d ~> d', f ≈ fmap[F] g ∘ η)
+  : UniversalArrow c F.
+Proof.
+  unshelve eapply Build_UniversalArrow. simpl. unshelve esplit.
+  - simpl. unshelve esplit; [ split; [ exact ttt | exact d ] | exact η ].
+  - simpl. intros [ [unit d'] f]; simpl in *.
+    unshelve esplit; [ split ; [ exact ttt | exact (unique_obj (u d' f))] | ].
+    rewrite id_right; simpl. exact (unique_property (u d' f)).
+  - simpl. intros [[unit d']  f]; simpl in *.
+    intros [[unit2 g] g_eq]. simpl in g_eq.
+    intros [[unit3 h] h_eq]. split.
+    + simpl. destruct unit2, unit3; reflexivity.
+    + simpl. rewrite id_right in g_eq, h_eq. simpl in h_eq.
+      rewrite <- (uniqueness (u d' f) _ g_eq).
+      exact (uniqueness (u d' f) _ h_eq).
+Defined.
+
+Context (U : @Functor D C).
+
+Arguments arrow : clear implicits.
+Arguments arrow_obj : clear implicits.
+Definition LeftAdjointFunctorFromUniversalArrows (H : forall c : C, UniversalArrow c U) 
+  : @Functor C D.
+Proof.
+  refine
+    ({|
+        fobj := (fun c => arrow_obj _ _ (H c));
+        fmap := (fun x y f => unique_obj (ump_universal_arrows (H x)
+                                            ((arrow _ _ (H y) ∘ f))))
+                  
+      |}).
+  - abstract(intros x y f g f_eq_g;
+             apply uniqueness;
+             rewrite <- (unique_property
+                  (ump_universal_arrows (H x) (arrow y U (H y) ∘ g)));
+             now rewrite f_eq_g).
+  - abstract(intros ?; apply uniqueness; cat_simpl).
+  - abstract(intros c1 c2 c3 g f; apply uniqueness;
+      rewrite fmap_comp,
+      <- comp_assoc,
+      <- (unique_property (ump_universal_arrows (H c1) _)),
+      2! comp_assoc;
+      exact (compose_respects _ _
+             (unique_property (ump_universal_arrows (H c2) _))
+             f f (Equivalence_Reflexive _))).
+Defined.
+
+Definition AdjunctionFromUniversalArrows (H: forall c : C, UniversalArrow c U) :
+  @Adjunction _ _ (LeftAdjointFunctorFromUniversalArrows H) U.
+Proof.
+  unshelve eapply Build_Adjunction'.
+  + intros c d; unshelve eapply Isomorphism.Build_Isomorphism.
+  - unshelve eapply Sets.Build_SetoidMorphism.
+    * exact (fun g => (fmap[U] g) ∘ (arrow _ _ (H c))).
+    * abstract(intros ? ? g1_eq_g2; rewrite g1_eq_g2; reflexivity).
+  - unshelve eapply Sets.Build_SetoidMorphism.
+    * exact(fun f => unique_obj (ump_universal_arrows (H c) f)).
+    * abstract(intros f1 f2 f1_eq_f2; apply uniqueness; rewrite f1_eq_f2;
+               apply (unique_property (ump_universal_arrows (H c) f2))).
+  - abstract(intro f; symmetry; exact (unique_property (ump_universal_arrows (H c) f))).
+  - abstract(simpl; intro g; apply uniqueness; reflexivity).
+  + abstract(intros c1 c2 d f g;
+             simpl; rewrite fmap_comp, <- 2! comp_assoc;
+             apply (compose_respects (fmap[U] f) _ (Equivalence_Reflexive _) _ _);
+             symmetry;
+             apply (unique_property (ump_universal_arrows (H c1) _))).
+  + abstract(intros ? ? ? ? ?; simpl; rewrite fmap_comp, <- comp_assoc; reflexivity).
+Defined.
 
 End UniversalArrow.

--- a/_CoqProject
+++ b/_CoqProject
@@ -21,6 +21,7 @@ Construction/Product/Comma.v
 Construction/Slice.v
 Construction/Slice/Pullback.v
 Construction/Subcategory.v
+Construction/Free/Quiver.v
 Functor/Applicative.v
 Functor/Bifunctor.v
 Functor/Construction/Product.v
@@ -54,6 +55,7 @@ Instance/Cat.v
 Instance/Cat/Cartesian.v
 Instance/Cat/Cartesian/Closed.v
 Instance/Cat/Cocartesian.v
+Instance/StrictCat.v
 Instance/Comp.v
 Instance/Cones.v
 Instance/Cones/Comma.v


### PR DESCRIPTION
In this PR, we 
- Add a new constructor to Universal/Arrow.v so that one can more easily construct a universal arrow by appeal to its universal property. The definition of a Universal Arrow is in terms of comma categories and so contains the "dummy" category 1 and the functor 1 -> c; we give a constructor which omits reference to 1 and only talks about c.
- Added a new constructor for adjunctions in Universal/Arrow.v, so that one can construct a left adjoint to  F: D ->C by proving that for every c in C, there is a universal arrow c -> F.
- In the file TList.v, we change the definition of a tlist so that one argument which was previously an annotation is now a parameter; this is a small change that should make proofs by induction slightly easier. We define a setoid equality on TLists where two paths are equal if they are the same length, if their nodes are strictly equal at each step in the path, and if their arrows are setoid equivalent at each step in the graph. (The existing setoid equality is only defined under the hypothesis that equality between nodes in the graph is decidable.)
- Added a new constructor to Theory/Adjunctions.v for an adjunction which does not require redundant data for the sake of duality.
- Added a new setoid structure for the type of functors C -> D, "strict equality", where two functors F, G are equal if F(c) = G(c) for all c, and if F(f) \cong G(f) for all f : c -> d. (This has been put in Theory/Functor.v after the other setoid structure.)
- Defined a new category, StrictCat, in Instance/StrictCat.v the category whose objects are categories, and whose morphisms are functors considered up to "strict equality."
- Defined a "quiver" in a new file Constructions/Free/Quiver.v. A quiver is a directed graph with a type of nodes and, for each node, a setoid of edges between them. 
- We define the category of quivers and quiver homomorphisms.
- We define the "free category on a quiver", the category whose objects are the set of nodes of the quiver Q, and whose morphisms are formal paths through the edges of the graph. The identity morphism is the empty list, and composition of morphisms is given by formal path concatenation.
- We define the "underlying quiver" forgetful functor from StrictCat to Quiver, which sends each category to its underlying directed graph, and sends each functor to its underlying quiver homomorphism. Note that we had to use StrictCat rather than Cat in this definition, as the forgetful functor does not respect the equivalence relation of natural isomorphism which is asserted in the definition of Cat.
- For each Q, we construct a universal arrow from Q into the forgetful functor U : StrictCat -> Quiver, whose object part is the free category on Q. We use the aforementioned lemma on universal arrows to construct a left adjoint to U.