### PR TITLE
fix(Makefile): make format-check detect whitespace instead of always failing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,9 @@ lint: todo bench-config-check
 
 format-check:
 	@echo "Checking for trailing whitespace..."
-	@if find . -name '*.v' -print0 | xargs -0 grep -n '[[:blank:]]$$' 2>/dev/null | head -20; then \
+	@ws=`find . -name '*.v' -print0 | xargs -0 grep -n '[[:blank:]]$$' 2>/dev/null | head -20`; \
+	if [ -n "$$ws" ]; then \
+		printf '%s\n' "$$ws"; \
 		echo "ERROR: Trailing whitespace found in .v files"; \
 		exit 1; \
 	fi


### PR DESCRIPTION
## Problem

`make format-check` always failed, even on a clean tree. Its recipe was:

```make
@if find . -name '*.v' -print0 | xargs -0 grep -n '[[:blank:]]$$' 2>/dev/null | head -20; then \
	echo "ERROR: Trailing whitespace found in .v files"; \
	exit 1; \
fi
```

The `if` tests the exit status of the pipeline, but the pipeline ends in
`head`, which exits `0` regardless of whether `grep` matched anything (there is
no `pipefail`). So the error branch fired unconditionally: the target printed
*"Trailing whitespace found in .v files"* and exited 1 on every invocation, and
never reached *"Format check passed."* Because `check: format-check
admitted-check bench-config-check category-theory`, `make check` was always
failing too.

(CI is unaffected — `coq-ci.yml` runs only `make bench-config-check` and its
selftest — which is why this went unnoticed.)

## Fix

Capture the grep output into a variable and branch on whether it is non-empty,
mirroring the correct logic already used by lefthook's `whitespace` hook.

## Verification

```
# clean tree
$ make format-check
Checking for trailing whitespace...
Format check passed.

# with trailing whitespace injected into a .v file
$ make format-check
Checking for trailing whitespace...
./_ws_probe.v:1:Definition foo := 1.
ERROR: Trailing whitespace found in .v files
make: *** [Makefile:45: format-check] Error 1

# after removing it
$ make format-check
Checking for trailing whitespace...
Format check passed.
```

Now it passes on a clean tree and fails — printing the offending `file:line` —
only when trailing whitespace is actually present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQLwg2GCGz4CuEk58KnbZC
