### PR TITLE
updates

### DIFF
--- a/Adjunction/Hom.v
+++ b/Adjunction/Hom.v
@@ -279,4 +279,4 @@ Qed.
 
 End AdjunctionHom.
 
-Arguments Adjunction_Hom {C D} F%functor U%functor.
+Arguments Adjunction_Hom {C D} F%_functor U%_functor.

--- a/Adjunction/Natural/Transformation.v
+++ b/Adjunction/Natural/Transformation.v
@@ -24,7 +24,7 @@ Class Adjunction_Transform := {
 
 End AdjunctionTransform.
 
-Arguments Adjunction_Transform {C D} F%functor U%functor.
+Arguments Adjunction_Transform {C D} F%_functor U%_functor.
 
 Declare Scope adjunction_scope.
 Declare Scope adjunction_type_scope.

--- a/Functor/Strong.v
+++ b/Functor/Strong.v
@@ -12,7 +12,7 @@ Require Import Category.Functor.Construction.Product.
 Generalizable All Variables.
 
 Class StrongFunctor `{@Monoidal C} (F : C ⟶ C) := {
-  strength {x y} : x ⨂ F y ~> F (x ⨂ y);
+  strength {x y} : (x ⨂ F y)%object ~> F (x ⨂ y)%object;
   strength_natural : natural (@strength);
 
   strength_id_left {x} :
@@ -22,14 +22,14 @@ Class StrongFunctor `{@Monoidal C} (F : C ⟶ C) := {
 
   strength_assoc {x y z} :
     fmap[F] (to (@tensor_assoc _ _ x y z)) ∘ strength
-      << (x ⨂ y) ⨂ F z ~~> F (x ⨂ y ⨂ z) >>
+      << (x ⨂ y) ⨂ F z ~~> F (x ⨂ y ⨂ z)%object >>
     strength ∘ bimap id strength ∘ to (@tensor_assoc _ _ x y (F z))
 }.
 
 Class RightStrongFunctor `{@Monoidal C} (F : C ⟶ C) := {
   rstrength_nat : (⨂) ◯ F ∏⟶ Id ⟹ F ◯ (⨂);
 
-  rstrength {x y} : F x ⨂ y ~> F (x ⨂ y) := transform[rstrength_nat] (x, y);
+  rstrength {x y} : F x ⨂ y ~> F (x ⨂ y)%object := transform[rstrength_nat] (x, y);
 
   rrstrength_id_right {x} :
     fmap[F] (to unit_right) ∘ rstrength ≈ to (@unit_right _ _ (F x));

--- a/Functor/Structure/Monoidal.v
+++ b/Functor/Structure/Monoidal.v
@@ -22,7 +22,7 @@ Context {F : C ⟶ D}.
 Lemma ap_iso_to_from
       (ap_functor_iso : (⨂) ◯ F ∏⟶ F ≅[[C ∏ C, D]] F ◯ (⨂)) {x y} :
   transform (to ap_functor_iso) (x, y)
-    ∘ transform (from ap_functor_iso) (x, y) ≈ id[F (x ⨂ y)].
+    ∘ transform (from ap_functor_iso) (x, y) ≈ id[F (x ⨂ y)%object].
 Proof.
   spose (iso_to_from ap_functor_iso (x, y)) as X.
   rewrite !fmap_id in X.
@@ -74,12 +74,12 @@ Class LaxMonoidalFunctor := {
 
   ap_functor_nat : ((⨂) ◯ F ∏⟶ F) ~{[C ∏ C, D]}~> (F ◯ (⨂));
 
-  lax_ap {x y} : F x ⨂ F y ~> F (x ⨂ y) := transform[ap_functor_nat] (x, y);
+  lax_ap {x y} : F x ⨂ F y ~> F (x ⨂ y)%object := transform[ap_functor_nat] (x, y);
 
   pure_left {x}  : I ⨂ F x ≅ F (I ⨂ x);
   pure_right {x} : F x ⨂ I ≅ F (x ⨂ I);
 
-  ap_assoc {x y z} : (F x ⨂ F y) ⨂ F z ≅ F (x ⨂ (y ⨂ z));
+  ap_assoc {x y z} : ((F x ⨂ F y) ⨂ F z) ≅ F (x ⨂ (y ⨂ z));
 
   lax_monoidal_unit_left {x} :
     to unit_left

--- a/Structure/End.v
+++ b/Structure/End.v
@@ -14,8 +14,8 @@ Class End `(F : C^op ∏ C ⟶ D) := {
     wedge_map[end_wedge] ∘ u ≈ @wedge_map _ _ _ W x
 }.
 
-Arguments End {_%category _%category} F%functor.
-Arguments end_wedge {_%category _%category} F%functor {_}.
+Arguments End {_%_category _%_category} F%_functor.
+Arguments end_wedge {_%_category _%_category} F%_functor {_}.
 
 Coercion wedge_obj `(F : C^op ∏ C ⟶ D) (E : End F) := @end_wedge _ _ _ E.
 

--- a/Structure/Pullback/Limit.v
+++ b/Structure/Pullback/Limit.v
@@ -12,10 +12,10 @@ Require Import Category.Instance.Roof.
 Generalizable All Variables.
 
 Definition Pullback_Limit {C : Category} (F : Cospan C) := Limit F.
-Arguments Pullback_Limit {_%category} F%functor /.
+Arguments Pullback_Limit {_%_category} F%_functor /.
 
 Definition Pushout_Limit {C : Category} (F : Span C) := Colimit F.
-Arguments Pushout_Limit {_%category} F%functor /.
+Arguments Pushout_Limit {_%_category} F%_functor /.
 
 Program Definition Pullback_to_Universal {C : Category}
         (F : Cospan C) (P : Pullback_Limit F) :

--- a/Theory/Adjunction.v
+++ b/Theory/Adjunction.v
@@ -248,7 +248,7 @@ Proof. intros; now rewrites. Qed.
 
 End Adjunction.
 
-Arguments Adjunction {C D} F%functor U%functor.
+Arguments Adjunction {C D} F%_functor U%_functor.
 
 Declare Scope adjunction_scope.
 Declare Scope adjunction_type_scope.

--- a/Theory/Category.v
+++ b/Theory/Category.v
@@ -67,46 +67,46 @@ Delimit Scope object_scope with object.
 Delimit Scope homset_scope with homset.
 Delimit Scope morphism_scope with morphism.
 
-Arguments dom {_%category _%object _%object} _%morphism.
-Arguments cod {_%category _%object _%object} _%morphism.
+Arguments dom {_%_category _%_object _%_object} _%_morphism.
+Arguments cod {_%_category _%_object _%_object} _%_morphism.
 
-Notation "obj[ C ]" := (@obj C%category)
+Notation "obj[ C ]" := (@obj C%_category)
   (at level 0, format "obj[ C ]") : type_scope.
-Notation "hom[ C ]" := (@hom C%category)
+Notation "hom[ C ]" := (@hom C%_category)
   (at level 0, format "hom[ C ]") : type_scope.
 
-Notation "x ~> y" := (@hom _%category x%object y%object)
+Notation "x ~> y" := (@hom _%_ category x%_object y%_object)
   (at level 90, right associativity) : homset_scope.
-Notation "x ~{ C }~> y" := (@hom C%category x%object y%object)
+Notation "x ~{ C }~> y" := (@hom C%_category x%_object y%_object)
   (at level 90) : homset_scope.
 
-Notation "x <~ y" := (@hom _%category y%object x%object)
+Notation "x <~ y" := (@hom _%_category y%_object x%_object)
   (at level 90, right associativity, only parsing) : homset_scope.
-Notation "x <~{ C }~ y" := (@hom C%category y%object x%object)
+Notation "x <~{ C }~ y" := (@hom C%_category y%_object x%_object)
   (at level 90, only parsing) : homset_scope.
 
-Notation "id[ x ]" := (@id _%category x%object)
+Notation "id[ x ]" := (@id _%_category x%_object)
   (at level 9, format "id[ x ]") : morphism_scope.
 
-Notation "id{ C }" := (@id C%category _%object)
+Notation "id{ C }" := (@id C%_category _%_object)
   (at level 9, format "id{ C }") : morphism_scope.
 
 Notation "f ∘ g" :=
-  (@compose _%category _%object _%object _%object f%morphism g%morphism)
+  (@compose _%_category _%_object _%_object _%_object f%_morphism g%_morphism)
   : morphism_scope.
 Notation "f ∘[ C ] g" :=
-  (@compose C%category _%object _%object _%object f%morphism g%morphism)
+  (@compose C%_category _%_object _%_object _%_object f%_morphism g%_morphism)
   (at level 40, only parsing) : morphism_scope.
 
 Notation "f ≈[ C ] g" :=
-  (@equiv _ (@homset C%category _%object _%object) f%morphism g%morphism)
+  (@equiv _ (@homset C%_category _%_object _%_object) f%_morphism g%_morphism)
   (at level 79, only parsing) : category_theory_scope.
 Notation "f ≈[ C ] g" :=
-  (@equiv _ (@homset C%category _%object _%object) f%morphism g%morphism)
+  (@equiv _ (@homset C%_category _%_object _%_object) f%_morphism g%_morphism)
   (at level 79, only parsing) : category_theory_scope.
 
 Notation "f << A ~~> B >> g" :=
-  (@equiv (A%object ~> B%object)%homset _ f%morphism g%morphism)
+  (@equiv (A%_object ~> B%_object)%homset _ f%_morphism g%_morphism)
   (at level 99, A at next level, B at next level, only parsing) : category_theory_scope.
 
 Coercion obj : Category >-> Sortclass.
@@ -178,12 +178,12 @@ Proof. split; auto. Qed.
 
 End Category.
 
-Arguments dom {_%category _%object _%object} _%morphism.
-Arguments cod {_%category _%object _%object} _%morphism.
-Arguments id_left {_%category _%object _%object} _%morphism.
-Arguments id_right {_%category _%object _%object} _%morphism.
-Arguments comp_assoc {_%category _%object _%object _%object _%object}
-  _%morphism _%morphism _%morphism.
+Arguments dom {_%_category _%_object _%_object} _%_morphism.
+Arguments cod {_%_category _%_object _%_object} _%_morphism.
+Arguments id_left {_%_category _%_object _%_object} _%_morphism.
+Arguments id_right {_%_category _%_object _%_object} _%_morphism.
+Arguments comp_assoc {_%_category _%_object _%_object _%_object _%_object}
+  _%_morphism _%_morphism _%_morphism.
 
 #[export]
 Program Instance hom_preorder {C : Category} : PreOrder (@hom C) := {

--- a/Theory/Isomorphism.v
+++ b/Theory/Isomorphism.v
@@ -144,8 +144,8 @@ Notation "x ≅ y" := (@Isomorphism _%category x%object y%object)
 Notation "x ≅[ C ] y" := (@Isomorphism C%category x%object y%object)
   (at level 91, only parsing) : isomorphism_scope.
 
-Arguments to {_%category x%object y%object} _%morphism.
-Arguments from {_%category x%object y%object} _%morphism.
+Arguments to {_%_category x%_object y%_object} _%_morphism.
+Arguments from {_%_category x%_object y%_object} _%_morphism.
 Arguments iso_to_from {_ _ _} _.
 Arguments iso_from_to {_ _ _} _.
 

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,15 +1,4 @@
--R _build/default Category
--Q Adjunction Category.Adjunction
--Q Construction Category.Construction
--Q Functor Category.Functor
--Q Instance Category.Instance
--Q Lib Category.Lib
--Q Monad Category.Monad
--Q Natural Category.Natural
--Q Structure Category.Structure
--Q Theory Category.Theory
--Q Tools Category.Tools
-
+-R . Category
 Adjunction/Diagonal/Product.v
 Adjunction/Hom.v
 Adjunction/Natural/Transformation.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,4 +1,15 @@
--R . Category
+-R _build/default Category
+-Q Adjunction Category.Adjunction
+-Q Construction Category.Construction
+-Q Functor Category.Functor
+-Q Instance Category.Instance
+-Q Lib Category.Lib
+-Q Monad Category.Monad
+-Q Natural Category.Natural
+-Q Structure Category.Structure
+-Q Theory Category.Theory
+-Q Tools Category.Tools
+
 Adjunction/Diagonal/Product.v
 Adjunction/Hom.v
 Adjunction/Natural/Transformation.v

--- a/coq-category-theory.opam
+++ b/coq-category-theory.opam
@@ -15,7 +15,7 @@ practical work.
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.14" & < "8.20~") | (= "dev")}
+  "coq" { >= "8.14" | (= "dev")}
   "coq-equations" {(>= "1.2" & < "1.4~") | (= "dev")}
 ]
 

--- a/dune
+++ b/dune
@@ -1,0 +1,8 @@
+(include_subdirs qualified)
+
+(coq.theory
+ (name Category)
+ (package coq-category-theory)
+ (synopsis "An axiom-free formalization of category theory in Coq for personal study and practical work")
+ (theories Equations)
+ )

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.14)
+(using coq 0.8)


### PR DESCRIPTION
On my machine, the library compiles as is on Rocq 9.0, without the need for changes.

However, there are deprecation warnings with how the notation system works; this PR addresses these issues.