### PR TITLE
Exercise the issue #158 guard's failure path and tighten its opam check

### DIFF
--- a/.github/workflows/coq-ci.yml
+++ b/.github/workflows/coq-ci.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Bench build-config regression guard (issue #158)
         run: make bench-config-check
+      - name: Bench build-config guard self-test (reject path, issue #158)
+        run: make bench-config-check-selftest
 
   build:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ bench-config-check:
 		exit 1; \
 	fi
 	@bi=$$(grep -E '^[[:space:]]*(build|install):' coq-category-theory.opam); \
-	if printf '%s\n' "$$bi" | grep -q 'dune'; then \
+	if printf '%s\n' "$$bi" | grep -qw 'dune'; then \
 		echo "ERROR: coq-category-theory.opam build/install invokes dune; the bench requires make"; \
 		printf '%s\n' "$$bi"; \
 		exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,38 @@ bench-config-check:
 	done
 	@echo "Bench config check passed."
 
+# Self-test for the issue #158 guard: prove bench-config-check actually
+# REJECTS each broken PR #156 facet, not merely that it accepts the current
+# tree. Each scenario writes a throwaway copy of this Makefile into a temp
+# dir with one facet broken and asserts the guard fails there; then it
+# asserts the guard passes on the real tree. Wired into CI so the failure
+# path is exercised on Linux, not only on a developer's machine.
+bench-config-check-selftest:
+	@echo "Self-testing bench-config-check (issue #158)..."
+	@mk='$(CURDIR)/$(firstword $(MAKEFILE_LIST))'; rc=0; \
+	mkgood() { \
+		printf '%s\n' '-R . Category' 'Theory/Category.v' > "$$1/_CoqProject"; \
+		printf '%s\n' 'build: [make "-j"]' 'install: [make "install"]' > "$$1/coq-category-theory.opam"; \
+	}; \
+	expect_reject() { \
+		cp "$$mk" "$$1/Makefile"; \
+		if $(MAKE) -C "$$1" -s bench-config-check >/dev/null 2>&1; then \
+			echo "  FAIL: guard ACCEPTED a broken config ($$2)"; rc=1; \
+		else \
+			echo "  ok: rejected $$2"; \
+		fi; \
+		rm -rf "$$1"; \
+	}; \
+	t=$$(mktemp -d); mkgood "$$t"; printf '%s\n' '-R _build/default Category' 'Theory/Category.v' > "$$t/_CoqProject"; expect_reject "$$t" "guard 1: -R _build/default (PR #156)"; \
+	t=$$(mktemp -d); mkgood "$$t"; printf '%s\n' '-R . Category' '-arg _build/default' 'Theory/Category.v' > "$$t/_CoqProject"; expect_reject "$$t" "guard 2: _build token"; \
+	t=$$(mktemp -d); mkgood "$$t"; printf '%s\n' '-R . Category' '-Q Lib Category.Lib' 'Theory/Category.v' > "$$t/_CoqProject"; expect_reject "$$t" "guard 3: -Q directive"; \
+	t=$$(mktemp -d); mkgood "$$t"; printf '%s\n' 'build: ["dune" "build" "-p" name "-j" jobs]' > "$$t/coq-category-theory.opam"; expect_reject "$$t" "guard 4: opam invokes dune"; \
+	t=$$(mktemp -d); mkgood "$$t"; : > "$$t/dune"; expect_reject "$$t" "guard 5: stray dune file"; \
+	if [ $$rc -ne 0 ]; then echo "Self-test FAILED."; exit 1; fi
+	@$(MAKE) -s bench-config-check >/dev/null || { echo "  FAIL: guard rejected the current (fixed) tree"; exit 1; }
+	@echo "  ok: accepted the current tree"
+	@echo "Self-test passed."
+
 timing: Makefile.coq
 	$(MAKE) -f Makefile.coq TIMED=1 2>&1 | tee build-timing.log
 	@echo "Timing saved to build-timing.log"
@@ -156,4 +188,4 @@ force _CoqProject Makefile: ;
 	@+$(MAKE) -f Makefile.coq $@
 
 .PHONY: all clean force lint format-check format admitted-count admitted-check
-.PHONY: bench-config-check timing timing-report build-strict check print-assumptions
+.PHONY: bench-config-check bench-config-check-selftest timing timing-report build-strict check print-assumptions


### PR DESCRIPTION
Follow-up to #178 (merged), which added the `bench-config-check` guard for issue #158. A self-audit of that PR surfaced three honest gaps, fixed here.

## What was wrong

1. **The guard's *reject* path was never proven on Linux.** #178's CI only ran the guard's *accept* path (`make bench-config-check` on a healthy tree). The proof that the guard actually *catches* a regression existed only as ad-hoc local tests on a macOS/BSD machine. The merged PR's description ("verified under … Linux") implied more than the accept path was exercised there.
2. **The opam `dune` check was a bare substring match** (`grep -q 'dune'`) while the `make` check required a whole word (`grep -qw make`) — asymmetric, so an unrelated token merely *containing* "dune" could trip the guard.
3. **The "all CI checks green" framing conflated two things.** The heavy `build` jobs pass because the tree is already healthy (PR #159's revert); they would pass with or without the guard. They never validated the guard itself.

## What this PR does

**`bench-config-check-selftest`** (`Makefile`) reconstructs each broken PR #156 facet in a throwaway copy of the build tree and asserts the guard *rejects* it, then asserts it *accepts* the current tree:

- guard 1 — `_CoqProject` load path `-R _build/default Category`
- guard 2 — a stray `_build` token elsewhere in `_CoqProject`
- guard 3 — a `-Q` directive shadowing the `-R`
- guard 4 — an opam `build:` that invokes `dune`
- guard 5 — a `dune` file at the repo root

It is added to the `config-check` CI job, so the **failure path now runs on Linux** on every push/PR. Like the guard, it only inspects files — no Coq toolchain, seconds on the bare runner.

**Word-boundary opam check** (`Makefile`): `grep -q 'dune'` → `grep -qw 'dune'`, symmetric with the existing `make` check. The PR #156 form `build: ["dune" …]` is still caught (quotes are word boundaries).

## Verification (what was actually run, and where)

- `make bench-config-check-selftest` → all 5 guards reject, tree accepted, **exit 0** — run under macOS `/bin/sh` **and** under `make SHELL=/bin/dash` (the CI shell).
- **Non-vacuity:** disabling a single-check guard (guard 5) flips the self-test to `FAIL: guard ACCEPTED … Self-test FAILED.` with **exit 2** — confirmed under both `/bin/sh` and dash. So the self-test would catch a guard that stops working.
- `make bench-config-check` still passes on the real tree under dash (exit 0).
- The self-test recipe uses only POSIX `printf '%s\n'` / `mktemp` / `cp` / shell functions (no `--`/`\n`-format reliance, no bashisms), verified against `/bin/dash`.

Note: `make check` (which depends on this target) still also depends on the full Coq build, so it was not run end-to-end locally — `coqc` isn't available in this environment. The new prerequisite is the exact target proven above.

Refs: #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)