### PR TITLE
dune

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,4 +1,16 @@
--R . Category
+-R _build/default Category
+-Q Adjunction Category.Adjunction
+-Q Construction Category.Construction
+-Q Functor Category.Functor
+-Q Instance Category.Instance
+-Q Lib Category.Lib
+-Q Monad Category.Monad
+-Q Natural Category.Natural
+-Q Solver Category.Solver
+-Q Structure Category.Structure
+-Q Theory Category.Theory
+-Q Tools Category.Tools
+
 Adjunction/Diagonal/Product.v
 Adjunction/Hom.v
 Adjunction/Natural/Transformation.v

--- a/coq-category-theory.opam
+++ b/coq-category-theory.opam
@@ -12,8 +12,7 @@ An axiom-free formalization of category theory in Coq for personal study and
 practical work.
 """
 
-build: [make "-j%{jobs}%"]
-install: [make "install"]
+build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "coq" {(>= "8.14" & < "8.20~") | (= "dev")}
   "coq-equations" {(>= "1.2" & < "1.4~") | (= "dev")}

--- a/dune
+++ b/dune
@@ -1,0 +1,8 @@
+(include_subdirs qualified)
+
+(coq.theory
+ (name Category)
+ (package coq-category-theory)
+ (synopsis "An axiom-free formalization of category theory in Coq for personal study and practical work")
+ (theories Equations)
+ )

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.14)
+(using coq 0.8)


### PR DESCRIPTION
Converts the build system from a makefile to Dune.

For Rocq 9.0, one should edit the dune file to read `(theories Equations Stdlib)` because Rocq 9.0 splits the stdlib into its own separate package.

The changes to `_CoqProject` are not strictly necessary but since a lot of tooling still uses `_CoqProject` to find pointers to the `*.vo` files (ProofGeneral, for example) it helps to rewrite the `_CoqProject` file to point to the correct location of the build artifacts generated by Dune.