### PR TITLE
Solidify StrictCat as the strict category of categories (#138)

### DIFF
--- a/Instance/Cat.v
+++ b/Instance/Cat.v
@@ -26,20 +26,39 @@ Generalizable All Variables.
    [obj := Category] sit below the universe of [Cat] itself.
 
    Strict vs. weak: because the hom-setoid [Functor_Setoid] identifies functors
-   only up to natural isomorphism (not on-the-nose equality of object/morphism
-   maps), an isomorphism in this [Cat] is an *equivalence* of categories rather
-   than a strict isomorphism. Cat is the underlying 1-category of the strict
-   2-category whose 2-cells are natural transformations; only the 1-category
-   structure is built here.
+   whenever they are naturally isomorphic (not on-the-nose equal on objects and
+   morphisms), an isomorphism in this [Cat] is an *equivalence* of categories.
+   Identifying functors up to natural isomorphism makes this the homotopy
+   category Ho(Cat) (the 1-truncation of the 2-category Cat), whose morphisms are
+   natural-isomorphism classes of functors. It is therefore NOT the strict
+   1-category of categories of the textbooks; and although it keeps the same
+   objects, it is neither the *underlying* 1-category of the 2-category Cat
+   (which keeps functor equality) nor its *core* (which keeps only the
+   isomorphisms).
 
-   The strict counterpart — functors compared by on-the-nose equality of their
-   object and morphism maps — is [Category.Instance.StrictCat.StrictCat]; the
-   identity-on-objects comparison functor [StrictCat_to_Cat : StrictCat ⟶ Cat]
-   of [Category.Instance.StrictCat.ToCat] exhibits the former as a refinement of
-   the latter. Issue #138 discusses why the weak hom-equivalence is retained
-   here (the Lawvere/comma characterisation of adjunctions, e.g.
-   [Construction.Comma.Adjunction], genuinely needs [≅] in [Cat] to mean
-   equivalence of categories). *)
+   This is deliberate, and consistent with the rest of the library: lacking
+   function extensionality, the development compares morphisms up to a setoid
+   equivalence [≈] rather than by Coq's intensional equality [=]. For [Cat] the
+   morphisms are functors, and the corresponding [≈] is natural isomorphism —
+   the equivalence-invariant notion of sameness for functors. So [Cat] applies
+   the weaker notion of equivalence used everywhere else, lifted one level up, to
+   suit Coq's metatheory.
+
+   The reporter of issue #138 is right that the textbook bare-name "Cat" is the
+   STRICT 1-category (functors compared by on-the-nose equality); that is
+   [Category.Instance.StrictCat.StrictCat]. The choice here is not an error but a
+   weaker, equivalence-invariant convention (cf. agda-categories' [Cats], whose
+   functor equivalence is likewise natural isomorphism). The identity-on-objects
+   comparison functor [StrictCat_to_Cat : StrictCat ⟶ Cat] of
+   [Category.Instance.StrictCat.ToCat] sends each strict equality to the natural
+   isomorphism it induces, exhibiting [StrictCat] as a strictification of this
+   Ho(Cat). Note that the comma/slice comparisons phrased with [≅[Cat]] (e.g.
+   [Construction.Comma.Adjunction]) are in fact *strict* isomorphisms of
+   categories — the Lawvere comma comparison is bijective on objects with an
+   on-the-nose inverse — so using the weak [Cat] there is a convenience, not a
+   necessity. What genuinely requires strict equality is the object-equality-
+   dependent underlying-graph functor [Forgetful : StrictCat ⟶ Quiv] of issue
+   #138, which has no counterpart over this [Cat]. *)
 
 #[export]
 Instance Cat : Category := {

--- a/Instance/Cat.v
+++ b/Instance/Cat.v
@@ -52,13 +52,17 @@ Generalizable All Variables.
    comparison functor [StrictCat_to_Cat : StrictCat ⟶ Cat] of
    [Category.Instance.StrictCat.ToCat] sends each strict equality to the natural
    isomorphism it induces, exhibiting [StrictCat] as a strictification of this
-   Ho(Cat). Note that the comma/slice comparisons phrased with [≅[Cat]] (e.g.
-   [Construction.Comma.Adjunction]) are in fact *strict* isomorphisms of
-   categories — the Lawvere comma comparison is bijective on objects with an
-   on-the-nose inverse — so using the weak [Cat] there is a convenience, not a
-   necessity. What genuinely requires strict equality is the object-equality-
-   dependent underlying-graph functor [Forgetful : StrictCat ⟶ Quiv] of issue
-   #138, which has no counterpart over this [Cat]. *)
+   Ho(Cat). The weak hom-equivalence is moreover used substantively, not merely
+   for phrasing: [Construction.Comma.Adjunction], for instance, builds an
+   adjunction's unit and counit out of the *natural-isomorphism components* of a
+   comma equivalence [≅[Cat]] — it takes the underlying morphism
+   [from (`1 (iso_from_to lawvere_iso) x)] of such a component — which relies on
+   [≅] in [Cat] being a natural isomorphism; a strict reformulation would be a
+   genuinely different, transport-based construction rather than a rename.
+   Conversely, the construction that cannot live over this
+   [Cat] at all is the object-equality-dependent underlying-graph functor
+   [Forgetful : StrictCat ⟶ Quiv] of issue #138, which does not respect natural
+   isomorphism. *)
 
 #[export]
 Instance Cat : Category := {

--- a/Instance/Cat.v
+++ b/Instance/Cat.v
@@ -30,7 +30,16 @@ Generalizable All Variables.
    maps), an isomorphism in this [Cat] is an *equivalence* of categories rather
    than a strict isomorphism. Cat is the underlying 1-category of the strict
    2-category whose 2-cells are natural transformations; only the 1-category
-   structure is built here. *)
+   structure is built here.
+
+   The strict counterpart — functors compared by on-the-nose equality of their
+   object and morphism maps — is [Category.Instance.StrictCat.StrictCat]; the
+   identity-on-objects comparison functor [StrictCat_to_Cat : StrictCat ⟶ Cat]
+   of [Category.Instance.StrictCat.ToCat] exhibits the former as a refinement of
+   the latter. Issue #138 discusses why the weak hom-equivalence is retained
+   here (the Lawvere/comma characterisation of adjunctions, e.g.
+   [Construction.Comma.Adjunction], genuinely needs [≅] in [Cat] to mean
+   equivalence of categories). *)
 
 #[export]
 Instance Cat : Category := {

--- a/Instance/StrictCat.v
+++ b/Instance/StrictCat.v
@@ -36,7 +36,16 @@ Generalizable All Variables.
    StrictCat instead uses [Functor_StrictEq_Setoid] with [F x = G x], so it is
    the strict 1-category in which an isomorphism is a genuine (on-the-nose)
    isomorphism of categories. Under the axiom of choice this strict 1-category
-   is equivalent, as a bicategory, to the weak [Cat]. *)
+   is equivalent, as a bicategory, to the weak [Cat].
+
+   Strict equality of functors implies natural isomorphism, so there is an
+   identity-on-objects comparison functor [StrictCat_to_Cat : StrictCat ⟶ Cat],
+   built in [Category.Instance.StrictCat.ToCat]. The strictness of StrictCat is
+   what makes functors *out of* it well-defined even when they do not respect
+   natural isomorphism — e.g. the underlying-graph functor
+   [Category.Construction.Free.Quiver.Forgetful : StrictCat ⟶ Quiv], the
+   motivating example of issue #138, which has no counterpart over the weak
+   [Cat]. *)
 
 #[export]
 Instance StrictCat : Category := {

--- a/Instance/StrictCat.v
+++ b/Instance/StrictCat.v
@@ -31,12 +31,17 @@ Generalizable All Variables.
    agreement of the underlying morphism actions.
 
    Difference from [Cat]: the sibling category [Cat] uses [Functor_Setoid],
-   which identifies functors only up to natural isomorphism (object maps related
-   by [F x ≅ G x]); its isomorphisms are therefore *equivalences* of categories.
-   StrictCat instead uses [Functor_StrictEq_Setoid] with [F x = G x], so it is
-   the strict 1-category in which an isomorphism is a genuine (on-the-nose)
-   isomorphism of categories. Under the axiom of choice this strict 1-category
-   is equivalent, as a bicategory, to the weak [Cat].
+   which identifies functors up to natural isomorphism (object maps related by
+   [F x ≅ G x]); its isomorphisms are therefore *equivalences* of categories,
+   making it the homotopy category Ho(Cat). StrictCat instead uses
+   [Functor_StrictEq_Setoid] with [F x = G x], so it is the strict 1-category in
+   which an isomorphism is a genuine (on-the-nose) isomorphism of categories —
+   matching the textbook bare-name "Cat". The library nonetheless works up to the
+   weaker notion of equivalence in [Cat] almost everywhere, to suit Coq's
+   metatheory (no function extensionality); StrictCat is provided for the few
+   constructions that genuinely need on-the-nose object equality. Under the axiom
+   of choice this strict 1-category is equivalent, as a bicategory, to the weak
+   [Cat].
 
    Strict equality of functors implies natural isomorphism, so there is an
    identity-on-objects comparison functor [StrictCat_to_Cat : StrictCat ⟶ Cat],

--- a/Instance/StrictCat/ToCat.v
+++ b/Instance/StrictCat/ToCat.v
@@ -1,0 +1,83 @@
+Require Import Category.Lib.
+Require Import Equations.Prop.Logic.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Instance.Cat.
+Require Import Category.Instance.StrictCat.
+
+Generalizable All Variables.
+
+(** * The comparison functor [StrictCat ⟶ Cat] *)
+
+(* Issue #138 observes that [Cat] uses [Functor_Setoid], which identifies
+   functors only up to natural isomorphism, whereas the ZFC-style notion of
+   equality of functors is the *strict* one used by [StrictCat]
+   ([Functor_StrictEq_Setoid]: equal object maps, with morphism maps agreeing
+   after transport).  The two notions are not interchangeable — the underlying
+   1-category of the 2-category [Cat] genuinely needs the weak hom-equivalence,
+   since an isomorphism there is an *equivalence* of categories (this is what
+   the Lawvere/comma characterisation of adjunctions in
+   [Construction.Comma.Adjunction] relies on).
+
+   What *is* true, and is the content of this file, is that the strict notion
+   refines the weak one: strict equality of functors implies natural
+   isomorphism.  This gives an identity-on-objects, identity-on-morphisms
+   comparison functor [StrictCat_to_Cat : StrictCat ⟶ Cat], exhibiting
+   [StrictCat] as a strictification of [Cat].  Functors *out of* [StrictCat]
+   that do not respect natural isomorphism — e.g. the underlying-graph functor
+   [Construction.Free.Quiver.Forgetful : StrictCat ⟶ Quiv] — therefore cannot
+   in general be factored through this comparison functor, which is precisely
+   why [StrictCat] is needed. *)
+
+(* An equality of objects induces an isomorphism: transport the identity along
+   the equality.  By path induction this is [iso_id] when the proof is
+   [eq_refl], so [to] and [from] compute to [id]. *)
+Definition iso_of_eq {C : Category} {x y : C} (p : x = y) : x ≅ y :=
+  match p in (_ = z) return (x ≅ z) with
+  | eq_refl => iso_id
+  end.
+
+(* Transporting a morphism along an equality of its codomain is the same as
+   post-composing with the induced isomorphism. *)
+Lemma transport_cod_to_iso {C : Category} {c a b : C} (p : a = b) (g : c ~> a) :
+  transport (fun z => hom c z) p g ≈ to (iso_of_eq p) ∘ g.
+Proof. destruct p; simpl; now rewrite id_left. Qed.
+
+(* Dually, transporting along an equality of the domain (via [transport_r]) is
+   pre-composition with the induced isomorphism. *)
+Lemma transport_r_dom_to_iso {C : Category} {a b d : C} (p : a = b) (g : b ~> d) :
+  transport_r (fun z => hom z d) p g ≈ g ∘ to (iso_of_eq p).
+Proof. destruct p; unfold transport_r; simpl; now rewrite id_right. Qed.
+
+(* The mathematical core of issue #138: two functors that are strictly equal
+   (equal on objects, with morphism maps agreeing after transport) are
+   naturally isomorphic.  The natural isomorphism is, objectwise, the identity
+   transported along the object equality. *)
+Lemma strict_equiv_implies_fun_equiv {C D : Category} (F G : C ⟶ D) :
+  @equiv _ Functor_StrictEq_Setoid F G ->
+  @equiv _ Functor_Setoid F G.
+Proof.
+  intros [eq_on_obj coh].
+  exists (fun x => iso_of_eq (eq_on_obj x)).
+  intros x y f.
+  pose proof (coh x y f) as Hc.
+  rewrite transport_cod_to_iso in Hc.
+  rewrite transport_r_dom_to_iso in Hc.
+  rewrite <- comp_assoc.
+  rewrite <- Hc.
+  rewrite comp_assoc.
+  rewrite iso_from_to.
+  now rewrite id_left.
+Qed.
+
+(* The comparison functor is the identity on both objects and morphisms; the
+   only content is that it sends strict equality to natural isomorphism. *)
+Program Definition StrictCat_to_Cat : StrictCat ⟶ Cat := {|
+  fobj := fun C => C;
+  fmap := fun _ _ F => F
+|}.
+Next Obligation.
+  repeat intro.
+  now apply strict_equiv_implies_fun_equiv.
+Qed.

--- a/Test/Issue138.v
+++ b/Test/Issue138.v
@@ -64,12 +64,14 @@ Check (@QuiverHomomorphismOfFunctor
 (* The composite Forgetful ◯ FreeCatFunctor is an endofunctor on QuiverCategory. *)
 Check (Forgetful ◯ FreeCatFunctor : QuiverCategory ⟶ QuiverCategory).
 
-(* The motivating NEGATIVE of issue #138: the underlying-graph functor cannot be
-   typed over the weak [Cat].  [Forgetful] is fixed as [StrictCat ⟶ Quiv], and no
-   functor with this object/morphism action exists over [Cat], because its
-   [fmap_respects] would need to turn a natural isomorphism [F x ≅ G x] into a
-   strict equality [F x = G x] of quiver nodes — which is exactly what fails.
-   These [Fail] commands lock that in: each ascription is a genuine type error. *)
+(* A negative check.  [Forgetful] is fixed as [StrictCat ⟶ Quiv], so ascribing
+   it the type [Cat ⟶ Quiv] is a genuine type error — the domain category differs
+   ("has type StrictCat ⟶ QuiverCategory while it is expected to have type
+   Cat ⟶ QuiverCategory").  These [Fail] commands lock in that [Forgetful] is NOT
+   a functor over the weak [Cat].  Note this only checks the type mismatch; it
+   does not itself exercise the deeper reason no such functor can be *built* over
+   [Cat] (its [fmap_respects] would have to turn a natural isomorphism [F x ≅ G x]
+   into a strict equality [F x = G x] of quiver nodes — see [Instance.Cat]). *)
 Fail Check (Forgetful : Cat ⟶ QuiverCategory).
 Fail Definition A138_forgetful_over_Cat : Cat ⟶ QuiverCategory := Forgetful.
 
@@ -97,9 +99,6 @@ Example B138_free_loop_nodes :
 Check (FreeCatFunctor ◯ Forgetful : StrictCat ⟶ StrictCat).
 
 (* ===== BLOCK C138 — StrictCat strict laws ===== *)
-
-(* StrictCat is a category. *)
-Check (StrictCat : Category).
 
 (* The defining property of issue #138's fix: StrictCat's hom-equivalence IS the
    strict equality [Functor_StrictEq_Setoid] (not the weak nat-iso
@@ -160,11 +159,13 @@ Example D138_obj (C : Category) : StrictCat_to_Cat C = C := eq_refl.
 
 Example D138_map {C D} (F : C ⟶ D) : fmap[StrictCat_to_Cat] F = F := eq_refl.
 
-(* Identity-on-objects content of the comparison: the natural isomorphism that
-   [strict_equiv_implies_fun_equiv] builds is, at each object, the identity
-   morphism transported along the object equality.  At a reflexivity proof this
-   per-object component [iso_of_eq eq_refl] is literally the identity iso, so its
-   [to] and [from] are [id]. *)
+(* The per-object isomorphism the comparison uses is [iso_of_eq] of the object
+   equality, which at a reflexivity proof is the identity iso (its [to] and
+   [from] are [id]).  These two examples pin [iso_of_eq]'s behaviour directly.
+   That [strict_equiv_implies_fun_equiv] builds its natural-iso family as
+   [fun x => iso_of_eq (eq_on_obj x)] is true by construction (see ToCat.v); it
+   is not separately machine-checked here because that lemma is opaque ([Qed]),
+   so its body does not reduce for an [eq_refl] comparison. *)
 Example D138_iso_of_eq_refl_to (C : Category) (x : C) :
   to (iso_of_eq (@eq_refl _ x)) = @id C x := eq_refl.
 

--- a/Test/Issue138.v
+++ b/Test/Issue138.v
@@ -1,0 +1,188 @@
+(* ========================================================================= *)
+(* Regression suite for issue #138.                                          *)
+(*                                                                           *)
+(* This file locks in the resolution of issue #138.  It checks that:        *)
+(*                                                                           *)
+(*   - [StrictCat] is the STRICT category of categories: its homset          *)
+(*     equivalence is [Functor_StrictEq_Setoid] (strict equality of          *)
+(*     functors), not the weak nat-iso equivalence [Functor_Setoid] used by  *)
+(*     the weak category [Cat].                                              *)
+(*                                                                           *)
+(*   - The underlying-graph [Forgetful] functor and the [Free] ⊣ [Forgetful] *)
+(*     adjunction live OVER [StrictCat], not over the weak [Cat].  They       *)
+(*     cannot be defined over [Cat] because they do not respect natural      *)
+(*     isomorphism: a category's underlying quiver is not invariant under     *)
+(*     the weak equivalence that [Cat]'s [Functor_Setoid] identifies.        *)
+(*                                                                           *)
+(*   - The comparison functor [StrictCat_to_Cat] witnesses that strict        *)
+(*     equality of functors implies natural isomorphism (strict-eq ⟹         *)
+(*     natural-iso), exhibiting [StrictCat] as a refinement of [Cat].        *)
+(* ========================================================================= *)
+
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Theory.Adjunction.
+Require Import Category.Instance.Cat.
+Require Import Category.Instance.StrictCat.
+Require Import Category.Instance.StrictCat.ToCat.
+Require Import Category.Construction.Free.Quiver.
+Generalizable All Variables.
+
+(* ===== BLOCK A138 — forgetful behaviour ===== *)
+
+(* The underlying-graph (Forgetful) functor is the motivating example of issue
+   #138.  It is defined over [StrictCat], NOT the weak [Cat], precisely because
+   it does NOT respect natural isomorphism: two categories can be equivalent
+   (naturally isomorphic functors witnessing an equivalence) while their
+   underlying quivers are genuinely different, so a functor sending a category
+   to its underlying quiver cannot be well-defined up to the weak equivalence
+   that [Cat]'s [Functor_Setoid] identifies.  It is well-defined up to the
+   STRICT equality of [StrictCat]'s [Functor_StrictEq_Setoid]. *)
+
+(* Forgetful is well-typed with the claimed signature. *)
+Check (Forgetful : StrictCat ⟶ QuiverCategory).
+
+(* Computational behaviour: underlying nodes are the category's objects. *)
+Example A138_nodes (C : Category) : @nodes (Forgetful C) = obj[C] := eq_refl.
+
+(* Underlying edges are the hom-sets. *)
+Example A138_edges (C : Category) (x y : C) :
+  @edges (Forgetful C) x y = (x ~> y) := eq_refl.
+
+(* The edge-map of the functor's fmap is the functor's fmap. *)
+Example A138_fedgemap (C D : Category) (F : C ⟶ D) (x y : C) (f : x ~> y) :
+  @fedgemap _ _ (fmap[Forgetful] F) x y f = fmap[F] f := eq_refl.
+
+(* The underlying constructions on objects and morphisms are well-typed. *)
+Check (QuiverOfCat : Category -> Quiver).
+Check (@QuiverHomomorphismOfFunctor
+        : ∀ (C D : Category), (C ⟶ D) ->
+            QuiverHomomorphism (QuiverOfCat C) (QuiverOfCat D)).
+
+(* The composite Forgetful ◯ FreeCatFunctor is an endofunctor on QuiverCategory. *)
+Check (Forgetful ◯ FreeCatFunctor : QuiverCategory ⟶ QuiverCategory).
+
+(* The motivating NEGATIVE of issue #138: the underlying-graph functor cannot be
+   typed over the weak [Cat].  [Forgetful] is fixed as [StrictCat ⟶ Quiv], and no
+   functor with this object/morphism action exists over [Cat], because its
+   [fmap_respects] would need to turn a natural isomorphism [F x ≅ G x] into a
+   strict equality [F x = G x] of quiver nodes — which is exactly what fails.
+   These [Fail] commands lock that in: each ascription is a genuine type error. *)
+Fail Check (Forgetful : Cat ⟶ QuiverCategory).
+Fail Definition A138_forgetful_over_Cat : Cat ⟶ QuiverCategory := Forgetful.
+
+(* ===== BLOCK B138 — free ⊣ forgetful adjunction ===== *)
+
+Check (FreeCatFunctor : QuiverCategory ⟶ StrictCat).
+
+Check (FreeForgetfulAdjunction : FreeCatFunctor ⊣ Forgetful).
+
+(* A concrete worked quiver: one node, one loop.
+   NB: bare [unit] in edge position resolves to the adjunction-unit notation, so
+   we must qualify the Coq type as [Datatypes.unit]. *)
+Definition B138_loop : Quiver :=
+  Build_Quiver_Standard_Eq Datatypes.unit (fun _ _ => Datatypes.unit).
+
+Check (FreeOnQuiver B138_loop : Category).
+Check (FreeCatFunctor B138_loop : Category).
+
+(* The nodes of the free category on the loop quiver are exactly the quiver's
+   nodes (here [unit]). *)
+Example B138_free_loop_nodes :
+  obj[FreeOnQuiver B138_loop] = Datatypes.unit := eq_refl.
+
+(* The composite endofunctor on StrictCat *)
+Check (FreeCatFunctor ◯ Forgetful : StrictCat ⟶ StrictCat).
+
+(* ===== BLOCK C138 — StrictCat strict laws ===== *)
+
+(* StrictCat is a category. *)
+Check (StrictCat : Category).
+
+(* The defining property of issue #138's fix: StrictCat's hom-equivalence IS the
+   strict equality [Functor_StrictEq_Setoid] (not the weak nat-iso
+   [Functor_Setoid] of [Cat]).  This pins it directly, so reverting StrictCat to
+   the weak setoid fails HERE, in the test body — not merely transitively
+   through some downstream consumer. *)
+Example C138_homset_is_strict (A B : Category) :
+  @homset StrictCat A B = @Functor_StrictEq_Setoid A B := eq_refl.
+
+(* The strict identity law, exercised through StrictCat's OWN category structure
+   (its [id], [compose], [homset] and [id_left]), rather than only via the
+   free-standing [fun_strict_equiv_*] lemmas. *)
+Example C138_strictcat_id_left (A B : Category) (F : A ⟶ B) :
+  @equiv _ (@homset StrictCat A B)
+         (@compose StrictCat _ _ _ (@id StrictCat B) F) F :=
+  @id_left StrictCat A B F.
+
+(* The three strict category laws, stated with the EXPLICIT strict setoid
+   and discharged by the existing lemmas. *)
+Example C138_id_left {A B} (F : A ⟶ B) :
+  @equiv _ Functor_StrictEq_Setoid (Id ◯ F) F := fun_strict_equiv_id_left F.
+
+Example C138_id_right {A B} (F : A ⟶ B) :
+  @equiv _ Functor_StrictEq_Setoid (F ◯ Id) F := fun_strict_equiv_id_right F.
+
+Example C138_comp_assoc {A B C D} (F : C ⟶ D) (G : B ⟶ C) (H : A ⟶ B) :
+  @equiv _ Functor_StrictEq_Setoid (F ◯ (G ◯ H)) ((F ◯ G) ◯ H) :=
+  fun_strict_equiv_comp_assoc F G H.
+
+(* Strict equality is genuinely an equivalence usable on concrete witnesses. *)
+
+(* Reflexivity of a functor under the strict setoid. *)
+Example C138_strict_refl {A B} (F : A ⟶ B) :
+  @equiv _ Functor_StrictEq_Setoid F F.
+Proof.
+  reflexivity.
+Qed.
+
+(* Id ◯ (Id ◯ F) relates to F under strict equality, using transitivity. *)
+Example C138_nested_id {A B} (F : A ⟶ B) :
+  @equiv _ Functor_StrictEq_Setoid (Id ◯ (Id ◯ F)) F.
+Proof.
+  transitivity (Id ◯ F).
+  - exact (fun_strict_equiv_id_left (Id ◯ F)).
+  - exact (fun_strict_equiv_id_left F).
+Qed.
+
+(* Strict equality refines weak (nat-iso) equality. *)
+Example C138_strict_refines_weak {A B} (F : A ⟶ B) :
+  @equiv _ Functor_Setoid (Id ◯ F) F :=
+  strict_equiv_implies_fun_equiv (Id ◯ F) F (fun_strict_equiv_id_left F).
+
+(* ===== BLOCK D138 — comparison functor ===== *)
+
+Check (StrictCat_to_Cat : StrictCat ⟶ Cat).
+
+Example D138_obj (C : Category) : StrictCat_to_Cat C = C := eq_refl.
+
+Example D138_map {C D} (F : C ⟶ D) : fmap[StrictCat_to_Cat] F = F := eq_refl.
+
+(* Identity-on-objects content of the comparison: the natural isomorphism that
+   [strict_equiv_implies_fun_equiv] builds is, at each object, the identity
+   morphism transported along the object equality.  At a reflexivity proof this
+   per-object component [iso_of_eq eq_refl] is literally the identity iso, so its
+   [to] and [from] are [id]. *)
+Example D138_iso_of_eq_refl_to (C : Category) (x : C) :
+  to (iso_of_eq (@eq_refl _ x)) = @id C x := eq_refl.
+
+Example D138_iso_of_eq_refl_from (C : Category) (x : C) :
+  from (iso_of_eq (@eq_refl _ x)) = @id C x := eq_refl.
+
+Example D138_strict_to_weak {C D} (F G : C ⟶ D)
+  (H : @equiv _ Functor_StrictEq_Setoid F G) : @equiv _ Functor_Setoid F G
+  := strict_equiv_implies_fun_equiv F G H.
+
+(* Concrete instance: re-derive a strict equality witness locally (id_left),
+   then push it through the comparison functor to obtain a weak (nat-iso)
+   equality in Cat. *)
+
+Definition D138_idleft_strict {C D} (F : C ⟶ D)
+  : @equiv _ Functor_StrictEq_Setoid (Id ◯ F) F
+  := fun_strict_equiv_id_left F.
+
+Definition D138_idleft_weak {C D} (F : C ⟶ D)
+  : @equiv _ Functor_Setoid (Id ◯ F) F
+  := strict_equiv_implies_fun_equiv (Id ◯ F) F (D138_idleft_strict F).

--- a/_CoqProject
+++ b/_CoqProject
@@ -271,5 +271,6 @@ Theory/Universal/Arrow.v
 Structure/Monoidal/Hypergraph/Tactics.v
 Structure/Monoidal/Strict/Tactics.v
 Test/HypergraphPROPResolution.v
+Test/Issue138.v
 Tools/Abstraction.v
 Tools/Represented.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -83,6 +83,7 @@ Instance/Cat/Cartesian.v
 Instance/Cat/Cartesian/Closed.v
 Instance/Cat/Cocartesian.v
 Instance/StrictCat.v
+Instance/StrictCat/ToCat.v
 Instance/Comp.v
 Instance/Cones.v
 Instance/Cones/Comma.v


### PR DESCRIPTION
## Summary

Issue #138 observes that `Cat` compares functors up to **natural isomorphism** (`Functor_Setoid`) rather than by the strict, ZFC-style equality of functors (equal object maps, with morphism maps agreeing after transport), and proposes eventually redefining `Cat` to be strict.

**The reporter is right about the terminology, and the weak `Cat` is not an error — it is a deliberate, library-wide choice.** Two things are true at once:

- The textbook / nLab bare-name **`Cat` is the strict 1-category** (functors compared by on-the-nose equality). That is exactly this library's **`StrictCat`**.
- The library's existing **`Cat` is the homotopy category `Ho(Cat)`**, in which an isomorphism is an *equivalence* of categories. This reflects the fact that, lacking function extensionality, the whole development compares morphisms up to a setoid `≈` rather than Coq's intensional `=`; for `Cat`, whose morphisms are functors, the corresponding `≈` is natural isomorphism. The library simply uses this **weaker, equivalence-invariant notion of sameness throughout, to suit Coq's metatheory** — the comparable setoid library [agda-categories](https://github.com/agda/agda-categories) makes the same nat-iso choice for its `Cats`.

So this is a question of which object gets the bare name, not of correctness. This PR keeps `Cat` as-is, solidifies `StrictCat` as the strict counterpart, connects the two with a comparison functor, and locks the design in with regression tests.

### On redefining `Cat` (issue #138's long-term proposal)

A wholesale swap is a large, separate undertaking, because the weak `≅[Cat]` is used **substantively** in places, not merely for phrasing:

- `Construction/Comma/Adjunction.v` builds an adjunction's unit and counit out of the **natural-isomorphism components** of a comma equivalence `≅[Cat]` — e.g. it takes ``from (`1 (iso_from_to lawvere_iso) x)``, the underlying morphism of the component at `x` of the natural isomorphism `ψ◯φ ≅ Id`. Under a strict `Cat` those components would be on-the-nose equalities with nothing to project, so redefining `Cat` means **reformulating** such constructions (transport-based), not renaming them. (The concrete iso that file *produces*, and the slice/coslice comparisons, are themselves strict-in-disguise; it is the *consuming* Lawvere construction that depends on the weak structure.)
- The construction that genuinely *requires* strict equality, and has no counterpart over the weak `Cat`, is the object-equality-dependent underlying-graph functor `Forgetful : StrictCat ⟶ Quiv` — the equivalence-non-invariant ("evil", in the sense of the [principle of equivalence](https://ncatlab.org/nlab/show/principle+of+equivalence)) functor of issue #138.

## What's in this PR

**1. Comparison functor `StrictCat_to_Cat : StrictCat ⟶ Cat`** (`Instance/StrictCat/ToCat.v`)

Its core is `strict_equiv_implies_fun_equiv`: *strict equality of functors implies natural isomorphism*. The witnessing iso is, objectwise, the identity transported along the object equality (`iso_of_eq`, by path induction); naturality is discharged from the strict coherence via two transport-to-iso lemmas. The functor is identity on objects and morphisms. **Axiom-free** (`Print Assumptions` → *Closed under the global context*).

**2. Regression suite** (`Test/Issue138.v`)

Locks in the resolution so a future regression fails at compile time:

- `StrictCat`'s hom-equivalence is pinned **directly** to `Functor_StrictEq_Setoid` (reverting it fails in the test body, not just transitively), plus the strict category laws.
- The underlying-graph `Forgetful : StrictCat ⟶ Quiv` and `Free ⊣ Forgetful` — object/morphism behaviour pinned by `eq_refl`, and a negative check `Fail Check (Forgetful : Cat ⟶ Quiv)` (a domain type mismatch confirming `Forgetful` is not a functor over the weak `Cat`).
- The comparison functor's identity-on-objects/morphisms behaviour and strict ⟹ nat-iso direction.

**3. Documentation** — `Cat.v`/`StrictCat.v` now state precisely that the weak `Cat` is `Ho(Cat)` (iso = equivalence), that `StrictCat` matches the textbook `Cat`, why the weaker notion is used throughout (Coq's metatheory), and that the weak hom-equivalence is used substantively (e.g. the Lawvere/comma machinery).

## Verification

- Full library builds under Rocq 9.1 and Coq 8.19 / 8.20 (CI green); the `lefthook` pre-commit hook runs a full `nix build` on every commit.
- All new lemmas and definitions are **axiom-free**.
- The strict/weak framing was checked against the standard literature (nLab, Mac Lane, Awodey) and other formalizations (agda-categories, Lean mathlib, 1lab, Coq-HoTT), and the comma machinery's dependence on the weak hom-equivalence was verified against the library's own proof scripts (`Construction/Comma/Adjunction.v:89`).

Addresses #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
