### PR TITLE
Adapt to Coq PR #18445, that fixes an issue with multiple signatures of implicit arguments for notations

### DIFF
--- a/Theory/Natural/Transformation.v
+++ b/Theory/Natural/Transformation.v
@@ -46,10 +46,8 @@ Qed.
 End Transform.
 
 Arguments transform {_ _ _ _} _ _.
-Arguments naturality
-  {_ _ _ _ _ _ _ _}, {_ _ _ _} _ {_ _ _}, {_ _ _ _} _ _ _ _.
-Arguments naturality_sym
-  {_ _ _ _ _ _ _ _}, {_ _ _ _} _ {_ _ _}, {_ _ _ _} _ _ _ _.
+Arguments naturality {_ _ _ _} _ _ _ _.
+Arguments naturality_sym {_ _ _ _} _ _ _ _.
 
 Declare Scope transform_scope.
 Declare Scope transform_type_scope.
@@ -214,8 +212,8 @@ Program Definition whisker_right {C D : Category} {F G : C ⟶ D} `(N : F ⟹ G)
         {E : Category} (X : E ⟶ C) : F ◯ X ⟹ G ◯ X := {|
   transform := λ x, N (X x);
 
-  naturality     := λ _ _ _, naturality;
-  naturality_sym := λ _ _ _, naturality_sym
+  naturality     := λ _ _ _, naturality _ _ _ _;
+  naturality_sym := λ _ _ _, naturality_sym _ _ _ _
 |}.
 
 Notation "N ⊲ F" := (whisker_right N F) (at level 10).


### PR DESCRIPTION
PR coq/coq#18445 implements the (originally intended) behaviour for selecting maximal implicit arguments of a notation for an applied constant in the presence of multiple signatures of implicit arguments. Such notation now behaves like ordinary constants or abbreviations for non applied constants, that is, they complete the application with as much implicit arguments as possible.

This impacts the notation `"naturality[ x ] := (@naturality _ _ _ _ x)"` which comes with 3 different signatures of implicit arguments. It is now resolved by default with 3 trailing implicit arguments, making tactics such as a `srewrite (naturality[unit])` later failing with unresolved arguments (e.g. in `Adjunction/Hom.v`).

It happens that the `naturality` constant is mostly used in practice with only one signature of implicit arguments. So, the proposed adaptation is to restrict `naturality` to only this signature.

This is of course not the only way to adapt to coq/coq#18445. Another approach would be e.g. to use `e`-tactics so that `srewrite` accepts to leave unresolved the added implicit arguments.

In any cases, the PR is backwards-compatible and can be merged as soon as now.