### PR TITLE
fix(Functor): drop functoriality fields from Full (#118)

### DIFF
--- a/Construction/Subcategory.v
+++ b/Construction/Subcategory.v
@@ -78,9 +78,6 @@ Proof.
   - exists g.
     destruct x, y.
     apply X; auto.
-  - proper.
-  - reflexivity.
-  - reflexivity.
   - reflexivity.
 Qed.
 

--- a/Functor/Hom.v
+++ b/Functor/Hom.v
@@ -97,10 +97,6 @@ Qed.
 Proof.
   unshelve econstructor; simpl in *.
   - exact (fun c d f => f c id).
-  - abstract(auto).
-  - abstract(intros c; simpl; now autorewrite with categories).
-  - abstract(intros; destruct f as [ftrans fnat ?]; simpl in *;
-             rewrite <- (id_right (g x id)), <- fnat at 1; reflexivity).
   - abstract(intros x y [Ftrans Fnat ?] c f; simpl in *;
     unfold op;
     now rewrite Fnat, id_right).

--- a/Instance/Cat.v
+++ b/Instance/Cat.v
@@ -118,22 +118,6 @@ Program Definition Cat_Iso_to_Full `(iso : C ≅ D) :
                            ∘ from (`1 (iso_from_to iso) x)
     |}.
 Next Obligation.
-  proper. comp_right. comp_left. now rewrite X.
-Qed.
-Next Obligation.
-  rewrite fmap_id, id_right.
-  apply iso_to_from.
-Qed.
-Next Obligation.
-  comp_right.
-  comp_left.
-  rewrite !fmap_comp.
-  comp_left.
-  rewrite comp_assoc.
-  rewrite iso_from_to.
-  cat.
-Qed.
-Next Obligation.
   rewrite !fmap_comp.
   srewrite H0.
   srewrite (`2 (iso_to_from iso)).

--- a/Test/FullIssue118.v
+++ b/Test/FullIssue118.v
@@ -1,0 +1,95 @@
+(** * Regression test for issue #118: the [Full] type class.
+
+    https://github.com/jwiegley/category-theory/issues/118
+
+    The [Full] type class must express the *standard* notion of a full
+    functor: a section [prefmap] of the hom-map [fmap[F]] together with the
+    surjectivity witness [fmap_sur] — and nothing more.  No functoriality may
+    be demanded of [prefmap].  The previous definition additionally carried
+    [prefmap_respects], [prefmap_id] and [prefmap_comp]; those three fields
+    were extraneous and have been removed, leaving exactly:
+
+      Class Full `(F : C ⟶ D) := {
+        prefmap {x y} (g : F x ~> F y) : x ~> y;
+        fmap_sur {x y} (g : F x ~> F y) : fmap[F] (prefmap g) ≈ g
+      }.
+
+    This file pins that two-field shape.  It constructs a [Full] instance
+    using *only* [prefmap] and [fmap_sur]:
+
+      - [Id_Full_build] applies the generated constructor [Build_Full] to
+        exactly those two values.  Under the old five-field class this is a
+        partial application whose type still expects the three dropped fields,
+        so it is rejected; under the corrected class it has type [Full Id[C]].
+
+      - [Full_from_section] does the same via a record literal that lists only
+        the two surviving fields.  Under the old class the omitted fields turn
+        into unresolved implicit arguments (a hard error); under the corrected
+        class the literal is complete.
+
+    Either construction therefore compiles only against the corrected
+    definition and fails against the old one.  Finally we reference
+    [FullyFaithful] — the lemma whose proof previously relied on the removed
+    [prefmap_comp] / [prefmap_id] — to confirm it still typechecks under the
+    leaner class. *)
+
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+
+Generalizable All Variables.
+
+(** ** Constructor form.
+
+    [Build_Full] is the constructor generated for the [Full] class.  We feed
+    it exactly the two fields of the corrected definition.  The identity
+    functor's hom-map is the identity on [x ~> y], so the chosen preimage is
+    [g] itself and [fmap_sur] holds by reflexivity (recall that [fmap[Id[C]] g]
+    reduces to [g]). *)
+Definition Id_Full_build (C : Category) : Full (Id[C]) :=
+  Build_Full _ _ Id[C]
+    (fun x y (g : Id[C] x ~> Id[C] y) => g)
+    (fun x y (g : Id[C] x ~> Id[C] y) => reflexivity g).
+
+(** ** Record-literal form.
+
+    The same two-field shape, expressed as a section of an arbitrary functor's
+    hom-map.  The literal mentions only [prefmap] and [fmap_sur]; under the old
+    class the missing functoriality fields would be unresolved implicits. *)
+Definition Full_from_section
+  `(F : C ⟶ D)
+  (pre : ∀ x y, F x ~> F y → x ~> y)
+  (sec : ∀ x y (g : F x ~> F y), fmap[F] (pre x y g) ≈ g) : Full F :=
+  {| prefmap x y g := pre x y g
+   ; fmap_sur x y g := sec x y g |}.
+
+(** The identity functor is full: every hom-map is the identity, hence its own
+    section.  The witness is exhibited through [Full_from_section]. *)
+Program Definition Id_Full {C : Category} : Full (@Id C) :=
+  Full_from_section Id (fun _ _ g => g) _.
+
+(** Register an instance so resolution of the leaner class is exercised too. *)
+#[local] Existing Instance Id_Full.
+
+(** The two surviving projections, with their expected types under the
+    corrected definition. *)
+Check @prefmap.
+Check @fmap_sur.
+
+(** ** [FullyFaithful] under the leaner class.
+
+    The identity functor is trivially faithful; combined with fullness this
+    lets us instantiate [FullyFaithful] and confirm the lemma — whose proof no
+    longer has access to [prefmap_comp] / [prefmap_id] — still elaborates. *)
+#[local] Program Instance Id_Faithful (C : Category) : Faithful (Id[C]) := {|
+  fmap_inj := fun x y (f g : x ~> y) (H : f ≈ g) => H
+|}.
+
+Definition FullyFaithful_under_lean_Full
+  `(F : C ⟶ D) `{@Full _ _ F} `{@Faithful _ _ F} :
+  ∀ x y, F x ≅ F y → x ≅ y := FullyFaithful F.
+
+(** Pin a concrete instantiation as well, independent of implicit inference. *)
+Check (fun C : Category =>
+         @FullyFaithful C C Id[C] (Id_Full_build C) (Id_Faithful C)).

