### PR TITLE
test(Poset): tighten regression test claims

### DIFF
--- a/Test/Poset.v
+++ b/Test/Poset.v
@@ -86,9 +86,15 @@ Definition poset_nat_comp_0_2 : (0 ~{Poset_nat}~> 2)%nat :=
 
 (** *** Antisymmetry / skeletality
 
-    This is the exact witness the fixed [Poset] relies on.  Its type is
-    [Antisymmetric ... eq ...]; it CANNOT be coerced to [Asymmetric], the
-    type the old definition demanded — a direct type mismatch. *)
+    [poset_nat_skeletal] records that the poset is skeletal: any two
+    mutually related objects are equal.  It is stated over [obj[Poset_nat]]
+    and the poset hom-types, so it type-checks only once [Poset_nat] is
+    well-formed, and its proof reuses [poset_nat_antisym], the
+    standard-library antisymmetry of [(nat, ≤)] that backs the
+    [Antisymmetric] hypothesis the fixed [Poset] requires.  (These
+    nat-level facts document the skeletal property; the regression guards
+    proper are the [Poset_nat] and [Poset_two] constructions, which do not
+    build under the old definition.) *)
 
 Definition poset_nat_antisym : Antisymmetric nat eq PeanoNat.Nat.le :=
   partial_order_antisym PeanoNat.Nat.le_partialorder.
@@ -98,19 +104,15 @@ Lemma poset_nat_skeletal :
     (x ~{Poset_nat}~> y)%nat -> (y ~{Poset_nat}~> x)%nat -> x = y.
 Proof. intros x y Hxy Hyx; exact (poset_nat_antisym x y Hxy Hyx). Qed.
 
-Lemma poset_nat_le_antisym :
-  forall x y : nat, (x <= y)%nat -> (y <= x)%nat -> x = y.
-Proof. intros x y; apply (antisymmetry (R:=PeanoNat.Nat.le)). Qed.
-
 (** ** A bespoke 2-element poset over a [Type] with no categorical structure
 
     This decisively exercises defect 1: the carrier [two] is an ordinary
     inductive [Type] that is NOT a [Category], so [@Poset two ...] is
     unbuildable under the old [{C : Category}] signature.  It also exercises
     defect 2: the fourth argument is an [Antisymmetric] instance, exactly
-    where the old definition demanded an [Asymmetric] one.  A self-contained
-    custom order is used (Rocq 9.1 ships [Bool.le] but no bundled
-    [PreOrder]/[Antisymmetric] instances for it). *)
+    where the old definition demanded an [Asymmetric] one.  A small bespoke
+    order on [two] is used so the example is self-contained and depends only
+    on this file. *)
 
 Inductive two : Type := lo | hi.
 


### PR DESCRIPTION
## Summary

Follow-up to #181 (the issue #124 Poset regression test). A self-audit of
that test surfaced two places where `Test/Poset.v` claimed more than it
actually verifies. This PR tightens it. No behavior change to the library;
the regression guards are unchanged.

## Changes

- **Drop `poset_nat_le_antisym`.** It was an unused lemma over
  `(nat, ≤, eq)` that names no `Poset` construction, so it compiled
  identically whether `Poset` was fixed, broken, or replaced by a stub —
  a *vacuous* regression guard that merely duplicated `poset_nat_skeletal`
  (which does reference `Poset_nat`). The surrounding comment is reworded
  to mark the `nat`-level antisymmetry facts as documentation, not guards;
  the guards proper are the `Poset_nat` and `Poset_two` constructions.
- **Remove an unverified standard-library claim from a comment.** The text
  asserted "Rocq 9.1 ships `Bool.le` but no bundled
  `PreOrder`/`Antisymmetric` instances for it" — a claim that was never
  verified. It is reworded to state only the rationale (the bespoke order
  keeps the example self-contained).

## Verification

- Compiles against the current (fixed) definition — `coqc` exit 0.
- Still **fails** against the pre-fix definition — `coqc` exit 1
  (`LessThanEqualTo_Category` not found) — so both regression guards remain
  intact.
- lefthook pre-commit (`whitespace`, `admitted`, full `nix build`,
  `nix flake check`) passes.

Refs #124, #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)