### PR TITLE
test: make issue #118 identity-functor witness explicit

### DIFF
--- a/Test/FullIssue118.v
+++ b/Test/FullIssue118.v
@@ -65,9 +65,11 @@ Definition Full_from_section
    ; fmap_sur x y g := sec x y g |}.
 
 (** The identity functor is full: every hom-map is the identity, hence its own
-    section.  The witness is exhibited through [Full_from_section]. *)
-Program Definition Id_Full {C : Category} : Full (@Id C) :=
-  Full_from_section Id (fun _ _ g => g) _.
+    section.  The witness is exhibited through [Full_from_section], with the
+    section law closed explicitly by [reflexivity] rather than left to the
+    ambient [Program] obligation tactic — so the test states its own proof. *)
+Definition Id_Full {C : Category} : Full (@Id C) :=
+  Full_from_section Id (fun _ _ g => g) (fun _ _ g => reflexivity g).
 
 (** Register an instance so resolution of the leaner class is exercised too. *)
 #[local] Existing Instance Id_Full.


### PR DESCRIPTION
## Summary

Follow-up cleanup to the issue #118 regression test added in #180.

`Id_Full` in `Test/FullIssue118.v` constructed its `Full Id` witness with
`Program Definition … := Full_from_section Id (fun _ _ g => g) _.`, leaving the
`fmap_sur` section law to an underscore hole discharged by the ambient
`Program` obligation tactic. That made the test's proof implicit and dependent
on hidden automation.

This closes the section law explicitly with `reflexivity` (the same witness
`Id_Full_build` already uses), so the test states its own proof and relies on
no obligation-tactic machinery.

## Validation

- Compiles against the current two-field `Full` (Rocq 9.1).
- Still **fails** to compile against the previous five-field definition — the
  `Build_Full` arity check (`Id_Full_build`) remains the discriminator — so the
  regression test continues to pin the corrected class shape.
- Single-file, test-only change; no behavioral effect on the library.