--- a/Theory/Functor.v
+++ b/Theory/Functor.v
@@ -249,17 +249,15 @@ Arguments fun_equiv_comp_assoc {A B C D} F G H.
    Wikipedia: https://en.wikipedia.org/wiki/Full_functor
 
    F is full when each hom-map fmap[F] : (x ~> y) → (F x ~> F y) is surjective.
-   Constructively this is witnessed by a section [prefmap] of [fmap[F]] (a
-   functorial choice of preimage with fmap[F] (prefmap g) ≈ g, [fmap_sur]),
-   rather than by a bare surjectivity proposition. *)
+   Constructively this is witnessed by a section [prefmap] of [fmap[F]]: a
+   choice of preimage with fmap[F] (prefmap g) ≈ g ([fmap_sur]), rather than by
+   a bare surjectivity proposition. No functoriality is demanded of [prefmap]
+   itself — it need not respect ≈ nor preserve identities/composition; only that
+   it lands in a genuine preimage. This matches the standard meaning of fullness
+   (cf. issue #118); the previous definition's [prefmap_respects], [prefmap_id]
+   and [prefmap_comp] fields were extraneous. *)
 Class Full `(F : C ⟶ D) := {
   prefmap {x y} (g : F x ~> F y) : x ~> y;     (* chosen preimage of g under fmap *)
-
-  prefmap_respects {x y} : Proper (equiv ==> equiv) (@prefmap x y);  (* prefmap respects ≈ *)
-
-  prefmap_id : ∀ x, @prefmap x x id ≈ id;      (* preimage is functorial: identities *)
-  prefmap_comp : ∀ x y z (f : F y ~> F z) (g : F x ~> F y),  (* ... and composition *)
-    prefmap (f ∘ g) ≈ prefmap f ∘ prefmap g;
 
   fmap_sur {x y} (g : F x ~> F y) : fmap[F] (prefmap g) ≈ g  (* prefmap is a section of fmap *)
 }.
@@ -277,9 +275,11 @@ Class Faithful `(F : C ⟶ D) := {
    Wikipedia: https://en.wikipedia.org/wiki/Full_and_faithful_functors
 
    A fully faithful functor (both Full and Faithful) reflects isomorphisms: if
-   F x ≅ F y then x ≅ y. The witnesses are built from [prefmap] applied to the
-   given iso; only fullness (via prefmap_comp / prefmap_id) is needed to verify
-   them here. *)
+   F x ≅ F y then x ≅ y. The witnesses are [prefmap] applied to the given iso;
+   the inverse laws are discharged by faithfulness ([fmap_inj]), which reduces
+   each to the corresponding law of the image iso after pushing [fmap] through
+   composition ([fmap_comp]) and cancelling the sections ([fmap_sur]). Fullness
+   alone no longer needs to be functorial. *)
 Lemma FullyFaithful `(F : C ⟶ D) `{@Full _ _ F} `{@Faithful _ _ F} :
   ∀ x y, F x ≅ F y → x ≅ y.
 Proof.
@@ -288,17 +288,13 @@ Proof.
   + apply prefmap, X.
   + apply prefmap, X.
   + abstract
-      (simpl;
-       rewrite <- prefmap_comp;
-       destruct H;
-       rewrite iso_to_from;
-       apply prefmap_id).
+      (apply fmap_inj;
+       rewrite fmap_comp, !fmap_sur, fmap_id;
+       apply iso_to_from).
   + abstract
-      (simpl;
-       rewrite <- prefmap_comp;
-       destruct H;
-       rewrite iso_from_to;
-       apply prefmap_id).
+      (apply fmap_inj;
+       rewrite fmap_comp, !fmap_sur, fmap_id;
+       apply iso_from_to).
 Defined.
 
 (* nLab: https://ncatlab.org/nlab/show/algebra+over+an+endofunctor

--- a/_CoqProject
+++ b/_CoqProject
@@ -269,6 +269,7 @@ Theory/Sheaf.v
 Theory/Universal/Arrow.v
 Structure/Monoidal/Hypergraph/Tactics.v
 Structure/Monoidal/Strict/Tactics.v
+Test/FullIssue118.v
 Test/HypergraphPROPResolution.v
 Tools/Abstraction.v
 Tools/Represented.v


### PR DESCRIPTION
## Summary

Fixes #118.

`Theory/Functor.v` defined the `Full` type class with a *functorial* chosen
preimage: in addition to the section `prefmap` and its surjectivity witness
`fmap_sur`, it required `prefmap_respects`, `prefmap_id` and `prefmap_comp`.
As the issue notes, this is nonstandard — fullness only asks that each hom-map
`fmap[F] : (x ~> y) → (F x ~> F y)` be surjective, witnessed by a bare section.
The maintainer concurred in the issue thread that the functoriality fields
should be dropped.

This PR removes those three fields, leaving:

```coq
Class Full `(F : C ⟶ D) := {
  prefmap {x y} (g : F x ~> F y) : x ~> y;
  fmap_sur {x y} (g : F x ~> F y) : fmap[F] (prefmap g) ≈ g
}.
```

