### PR TITLE
Surface 'cartesian category is monoidal' and rename Heunen–Vicary files (#139)

### DIFF
--- a/Functor/Construction/Product/Strong.v
+++ b/Functor/Construction/Product/Strong.v
@@ -6,7 +6,7 @@ Require Import Category.Functor.Bifunctor.
 Require Import Category.Functor.Strong.
 Require Import Category.Functor.Construction.Product.
 Require Import Category.Structure.Monoidal.Product.
-Require Import Category.Structure.Monoidal.Cartesian.
+Require Import Category.Structure.Monoidal.Heunen_Vicary.
 
 Generalizable All Variables.
 

--- a/Functor/Strong/Product.v
+++ b/Functor/Strong/Product.v
@@ -6,9 +6,9 @@ Require Import Category.Functor.Bifunctor.
 Require Import Category.Functor.Product.
 Require Import Category.Functor.Strong.
 Require Import Category.Structure.Monoidal.Proofs.
-Require Import Category.Structure.Monoidal.Cartesian.
+Require Import Category.Structure.Monoidal.Heunen_Vicary.
 Require Import Category.Structure.Monoidal.Semicartesian.Proofs.
-Require Import Category.Structure.Monoidal.Cartesian.Proofs.
+Require Import Category.Structure.Monoidal.Heunen_Vicary.Proofs.
 
 Generalizable All Variables.
 

--- a/Instance/Coq/Par.v
+++ b/Instance/Coq/Par.v
@@ -5,7 +5,7 @@ Require Import Category.Theory.Functor.
 Require Import Category.Structure.Cartesian.
 Require Import Category.Structure.Cocartesian.
 Require Import Category.Structure.Monoidal.Closed.
-Require Import Category.Structure.Monoidal.Cartesian.Cartesian.
+Require Import Category.Structure.Monoidal.Heunen_Vicary.Cartesian.
 Require Import Category.Structure.Initial.
 Require Import Category.Structure.Terminal.
 Require Import Category.Instance.Sets.

--- a/Structure/Group.v
+++ b/Structure/Group.v
@@ -1,6 +1,6 @@
 Require Import Category.Lib.
 Require Import Category.Theory.Category.
-Require Import Category.Structure.Monoidal.Cartesian.
+Require Import Category.Structure.Monoidal.Heunen_Vicary.
 Require Import Category.Structure.Monoid.
 
 Generalizable All Variables.

--- a/Structure/Group/Proofs.v
+++ b/Structure/Group/Proofs.v
@@ -4,7 +4,7 @@ Require Import Category.Theory.Isomorphism.
 Require Import Category.Theory.Naturality.
 Require Import Category.Functor.Bifunctor.
 Require Import Category.Structure.Monoidal.Proofs.
-Require Import Category.Structure.Monoidal.Cartesian.
+Require Import Category.Structure.Monoidal.Heunen_Vicary.
 Require Import Category.Structure.Monoid.
 Require Import Category.Structure.Group.
 

--- a/Structure/Monoidal/Cartesian.v
+++ b/Structure/Monoidal/Cartesian.v
@@ -69,49 +69,4 @@ Class CartesianMonoidal := {
 Coercion cartesian_is_relevance : CartesianMonoidal >-> RelevanceMonoidal.
 Coercion cartesian_is_semicartesian : CartesianMonoidal >-> SemicartesianMonoidal.
 
-Context `{CartesianMonoidal}.
-
-(* The product action on morphisms, built from the projections and fork (the
-   pairing ⟨-,-⟩ = (- ⨂ -) ∘ ∆ supplied by RelevanceMonoidal). With a genuine
-   product available these agree with the usual combinators: [first f] runs f
-   on the left factor and keeps the right, [second f] does the dual, and
-   [split f g] = f ⨂ g acts componentwise (the bifunctorial action). *)
-
-Definition first  {x y z : C} (f : x ~> y) : x ⨂ z ~> y ⨂ z :=
-  fork (f ∘ proj_left) proj_right.
-
-Definition second  {x y z : C} (f : x ~> y) : z ⨂ x ~> z ⨂ y :=
-  fork proj_left (f ∘ proj_right).
-
-Definition split  {x y z w : C} (f : x ~> y) (g : z ~> w) :
-  x ⨂ z ~> y ⨂ w :=
-  fork (f ∘ proj_left) (g ∘ proj_right).
-
-#[export] Program Instance first_respects {a b c : C} :
-  Proper (equiv ==> equiv) (@first a b c).
-Next Obligation.
-  proper.
-  unfold first.
-  rewrites.
-  reflexivity.
-Qed.
-
-#[export] Program Instance second_respects {a b c : C} :
-  Proper (equiv ==> equiv) (@second a b c).
-Next Obligation.
-  proper.
-  unfold second.
-  rewrites.
-  reflexivity.
-Qed.
-
-#[export] Program Instance split_respects {a b c d : C} :
-  Proper (equiv ==> equiv ==> equiv) (@split a b c d).
-Next Obligation.
-  proper.
-  unfold split.
-  rewrites.
-  reflexivity.
-Qed.
-
 End CartesianMonoidal.

--- a/Structure/Monoidal/Cartesian.v
+++ b/Structure/Monoidal/Cartesian.v
@@ -1,0 +1,51 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Structure.Cartesian.
+Require Import Category.Structure.Terminal.
+Require Import Category.Structure.Monoidal.
+Require Export Category.Structure.Monoidal.Internal.Product.
+
+Generalizable All Variables.
+
+(* nLab: https://ncatlab.org/nlab/show/cartesian+monoidal+category
+   Wikipedia: https://en.wikipedia.org/wiki/Cartesian_monoidal_category
+
+   The forward relationship between products and tensors: every cartesian
+   category -- a category with binary products ([Cartesian]) and a terminal
+   object ([Terminal]) -- is monoidal, with the tensor given by the
+   categorical product and the unit by the terminal object,
+
+       x ⨂ y := x × y,        I := 1.
+
+   This is the direction most users want, because it lets every theorem about
+   general monoidal categories specialize to cartesian products for free.
+
+   The construction itself, together with all of its coherence proofs (the
+   associator and unitors built from [prod_assoc]/[prod_one_l]/[prod_one_r],
+   the triangle and pentagon identities, and the symmetric / relevant /
+   semicartesian tower stacked on top), lives in
+   [Category.Structure.Monoidal.Internal.Product] as [CC_Monoidal] and the
+   [CC_*] family.  That file is re-exported here so that the forward direction
+   has a name where readers naturally look for it; [Cartesian_Monoidal] below
+   is the headline result.  A concrete use is [Instance/Coq.v], where
+   [Coq_Monoidal := @CC_Monoidal Coq Coq_Cartesian Coq_Terminal].
+
+   The *reverse* direction -- that a relevant and semicartesian monoidal
+   category is itself cartesian (Fox 1976 / Heunen-Vicary) -- is the
+   [CartesianMonoidal] typeclass in
+   [Category.Structure.Monoidal.Heunen_Vicary]. *)
+
+Section CartesianIsMonoidal.
+
+Context {C : Category}.
+Context `{@Cartesian C}.
+Context `{@Terminal C}.
+
+(* The cartesian monoidal structure: tensor := ×, unit := 1.  This is a plain
+   [Definition] rather than an [Instance] (mirroring [CC_Monoidal]): making it
+   an instance would let typeclass resolution silently pick the product as
+   *the* monoidal structure on every cartesian category, conflicting with
+   hand-rolled monoidal structures elsewhere.  Callers select it explicitly. *)
+Definition Cartesian_Monoidal : @Monoidal C := CC_Monoidal.
+
+End CartesianIsMonoidal.

--- a/Structure/Monoidal/Closed.v
+++ b/Structure/Monoidal/Closed.v
@@ -2,7 +2,7 @@ Require Import Category.Lib.
 Require Import Category.Theory.Category.
 Require Import Category.Theory.Isomorphism.
 Require Import Category.Theory.Functor.
-Require Export Category.Structure.Monoidal.Cartesian.
+Require Export Category.Structure.Monoidal.Heunen_Vicary.
 Require Import Category.Instance.Sets.
 
 Generalizable All Variables.

--- a/Structure/Monoidal/Heunen_Vicary.v
+++ b/Structure/Monoidal/Heunen_Vicary.v
@@ -58,7 +58,7 @@ Class CartesianMonoidal := {
      symmetric monoidal category these are derivable from Mac Lane's coherence
      theorem rather than minimal; they are kept as explicit fields here because
      this library's SymmetricMonoidal does not expose that derivation, and
-     downstream proofs (e.g. Cartesian/Proofs.v, Group/Proofs.v) rewrite with
+     downstream proofs (e.g. Heunen_Vicary/Proofs.v, Group/Proofs.v) rewrite with
      them directly. *)
   unit_left_braid  {x} : unit_left  ∘ @braid _ _ x I ≈ unit_right;
   unit_right_braid {x} : unit_right ∘ @braid _ _ I x ≈ unit_left

--- a/Structure/Monoidal/Heunen_Vicary/Cartesian.v
+++ b/Structure/Monoidal/Heunen_Vicary/Cartesian.v
@@ -11,8 +11,8 @@ Require Import Category.Structure.Monoidal.Symmetric.
 Require Import Category.Structure.Monoidal.Relevance.
 Require Import Category.Structure.Monoidal.Semicartesian.
 Require Import Category.Structure.Monoidal.Semicartesian.Proofs.
-Require Import Category.Structure.Monoidal.Cartesian.
-Require Import Category.Structure.Monoidal.Cartesian.Proofs.
+Require Import Category.Structure.Monoidal.Heunen_Vicary.
+Require Import Category.Structure.Monoidal.Heunen_Vicary.Proofs.
 
 Generalizable All Variables.
 

--- a/Structure/Monoidal/Heunen_Vicary/Proofs.v
+++ b/Structure/Monoidal/Heunen_Vicary/Proofs.v
@@ -5,7 +5,7 @@ Require Import Category.Theory.Isomorphism.
 Require Import Category.Theory.Functor.
 Require Import Category.Functor.Bifunctor.
 Require Import Category.Structure.Monoidal.Proofs.
-Require Import Category.Structure.Monoidal.Cartesian.
+Require Import Category.Structure.Monoidal.Heunen_Vicary.
 
 Generalizable All Variables.
 

--- a/Test/Issue139.v
+++ b/Test/Issue139.v
@@ -1,0 +1,54 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Functor.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Structure.Cartesian.
+Require Import Category.Structure.Terminal.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Monoidal.Cartesian.
+Require Import Category.Instance.Coq.
+
+Generalizable All Variables.
+
+(* Regression test for issue #139 ("CartesianMonoidal cleanup").
+
+   Issue #139 observed that the library appeared to be missing the forward
+   direction "every cartesian category is a monoidal category", and that the
+   file Monoidal/Cartesian.v misleadingly held the *reverse* (Heunen-Vicary)
+   result instead.  The forward direction in fact already existed, as
+   CC_Monoidal in Monoidal/Internal/Product.v; it is now surfaced under the
+   discoverable name Cartesian_Monoidal in Monoidal/Cartesian.v.
+
+   These checks pin that down: the forward direction is available generically
+   under its discoverable name, its tensor is the categorical product and its
+   unit the terminal object, and it agrees definitionally with the monoidal
+   structure that a concrete cartesian category (Coq) actually uses. *)
+
+Section Issue139.
+
+Context {C : Category}.
+Context `{@Cartesian C}.
+Context `{@Terminal C}.
+
+(* Theorem 1, generically: a cartesian category with a terminal object is
+   monoidal.  Before #139 this construction had no discoverable name. *)
+Definition issue_139_cartesian_is_monoidal : @Monoidal C := Cartesian_Monoidal.
+
+(* The tensor of that monoidal structure is exactly the categorical product. *)
+Example issue_139_tensor_is_product (x y : C) :
+  (x ⨂[Cartesian_Monoidal] y)%object = (x × y)%object.
+Proof. reflexivity. Qed.
+
+(* ...and its unit is exactly the terminal object. *)
+Example issue_139_unit_is_terminal :
+  @I C Cartesian_Monoidal = 1%object.
+Proof. reflexivity. Qed.
+
+End Issue139.
+
+(* End-to-end: the surfaced construction is definitionally the monoidal
+   structure that the concrete cartesian category Coq already uses
+   (Instance/Coq.v builds Coq_Monoidal from Coq_Cartesian + Coq_Terminal). *)
+Example issue_139_coq_monoidal :
+  Coq_Monoidal = @Cartesian_Monoidal Coq Coq_Cartesian Coq_Terminal.
+Proof. reflexivity. Qed.

--- a/_CoqProject
+++ b/_CoqProject
@@ -271,5 +271,6 @@ Theory/Universal/Arrow.v
 Structure/Monoidal/Hypergraph/Tactics.v
 Structure/Monoidal/Strict/Tactics.v
 Test/HypergraphPROPResolution.v
+Test/Issue139.v
 Tools/Abstraction.v
 Tools/Represented.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -188,9 +188,9 @@ Structure/Monoid.v
 Structure/Monoidal.v
 Structure/Monoidal/Balanced.v
 Structure/Monoidal/Braided.v
-Structure/Monoidal/Cartesian.v
-Structure/Monoidal/Cartesian/Cartesian.v
-Structure/Monoidal/Cartesian/Proofs.v
+Structure/Monoidal/Heunen_Vicary.v
+Structure/Monoidal/Heunen_Vicary/Cartesian.v
+Structure/Monoidal/Heunen_Vicary/Proofs.v
 Structure/Monoidal/Closed.v
 Structure/Monoidal/Commutative.v
 Structure/Monoidal/Compose.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -188,6 +188,7 @@ Structure/Monoid.v
 Structure/Monoidal.v
 Structure/Monoidal/Balanced.v
 Structure/Monoidal/Braided.v
+Structure/Monoidal/Cartesian.v
 Structure/Monoidal/Heunen_Vicary.v
 Structure/Monoidal/Heunen_Vicary/Cartesian.v
 Structure/Monoidal/Heunen_Vicary/Proofs.v


### PR DESCRIPTION
## Summary

Fixes the discoverability and naming problems raised in #139 around the
relationship between cartesian and monoidal structure.

While investigating, the central finding was that **theorem 1 — "every cartesian
category is a monoidal category" — already exists in the library**, contrary to
the issue's premise ("I'm not aware of a proof of 1. in the library at this
moment"). It is `CC_Monoidal` in `Structure/Monoidal/Internal/Product.v`
(`tensor := ×`, `I := 1`), with the full symmetric/relevant/semicartesian tower
above it, and `Instance/Coq.v` already builds `Coq_Monoidal` from it. The real
problem was exactly the one #139 describes: that construction was undiscoverable
under a cryptic name in a file about the internal product functor, while
`Monoidal/Cartesian.v` misleadingly held the **opposite** (Heunen–Vicary)
direction.

So this PR is a reorganization that surfaces theorem 1 where readers look for it,
renames the reverse direction to reflect its content, and locks the behavior in
with a regression test.

## Changes (atomic commits)

1. **`refactor: drop unused first/second/split from CartesianMonoidal`** — the
   `first`/`second`/`split` definitions and their `*_respects` instances in the
   class file had zero consumers anywhere in the tree (the only uses of those
   names resolve to the unrelated `Structure.Cartesian` combinators).
2. **`refactor: rename CartesianMonoidal files to Heunen_Vicary`** — relocate the
   reverse direction (Fox 1976 / Heunen–Vicary: a relevant + semicartesian
   monoidal category is cartesian) so its name reflects its content and frees the
   `Monoidal/Cartesian.v` name:
   - `Monoidal/Cartesian.v` → `Monoidal/Heunen_Vicary.v`
   - `Monoidal/Cartesian/Cartesian.v` → `Monoidal/Heunen_Vicary/Cartesian.v`
   - `Monoidal/Cartesian/Proofs.v` → `Monoidal/Heunen_Vicary/Proofs.v`

   All `Require` sites and `_CoqProject` are repointed; no proofs change.
3. **`feat: surface "cartesian category is monoidal" as Monoidal/Cartesian.v`** —
   the now-freed `Monoidal/Cartesian.v` re-exports `Internal.Product` and gives
   the forward direction the headline name `Cartesian_Monoidal`, with a header
   that orients readers (and points at `Heunen_Vicary.v` for the reverse).
4. **`test: add regression test for cartesian => monoidal (#139)`** —
   `Test/Issue139.v` checks that `Cartesian_Monoidal` exists generically, that its
   tensor is the categorical product and its unit the terminal object, and that it
   is definitionally the structure `Coq_Monoidal` already uses. It references
   `Cartesian_Monoidal`, which did not exist before this series, so it fails
   against the pre-#139 tree and passes now.

## On deleting the `CartesianMonoidal` typeclass

#139 also suggested deleting the `CartesianMonoidal` typeclass and assuming
`RelevanceMonoidal` + `Semicartesian` separately. A review of every consumer
(`Group`, `Group/Proofs`, `Closed`, `Internal/Product`, `Functor/Strong/Product`,
`Instance/Coq/Par`) showed the class is consumed/produced at 9 sites and bundles
exactly the data those sites need — including four Fox-coherence laws that are
**not** derivable from `Relevance` + `Semicartesian` alone, so "just assume the
two typeclasses" would still require re-listing those laws at every site.
Deleting it is pure boilerplate inflation with no soundness or modularity gain,
so the class is **kept** (it keeps its name and API); only the genuinely dead
code was removed. This keeps the PR low-risk while still addressing the issue's
real complaint (discoverability + name overloading).

## Verification

- `nix build` (Rocq 9.1) and the full dev-shell `make` are green.
- `nix flake check` passes.
- The new regression test `Test/Issue139.v` compiles as part of the library.

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)
