### PR TITLE
Guard against the issue #158 bench build-config regression

### DIFF
--- a/.github/workflows/coq-ci.yml
+++ b/.github/workflows/coq-ci.yml
@@ -3,6 +3,16 @@ name: Docker CI
 on: [push, pull_request]
 
 jobs:
+  config-check:
+    # Guard the make/coq_makefile build configuration that the Coq bench
+    # (opam install) relies on; see issue #158. Pure file inspection, so it
+    # runs on the bare runner in seconds without the Coq toolchain.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Bench build-config regression guard (issue #158)
+        run: make bench-config-check
+
   build:
     runs-on: ubuntu-latest
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ minimize-requires:
 	    $(COQ_TOOLS)/minimize-requires.py -i -R . Category {} ::: \
 	    $$(find . -name '*.v')
 
-lint: todo
+lint: todo bench-config-check
 	@echo "Lint checks complete."
 
 format-check:
@@ -67,6 +67,47 @@ admitted-check:
 	fi
 	@echo "Admitted proof count within baseline."
 
+# Guard against reintroducing the build configuration that broke the Coq
+# bench in issue #158 (the dune switch from PR #156). The bench runs
+# `opam install`, which builds via make/coq_makefile -- it never creates
+# dune's _build/default tree -- so the load path must stay `-R . Category`,
+# _CoqProject must carry no _build/-Q directives, and the opam build must
+# invoke make. See https://github.com/jwiegley/category-theory/issues/158.
+bench-config-check:
+	@echo "Checking bench build config (issue #158)..."
+	@first=$$(grep -vE '^[[:space:]]*(#|$$)' _CoqProject | grep -E '^[[:space:]]*-' | head -1); \
+	if [ "$$first" != "-R . Category" ]; then \
+		echo "ERROR: _CoqProject first load-path must be '-R . Category' but is '$$first'"; \
+		echo "  (PR #156 set '-R _build/default Category', breaking the make/coq_makefile bench)"; \
+		exit 1; \
+	fi
+	@if grep -n '_build' _CoqProject; then \
+		echo "ERROR: _CoqProject references '_build' (dune-only path absent under make/coq_makefile)"; \
+		exit 1; \
+	fi
+	@if grep -nE '(^|[[:space:]])-Q([[:space:]]|$$)' _CoqProject; then \
+		echo "ERROR: _CoqProject has -Q directive(s) shadowing '-R . Category' (overriding-logical-loadpath)"; \
+		exit 1; \
+	fi
+	@bi=$$(grep -E '^[[:space:]]*(build|install):' coq-category-theory.opam); \
+	if printf '%s\n' "$$bi" | grep -q 'dune'; then \
+		echo "ERROR: coq-category-theory.opam build/install invokes dune; the bench requires make"; \
+		printf '%s\n' "$$bi"; \
+		exit 1; \
+	fi; \
+	if ! printf '%s\n' "$$bi" | grep -qw make; then \
+		echo "ERROR: coq-category-theory.opam build/install must invoke make"; \
+		printf '%s\n' "$$bi"; \
+		exit 1; \
+	fi
+	@for f in dune dune-project; do \
+		if [ -e "$$f" ]; then \
+			echo "ERROR: $$f present at repo root; this repo builds with make/coq_makefile, not dune"; \
+			exit 1; \
+		fi; \
+	done
+	@echo "Bench config check passed."
+
 timing: Makefile.coq
 	$(MAKE) -f Makefile.coq TIMED=1 2>&1 | tee build-timing.log
 	@echo "Timing saved to build-timing.log"
@@ -78,7 +119,7 @@ timing-report: build-timing.log
 build-strict: Makefile.coq
 	$(MAKE) -f Makefile.coq COQEXTRAFLAGS="-w +default"
 
-check: format-check admitted-check category-theory
+check: format-check admitted-check bench-config-check category-theory
 	@echo "All checks passed."
 
 # Print Print-Assumptions output for the library's key definitions.
@@ -115,4 +156,4 @@ force _CoqProject Makefile: ;
 	@+$(MAKE) -f Makefile.coq $@
 
 .PHONY: all clean force lint format-check format admitted-count admitted-check
-.PHONY: timing timing-report build-strict check print-assumptions
+.PHONY: bench-config-check timing timing-report build-strict check print-assumptions

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,6 +14,9 @@ pre-commit:
           echo "Admitted proof count increased ($total > $baseline)"
           exit 1
         fi
+    bench-config:
+      glob: "{_CoqProject,*.opam,dune,dune-project}"
+      run: make -s bench-config-check
     nix-build:
       glob: "*.{v,nix}"
       run: nix build --no-warn-dirty 2>&1


### PR DESCRIPTION
## Issue

[#158](https://github.com/jwiegley/category-theory/issues/158) — *Fail in Coq bench*. The Coq CI bench builds the package via `opam install`, which runs `make`/`coq_makefile` (deliberately **not** dune, because dune does not emit the per-file timing the bench consumes). It failed with:

```
File "./Theory/Category.v", line 1, characters 15-27:
Error: Cannot find a physical path bound to logical path Category.Lib.
```
plus many `overriding-logical-loadpath` warnings.

## Root cause

PR #156 ("dune") rewrote `_CoqProject`'s first line from `-R . Category` to `-R _build/default Category` (plus a block of `-Q` directives) and switched the opam `build:` field to `dune build`. Under a `make`/`coq_makefile` build there is no `_build/default` directory, so the `Category` logical prefix was bound to a nonexistent path and `Require Import Category.Lib` could not resolve — the exact failure above. The `-Q` lines then collided with `coq_makefile`'s own load-path mapping, producing the remapping warnings.

## Status: already fixed, now guarded

PR #159 ("Revert dune") already reverted #156, so the tree is healthy today: `_CoqProject` is back to `-R . Category`, the opam build uses `make`, and no `dune`/`dune-project` files exist. Per the project's fix workflow, when a bug is already resolved the task is to **add a regression test** demonstrating it stays resolved.

This PR adds a `bench-config-check` make target asserting the five invariants that together distinguish the working make-based configuration from the broken dune one:

1. the first effective `_CoqProject` load path is exactly `-R . Category`;
2. `_CoqProject` contains no `_build` token;
3. `_CoqProject` contains no `-Q` directive shadowing the `-R`;
4. `coq-category-theory.opam`'s `build:`/`install:` invoke `make`, not `dune`;
5. no `dune`/`dune-project` file sits at the repo root.

It is wired into three layers, mirroring the existing `format-check`/`admitted-check` conventions:

- **`make` (`Makefile`)** — `bench-config-check`, added to the `lint` and `check` aggregates.
- **pre-commit (`lefthook.yml`)** — glob-scoped to `{_CoqProject,*.opam,dune,dune-project}` so it only fires when a relevant config file is staged.
- **CI (`coq-ci.yml`)** — a lightweight `config-check` job (bare runner, no Coq toolchain, seconds).

The guard is **portable POSIX sh** (no GNU-only flags; verified under macOS BSD grep and Linux) and deliberately scoped so it never inspects `flake.nix`, whose `dune` usage legitimately builds only the `rocq-equations` dependency.

## Verification

- **Passes** on the current (fixed) tree: `make bench-config-check` → `Bench config check passed.` (exit 0).
- **Fails** on a reconstructed PR #156 config: the first-line guard fires (`-R _build/default Category != -R . Category`, exit 1).
- Each of the five guards was tested in isolation and fires independently for its own reason, and the all-good config passes.

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)