### PR TITLE
test: tidy and strengthen the #139 regression test

### DIFF
--- a/Test/Issue139.v
+++ b/Test/Issue139.v
@@ -1,7 +1,6 @@
 Require Import Category.Lib.
 Require Import Category.Theory.Category.
 Require Import Category.Theory.Functor.
-Require Import Category.Functor.Bifunctor.
 Require Import Category.Structure.Cartesian.
 Require Import Category.Structure.Terminal.
 Require Import Category.Structure.Monoidal.
@@ -20,9 +19,9 @@ Generalizable All Variables.
    discoverable name Cartesian_Monoidal in Monoidal/Cartesian.v.
 
    These checks pin that down: the forward direction is available generically
-   under its discoverable name, its tensor is the categorical product and its
-   unit the terminal object, and it agrees definitionally with the monoidal
-   structure that a concrete cartesian category (Coq) actually uses. *)
+   under its discoverable name; its tensor is the categorical product, on both
+   objects and morphisms; its unit is the terminal object; and it agrees with
+   the monoidal structure that a concrete cartesian category (Coq) uses. *)
 
 Section Issue139.
 
@@ -43,6 +42,19 @@ Proof. reflexivity. Qed.
 Example issue_139_unit_is_terminal :
   @I C Cartesian_Monoidal = 1%object.
 Proof. reflexivity. Qed.
+
+(* Beyond the object level, the monoidal action on *morphisms* is the product's
+   bifunctorial action: projecting after the tensor f ⨂ g recovers f on the
+   left factor and g on the right.  These are genuine equational checks via the
+   product UMP (exl_fork / exr_fork), so they fail for any non-product tensor --
+   they exercise the structure itself, not merely the discoverable name. *)
+Example issue_139_exl_tensor {a b c d : C} (f : a ~> b) (g : c ~> d) :
+  exl ∘ (f ⨂[Cartesian_Monoidal] g) ≈ f ∘ exl.
+Proof. simpl; now rewrite exl_fork. Qed.
+
+Example issue_139_exr_tensor {a b c d : C} (f : a ~> b) (g : c ~> d) :
+  exr ∘ (f ⨂[Cartesian_Monoidal] g) ≈ g ∘ exr.
+Proof. simpl; now rewrite exr_fork. Qed.
 
 End Issue139.
 


### PR DESCRIPTION
## Summary

Small follow-up to #179 (issue #139), tightening the regression test
`Test/Issue139.v`. Two changes, both confined to that one file:

1. **Drop the unused `Category.Functor.Bifunctor` import.** It was dead —
   `bimap` is already in scope transitively via `Structure.Monoidal`
   (`Structure/Monoidal.v` imports `Bifunctor`). Verified by removing it and
   recompiling.

2. **Strengthen the test with behavioral checks on the tensor's action on
   morphisms.** The original checks pinned the object-level tensor
   (`x ⨂ y = x × y`), the unit (`I = 1`), and the alias identity
   (`Coq_Monoidal = Cartesian_Monoidal`) — all by `reflexivity`. They did not
   exercise the bifunctor. The two new checks

   ```coq
   exl ∘ (f ⨂[Cartesian_Monoidal] g) ≈ f ∘ exl
   exr ∘ (f ⨂[Cartesian_Monoidal] g) ≈ g ∘ exr
   ```

   are genuine equational proofs through the product UMP (`exl_fork` /
   `exr_fork`), so they fail for any non-product tensor. This makes the test
   verify the structure, not merely the discoverable name.

## What I deliberately did NOT change

The other imports in `Structure/Monoidal/Cartesian.v` (`Lib`, `Category`,
`Cartesian`, `Terminal`, `Monoidal`) look redundant with the
`Require Export ...Internal.Product` line, but each names a symbol used
directly in that file (`@Cartesian C`, `@Terminal C`, `@Monoidal C`, ...).
Keeping direct dependencies explicit is the right call; relying on transitive
re-export would be more fragile, so they stay.

## Verification

- `Test/Issue139.v` compiles; the two new proofs are non-trivial (`cat` alone
  and the `exl_split` lemma both fail to close them — `simpl` must expose the
  bifunctor's fork first, confirming the rewrite does real work).
- Full `make` build of the library is green.
- The pre-commit hook ran the full `nix build` (Rocq 9.1) and `nix flake check`.

Refs #139. Follow-up to #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
