### PR TITLE
Adapt to https://github.com/coq/coq/pull/19530

### DIFF
--- a/Instance/Lambda/Ltac.v
+++ b/Instance/Lambda/Ltac.v
@@ -1,5 +1,5 @@
-Require Import Coq.Unicode.Utf8.
-Require Import Coq.Program.Program.
+From Coq Require Import Utf8.
+From Coq Require Import Program.
 
 Local Set Warnings "-deprecated-notation".
 

--- a/Lib/Foundation.v
+++ b/Lib/Foundation.v
@@ -1,5 +1,5 @@
-Require Export Coq.Program.Program.
-Require Export Coq.Classes.CMorphisms.
+From Coq Require Export Program.
+From Coq Require Export CMorphisms.
 
 Generalizable All Variables.
 Set Primitive Projections.

--- a/Lib/MapDecide.v
+++ b/Lib/MapDecide.v
@@ -1,6 +1,6 @@
-Require Import Coq.NArith.NArith.
-Require Import Coq.FSets.FMaps.
-Require Import Coq.micromega.Lia.
+From Coq Require Import NArith.
+From Coq Require Import FMaps.
+From Coq Require Import Lia.
 
 (* Override ++> notation with the crelation-based version. *)
 #[local] Set Warnings "-notation-overridden".

--- a/Theory/Coq/List.v
+++ b/Theory/Coq/List.v
@@ -399,9 +399,7 @@ Instance List_Applicative : Applicative list := {
   ap   := @list_ap
 }.
 
-Require Import
-  Coq.Relations.Relations
-  Coq.Reals.ROrderedType.
+From Coq Require Import Relations ROrderedType.
 
 Require Export Coq.Lists.List.
 

--- a/Theory/Coq/Map.v
+++ b/Theory/Coq/Map.v
@@ -1,5 +1,5 @@
-Require Import Coq.Lists.List.
-Require Import Coq.micromega.Lia.
+From Coq Require Import List.
+From Coq Require Import Lia.
 
 From Equations Require Import Equations.
 Set Equations With UIP.

--- a/Theory/Metacategory.v
+++ b/Theory/Metacategory.v
@@ -1,7 +1,7 @@
-Require Import Coq.Structures.DecidableTypeEx.
-Require Import Coq.FSets.FMapFacts.
+From Coq Require Import DecidableTypeEx.
+From Coq Require Import FMapFacts.
 Require Import Category.Lib.FMapExt.
-Require Import Coq.Arith.PeanoNat.
+From Coq Require Import PeanoNat.
 
 (* Override ++> notation with the crelation-based version. *)
 #[local] Set Warnings "-notation-overridden".

--- a/Theory/Metacategory/ArrowsOnly.v
+++ b/Theory/Metacategory/ArrowsOnly.v
@@ -1,5 +1,5 @@
-Require Import Coq.NArith.NArith.
-Require Import Coq.micromega.Lia.
+From Coq Require Import NArith.
+From Coq Require Import Lia.
 
 Require Import Category.Lib.
 Require Import Category.Lib.MapDecide.


### PR DESCRIPTION
Adapt to https://github.com/coq/coq/pull/19530
This is an adaptation in anticipation of the day the temporary backward compatibility introduced in the upstream PR will be removed (probably a few years in the future).
Merging this is not required for the upstream PR, you can do whatever you want with it.