## Changes

- **`Theory/Functor.v`** — drop `prefmap_respects` / `prefmap_id` /
  `prefmap_comp`; update the class comment. Reprove `FullyFaithful`, whose old
  proof used `prefmap_comp` / `prefmap_id`: the iso inverse laws are now
  discharged by faithfulness (`fmap_inj`), reducing each to a law of the image
  iso after `fmap_comp` + `fmap_sur` + `fmap_id`.
- **`Instance/Cat.v`** — `Cat_Iso_to_Full` no longer needs the three
  obligations for the dropped fields.
- **`Functor/Hom.v`** — `Yoneda_Full` drops the three `econstructor` branches
  for the dropped fields.
- **`Construction/Subcategory.v`** — `Full_Implies_Full_Functor` drops the
  three corresponding bullets.
- **`Test/FullIssue118.v`** (new, registered in `_CoqProject`) — a regression
  test that constructs `Full` from exactly `prefmap` and `fmap_sur` (via
  `Build_Full` and via a record literal) so it compiles only against the
  corrected two-field class, and instantiates `FullyFaithful` to confirm it
  still elaborates.

## Validation

The full library builds cleanly (`make`, Rocq 9.1). The new regression test
fails to compile against the previous five-field definition (unresolved /
missing functoriality fields) and succeeds against the corrected one. The
change introduces no axioms.
