### PR TITLE
Phase 1: copy/discard, determinism, Markov categories + monoidal enablers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,8 @@ Example: `f ∘[C] g` specifies category C when needed.
 - **Structure/Cartesian.v**: Products via universal property
 - **Structure/Closed.v**: Exponentials and internal hom
 - **Structure/Monoidal.v**: Tensor products with coherence
+- **Structure/Monoidal/CopyDiscard.v**: Copy/discard (gs-monoidal) categories — comonoid supply with no naturality; deterministic morphisms and the wide subcategory Det in CopyDiscard/Deterministic.v
+- **Structure/Monoidal/Markov.v**: Markov categories (copy/discard + semicartesian); Fox's theorem in Markov/Fox.v (all-deterministic ⟺ cartesian)
 - **Structure/Limit.v**: Limits and colimits
 
 ### Constructions (External Combinators)

--- a/Construction/Opposite/Monoidal.v
+++ b/Construction/Opposite/Monoidal.v
@@ -1,0 +1,338 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Construction.Opposite.
+Require Import Category.Construction.Product.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Monoidal.Proofs.
+Require Import Category.Structure.Monoidal.Braided.
+Require Import Category.Structure.Monoidal.Symmetric.
+Require Import Category.Theory.Algebra.Monoid.
+Require Import Category.Theory.Algebra.Comonoid.
+Require Import Category.Theory.Algebra.Monoid.Hom.
+Require Import Category.Theory.Algebra.Comonoid.Hom.
+
+Generalizable All Variables.
+
+(** * Monoidal structure on the opposite category *)
+
+(* nLab: https://ncatlab.org/nlab/show/opposite+category
+   nLab: https://ncatlab.org/nlab/show/monoidal+category
+
+   A monoidal structure (I, ⨂, λ, ρ, α) on C induces one on C^op: the tensor
+   acts the same way on objects, morphisms are tensored by reading the same
+   [bimap] against the reversed hom-sets, and the structural isomorphisms are
+   the original ones read in the opposite category (so their [to] components
+   are the original [from] components, via [Isomorphism_Opposite]).  Every
+   coherence obligation is discharged by the corresponding law of C in the
+   opposite orientation: the library records both directions of each
+   naturality square, and the inverse-direction triangle and pentagon are
+   already derived in Structure/Monoidal/Proofs.v, precisely so that this
+   dualization is cheap.  A braiding or symmetry likewise transports, with
+   the two hexagon identities exchanging roles — the reason Braided.v
+   carries both hexagons as data.
+
+   [Monoidal_op], [Braided_op] and [Symmetric_op] are Definitions rather
+   than global Instances: registering them would let resolution silently
+   equip C^op with a monoidal structure whenever C has one, which is rarely
+   what an unannotated goal means (cf. the deferral rationale in
+   Theory/Algebra/Comonoid.v).  Callers select them explicitly.
+
+   The payoff is duality transfer for internal algebra: a comonoid in C is
+   exactly a monoid in (C^op, Monoidal_op) and vice versa, on the nose (the
+   round trips are definitional), and comonoid homomorphisms in C are
+   exactly monoid homomorphisms in C^op with source and target exchanged.
+   This is packaged both pointwise ([Comonoid_to_op_Monoid] and companions)
+   and functorially, as functors Mon(C^op) ⟶ Comon(C)^op and back.
+
+   No involution claim is made for [Monoidal_op]: its tensor is a functor
+   on C^op ∏ C^op, which is not definitionally (C ∏ C)^op, so
+   [Monoidal_op (Monoidal_op M)] is not definitionally M even though
+   (C^op)^op = C holds by reflexivity. *)
+
+Section OppositeMonoidal.
+
+Context {C : Category}.
+
+#[local] Obligation Tactic := intros.
+
+(* The tensor on C^op: the same object action, with the morphism action
+   given componentwise by the tensor of C read against the reversed
+   hom-sets.  Note that the domain is the product category C^op ∏ C^op —
+   we do not route through a mediating (C ∏ C)^op. *)
+Program Definition Opposite_Tensor `{M : @Monoidal C} :
+  C^op ∏ C^op ⟶ C^op := {|
+  fobj := fun p => (fst p ⨂[M] snd p)%object;
+  fmap := fun x y f => (fst f ⨂[M] snd f)
+|}.
+Next Obligation.
+  (* fmap respects ≈, componentwise. *)
+  intros f g e; destruct e as [e1 e2]; simpl.
+  apply bimap_respects; assumption.
+Qed.
+Next Obligation.
+  simpl.
+  apply bimap_id_id.
+Qed.
+Next Obligation.
+  simpl.
+  apply bimap_comp.
+Qed.
+
+(* The monoidal structure on C^op.  The unit is that of C; the unitors and
+   associator are those of C read in the opposite category.  Each law of the
+   [Monoidal] class then dualizes to a law of C: the to/from naturality
+   squares trade places, and the triangle and pentagon become their
+   inverse-direction forms from Structure/Monoidal/Proofs.v.
+
+   A Definition, NOT an Instance — callers select it explicitly. *)
+Program Definition Monoidal_op `{M : @Monoidal C} : @Monoidal (C^op) := {|
+  I            := @I C M;
+  tensor       := Opposite_Tensor;
+  unit_left    := fun x => Isomorphism_Opposite (@unit_left C M x);
+  unit_right   := fun x => Isomorphism_Opposite (@unit_right C M x);
+  tensor_assoc := fun x y z => Isomorphism_Opposite (@tensor_assoc C M x y z)
+|}.
+Next Obligation.
+  (* to_unit_left_natural in C^op = from_unit_left_natural in C *)
+  simpl; symmetry; apply from_unit_left_natural.
+Qed.
+Next Obligation.
+  (* from_unit_left_natural in C^op = to_unit_left_natural in C *)
+  simpl; symmetry; apply to_unit_left_natural.
+Qed.
+Next Obligation.
+  simpl; symmetry; apply from_unit_right_natural.
+Qed.
+Next Obligation.
+  simpl; symmetry; apply to_unit_right_natural.
+Qed.
+Next Obligation.
+  simpl; symmetry; apply from_tensor_assoc_natural.
+Qed.
+Next Obligation.
+  simpl; symmetry; apply to_tensor_assoc_natural.
+Qed.
+Next Obligation.
+  (* Triangle in C^op: ρ⁻¹ ⨂ id ≈ α⁻¹ ∘ (id ⨂ λ⁻¹) in C, the triangle
+     identity of C solved for the inverse unitors. *)
+  simpl.
+  assert (X : (@unit_right C M x)⁻¹ ⨂ to (@unit_left C M y)
+                ≈ (@tensor_assoc C M x I y)⁻¹).
+  { symmetry.
+    rewrite <- (bimap_id_right_left
+                  ((@unit_right C M x)⁻¹) (to (@unit_left C M y))).
+    rewrite inverse_triangle_identity.
+    rewrite comp_assoc.
+    rewrite <- bimap_comp.
+    rewrite iso_from_to.
+    cat. }
+  rewrite <- X.
+  rewrite <- bimap_comp.
+  rewrite iso_to_from.
+  cat.
+Qed.
+Next Obligation.
+  (* Pentagon in C^op = the inverse pentagon of C. *)
+  simpl.
+  rewrite comp_assoc.
+  apply inverse_pentagon_identity.
+Qed.
+
+(* A braiding on C transports to C^op: the braid at (x, y) in C^op is the
+   braid at (y, x) in C.  Naturality dualizes to naturality, and the two
+   hexagon identities exchange roles. *)
+Program Definition Braided_op `{B : @BraidedMonoidal C} :
+  @BraidedMonoidal (C^op) := {|
+  braided_is_monoidal := Monoidal_op;
+  braid := fun x y => @braid C B y x
+|}.
+Next Obligation.
+  (* braid_natural in C^op = braid_natural in C, sides exchanged. *)
+  intros; simpl.
+  symmetry.
+  rewrite !comp_assoc.
+  exact (@braid_natural C B w z h y x g).
+Qed.
+Next Obligation.
+  (* hexagon_identity in C^op = hexagon_identity_sym in C. *)
+  simpl.
+  rewrite !comp_assoc.
+  exact (@hexagon_identity_sym C B y z x).
+Qed.
+Next Obligation.
+  (* hexagon_identity_sym in C^op = hexagon_identity in C. *)
+  simpl.
+  rewrite !comp_assoc.
+  exact (@hexagon_identity C B z x y).
+Qed.
+
+(* A symmetry on C transports to C^op: the involution law at (x, y) in C^op
+   is literally the involution law at (x, y) in C. *)
+Program Definition Symmetric_op `{S : @SymmetricMonoidal C} :
+  @SymmetricMonoidal (C^op) := {|
+  symmetric_is_braided := Braided_op
+|}.
+Next Obligation.
+  simpl.
+  apply braid_invol.
+Qed.
+
+(** ** Duality transfer for internal (co)monoids
+
+    A comonoid on x in C is exactly a monoid on x in (C^op, Monoidal_op):
+    the comultiplication reads as a multiplication against the reversed
+    hom-sets, coassociativity as associativity, and the counit laws as the
+    unit laws.  All four passages below are definitional on the underlying
+    data, and the round trips are literal (proved by reflexivity). *)
+
+Program Definition Comonoid_to_op_Monoid `{M : @Monoidal C} {x : C}
+  (Cm : @Comonoid C M x) : @Monoid (C^op) Monoidal_op x := {|
+  mu  := delta[Cm];
+  eta := epsilon[Cm]
+|}.
+Next Obligation.
+  (* mu_assoc in C^op unfolds to delta_coassoc in C. *)
+  simpl.
+  rewrite comp_assoc.
+  apply delta_coassoc.
+Qed.
+Next Obligation.
+  simpl.
+  apply delta_counit_left.
+Qed.
+Next Obligation.
+  simpl.
+  apply delta_counit_right.
+Qed.
+
+Program Definition Monoid_to_op_Comonoid `{M : @Monoidal C} {x : C}
+  (Mn : @Monoid C M x) : @Comonoid (C^op) Monoidal_op x := {|
+  delta   := mu[Mn];
+  epsilon := eta[Mn]
+|}.
+Next Obligation.
+  (* delta_coassoc in C^op unfolds to mu_assoc in C. *)
+  simpl.
+  rewrite comp_assoc.
+  apply mu_assoc.
+Qed.
+Next Obligation.
+  simpl.
+  apply mu_unit_left.
+Qed.
+Next Obligation.
+  simpl.
+  apply mu_unit_right.
+Qed.
+
+Program Definition op_Monoid_to_Comonoid `{M : @Monoidal C} {x : C}
+  (Mn : @Monoid (C^op) Monoidal_op x) : @Comonoid C M x := {|
+  delta   := mu[Mn];
+  epsilon := eta[Mn]
+|}.
+Next Obligation.
+  spose (@mu_assoc (C^op) Monoidal_op x Mn) as X.
+  rewrite <- comp_assoc.
+  apply X.
+Qed.
+Next Obligation.
+  spose (@mu_unit_left (C^op) Monoidal_op x Mn) as X.
+  apply X.
+Qed.
+Next Obligation.
+  spose (@mu_unit_right (C^op) Monoidal_op x Mn) as X.
+  apply X.
+Qed.
+
+Program Definition op_Comonoid_to_Monoid `{M : @Monoidal C} {x : C}
+  (Cm : @Comonoid (C^op) Monoidal_op x) : @Monoid C M x := {|
+  mu  := delta[Cm];
+  eta := epsilon[Cm]
+|}.
+Next Obligation.
+  spose (@delta_coassoc (C^op) Monoidal_op x Cm) as X.
+  rewrite <- comp_assoc.
+  apply X.
+Qed.
+Next Obligation.
+  spose (@delta_counit_left (C^op) Monoidal_op x Cm) as X.
+  apply X.
+Qed.
+Next Obligation.
+  spose (@delta_counit_right (C^op) Monoidal_op x Cm) as X.
+  apply X.
+Qed.
+
+(* Both round trips are definitional on the underlying data. *)
+
+Lemma Comonoid_op_roundtrip `{M : @Monoidal C} {x : C}
+  (Cm : @Comonoid C M x) :
+  delta[op_Monoid_to_Comonoid (Comonoid_to_op_Monoid Cm)] ≈ delta[Cm]
+    ∧ epsilon[op_Monoid_to_Comonoid (Comonoid_to_op_Monoid Cm)] ≈ epsilon[Cm].
+Proof. split; reflexivity. Qed.
+
+Lemma Monoid_op_roundtrip `{M : @Monoidal C} {x : C}
+  (Mn : @Monoid C M x) :
+  mu[op_Comonoid_to_Monoid (Monoid_to_op_Comonoid Mn)] ≈ mu[Mn]
+    ∧ eta[op_Comonoid_to_Monoid (Monoid_to_op_Comonoid Mn)] ≈ eta[Mn].
+Proof. split; reflexivity. Qed.
+
+(** ** Duality transfer for homomorphisms
+
+    A comonoid homomorphism in C is exactly a monoid homomorphism in C^op
+    between the transported monoids, with source and target exchanged (and
+    vice versa): the preservation squares are the same equations read
+    against the reversed hom-sets. *)
+
+Lemma ComonoidHom_to_op_MonoidHom `{M : @Monoidal C} {x y : C}
+      {Cx : @Comonoid C M x} {Cy : @Comonoid C M y} {f : x ~{C}~> y} :
+  ComonoidHom Cx Cy f →
+  MonoidHom (Comonoid_to_op_Monoid Cy) (Comonoid_to_op_Monoid Cx) f.
+Proof.
+  intros F; destruct F as [Fd Fe].
+  split; simpl.
+  - apply Fd.
+  - apply Fe.
+Qed.
+
+Lemma op_MonoidHom_to_ComonoidHom `{M : @Monoidal C} {x y : C}
+      {Mx : @Monoid (C^op) Monoidal_op x} {My : @Monoid (C^op) Monoidal_op y}
+      {f : x ~{C^op}~> y} :
+  MonoidHom Mx My f →
+  ComonoidHom (op_Monoid_to_Comonoid My) (op_Monoid_to_Comonoid Mx) f.
+Proof.
+  intros F; destruct F as [Fm Fe].
+  split; simpl.
+  - apply Fm.
+  - apply Fe.
+Qed.
+
+#[local] Obligation Tactic := cat_simpl.
+
+(* Functorially: Mon(C^op) and Comon(C)^op agree up to the identity on
+   underlying data.  The two functors below are mutually inverse on that
+   underlying data — the mu/eta/delta/epsilon components and the carrier
+   morphisms round-trip definitionally (fmap is the identity on the
+   underlying C-morphism) — but NOT on the nose at the record level: each
+   object round trip rebuilds the law fields (delta_coassoc etc.) as fresh
+   Qed-opaque proof terms, so the round-tripped sigma objects are not
+   definitionally equal to the originals (proof-irrelevant, but opaque).
+   No isomorphism-of-categories lemma is claimed here; nothing downstream
+   needs one. *)
+
+Program Definition Mon_op_to_Comon_op `{M : @Monoidal C} :
+  @Mon (C^op) Monoidal_op ⟶ (@Comon C M)^op := {|
+  fobj := fun X => (`1 X; op_Monoid_to_Comonoid `2 X);
+  fmap := fun X Y f => (`1 f; op_MonoidHom_to_ComonoidHom `2 f)
+|}.
+
+Program Definition Comon_op_to_Mon_op `{M : @Monoidal C} :
+  (@Comon C M)^op ⟶ @Mon (C^op) Monoidal_op := {|
+  fobj := fun X => (`1 X; Comonoid_to_op_Monoid `2 X);
+  fmap := fun X Y f => (`1 f; ComonoidHom_to_op_MonoidHom `2 f)
+|}.
+
+End OppositeMonoidal.

--- a/Construction/Opposite/Monoidal.v
+++ b/Construction/Opposite/Monoidal.v
@@ -47,10 +47,11 @@ Generalizable All Variables.
    This is packaged both pointwise ([Comonoid_to_op_Monoid] and companions)
    and functorially, as functors Mon(C^op) ⟶ Comon(C)^op and back.
 
-   No involution claim is made for [Monoidal_op]: its tensor is a functor
-   on C^op ∏ C^op, which is not definitionally (C ∏ C)^op, so
-   [Monoidal_op (Monoidal_op M)] is not definitionally M even though
-   (C^op)^op = C holds by reflexivity. *)
+   No involution claim is made for [Monoidal_op]: although (C ∏ C)^op and
+   C^op ∏ C^op are convertible, [Opposite_Tensor] and the [Monoidal_op]
+   obligations rebuild the functor-law and coherence fields as fresh
+   Qed-opaque proof terms, so [Monoidal_op (Monoidal_op M)] is not
+   definitionally M even though (C^op)^op = C holds by reflexivity. *)
 
 Section OppositeMonoidal.
 

--- a/Functor/Structure/Monoidal/Braided.v
+++ b/Functor/Structure/Monoidal/Braided.v
@@ -1,0 +1,253 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Monoidal.Braided.
+Require Import Category.Structure.Monoidal.Symmetric.
+Require Import Category.Functor.Structure.Monoidal.
+Require Import Category.Functor.Structure.Monoidal.Id.
+Require Import Category.Functor.Structure.Monoidal.Compose.
+Require Import Category.Theory.Algebra.SpecialCommutativeFrobenius.
+Require Import Category.Structure.Monoidal.Hypergraph.
+Require Import Category.Structure.Monoidal.HypergraphFunctor.
+
+Generalizable All Variables.
+
+(** * Braided and symmetric monoidal functors *)
+
+(* nLab: https://ncatlab.org/nlab/show/braided+monoidal+functor
+   nLab: https://ncatlab.org/nlab/show/symmetric+monoidal+functor
+   Wikipedia: https://en.wikipedia.org/wiki/Monoidal_functor
+
+   A monoidal functor F between braided monoidal categories C and D is
+   BRAIDED when its tensor comparison commutes with the two braidings: for
+   all x y, the square
+
+       F x ⨂ F y --- braid^D ---> F y ⨂ F x
+           |                          |
+         μ_{x,y}                    μ_{y,x}
+           ↓                          ↓
+       F (x ⨂ y) -- F braid^C --> F (y ⨂ x)
+
+   commutes.  Being braided is a PROPERTY of a (lax or strong) monoidal
+   functor, not extra structure: no new data is involved beyond the single
+   compatibility equation.  [BraidedLaxMonoidalFunctor] states it over the
+   lax tensor comparison [lax_ap]; [BraidedMonoidalFunctor] states it over
+   the strong comparison [ap_iso].  A braided monoidal functor between
+   SYMMETRIC monoidal categories is called a symmetric monoidal functor;
+   the condition is literally the same equation, so
+   [SymmetricMonoidalFunctor] below is a definition, not a new class.
+
+   The identity functor is braided monoidal, and braided monoidal functors
+   compose (paste the outer compatibility square with the image of the
+   inner one under the outer functor), so braided monoidal categories,
+   braided (strong) monoidal functors, and monoidal natural transformations
+   form a 2-category BrMonCat, with symmetric monoidal categories and
+   symmetric monoidal functors as a full sub-2-category. *)
+
+Section BraidedMonoidalFunctor.
+
+Context {C D : Category}.
+Context `{BC : @BraidedMonoidal C}.
+Context `{BD : @BraidedMonoidal D}.
+Context {F : C ⟶ D}.
+
+(* Lax variant: F β ∘ μ ≈ μ ∘ β over the lax tensor comparison. *)
+Class BraidedLaxMonoidalFunctor : Type := {
+  braided_is_lax : @LaxMonoidalFunctor C D _ _ F;
+
+  lax_braid_compat {x y : C} :
+    fmap[F] (@braid C _ x y) ∘ lax_ap
+      ≈ lax_ap ∘ @braid D _ (F x) (F y)
+}.
+#[export] Existing Instance braided_is_lax.
+
+Coercion braided_is_lax :
+  BraidedLaxMonoidalFunctor >-> LaxMonoidalFunctor.
+
+(* Strong variant: the same square over the invertible comparison. *)
+Class BraidedMonoidalFunctor : Type := {
+  braided_is_strong : @MonoidalFunctor C D _ _ F;
+
+  braid_compat {x y : C} :
+    fmap[F] (@braid C _ x y) ∘ to ap_iso
+      ≈ to ap_iso ∘ @braid D _ (F x) (F y)
+}.
+#[export] Existing Instance braided_is_strong.
+
+Coercion braided_is_strong :
+  BraidedMonoidalFunctor >-> MonoidalFunctor.
+
+(* A braided strong monoidal functor is in particular braided lax monoidal:
+   forgetting invertibility of the comparisons preserves the compatibility
+   square, since the lax comparison of [MonoidalFunctor_Is_Lax] is the [to]
+   component of [ap_iso]. *)
+Program Definition BraidedMonoidalFunctor_Is_Lax
+  (S : BraidedMonoidalFunctor) : BraidedLaxMonoidalFunctor := {|
+  braided_is_lax := MonoidalFunctor_Is_Lax braided_is_strong
+|}.
+Next Obligation. apply braid_compat. Qed.
+
+End BraidedMonoidalFunctor.
+
+Arguments BraidedLaxMonoidalFunctor {C D _ _} F.
+Arguments BraidedMonoidalFunctor {C D _ _} F.
+
+(* Over symmetric bases the braided compatibility IS the symmetric
+   condition — a symmetric monoidal functor is just a braided monoidal
+   functor between symmetric monoidal categories, with no new data or
+   axioms (nLab: symmetric+monoidal+functor).  The braided structures are
+   selected through the [symmetric_is_braided] instances. *)
+Definition SymmetricMonoidalFunctor {C D : Category}
+  `{@SymmetricMonoidal C} `{@SymmetricMonoidal D} (F : C ⟶ D) : Type :=
+  @BraidedMonoidalFunctor C D _ _ F.
+
+Definition SymmetricLaxMonoidalFunctor {C D : Category}
+  `{@SymmetricMonoidal C} `{@SymmetricMonoidal D} (F : C ⟶ D) : Type :=
+  @BraidedLaxMonoidalFunctor C D _ _ F.
+
+(** ** The identity functor is braided monoidal *)
+
+(* Both comparison maps of [Id_MonoidalFunctor] are identities, so the
+   compatibility square degenerates to braid ∘ id ≈ id ∘ braid. *)
+
+Section BraidedMonoidalId.
+
+Context {C : Category}.
+Context `{BC : @BraidedMonoidal C}.
+
+#[export] Program Instance Id_BraidedMonoidalFunctor :
+  BraidedMonoidalFunctor (Id[C]) := {
+  braided_is_strong := Id_MonoidalFunctor
+}.
+
+#[export] Program Instance Id_BraidedLaxMonoidalFunctor :
+  BraidedLaxMonoidalFunctor (Id[C]) := {
+  braided_is_lax := Id_LaxMonoidalFunctor
+}.
+
+End BraidedMonoidalId.
+
+(** ** Braided monoidal functors compose *)
+
+(* The composite comparison of [Compose_MonoidalFunctor] is
+   fmap[G] μ^F ∘ μ^G (G outer, F inner).  Its compatibility square is the
+   pasting of the outer square (for G, at F x and F y) with the image
+   under fmap[G] of the inner square (for F, at x and y). *)
+
+Section BraidedMonoidalCompose.
+
+Context {C D E : Category}.
+Context `{BC : @BraidedMonoidal C}.
+Context `{BD : @BraidedMonoidal D}.
+Context `{BE : @BraidedMonoidal E}.
+Context {G : D ⟶ E}.
+Context {F : C ⟶ D}.
+
+#[export] Program Instance Compose_BraidedMonoidalFunctor
+  `{@BraidedMonoidalFunctor D E BD BE G}
+  `{@BraidedMonoidalFunctor C D BC BD F} :
+  BraidedMonoidalFunctor (G ◯ F) := {
+  braided_is_strong := Compose_MonoidalFunctor braided_is_strong
+                                               braided_is_strong
+}.
+Next Obligation.
+  (* Goal: fmap[G] (fmap[F] braid) ∘ (fmap[G] μ^F ∘ μ^G)
+             ≈ (fmap[G] μ^F ∘ μ^G) ∘ braid. *)
+  rewrite comp_assoc.
+  rewrite <- fmap_comp.
+  spose (@braid_compat C D BC BD F _ x y) as XF.
+  rewrites.
+  rewrite fmap_comp.
+  rewrite <- comp_assoc.
+  spose (@braid_compat D E BD BE G _ (F x) (F y)) as XG.
+  rewrites.
+  now rewrite comp_assoc.
+Qed.
+
+#[export] Program Instance Compose_BraidedLaxMonoidalFunctor
+  `{@BraidedLaxMonoidalFunctor D E BD BE G}
+  `{@BraidedLaxMonoidalFunctor C D BC BD F} :
+  BraidedLaxMonoidalFunctor (G ◯ F) := {
+  braided_is_lax := Compose_LaxMonoidalFunctor braided_is_lax
+                                               braided_is_lax
+}.
+Next Obligation.
+  unfold lax_ap; simpl.
+  rewrite comp_assoc.
+  rewrite <- fmap_comp.
+  spose (@lax_braid_compat C D BC BD F _ x y) as XF.
+  rewrites.
+  rewrite fmap_comp.
+  rewrite <- comp_assoc.
+  spose (@lax_braid_compat D E BD BE G _ (F x) (F y)) as XG.
+  rewrites.
+  now rewrite comp_assoc.
+Qed.
+
+End BraidedMonoidalCompose.
+
+(** ** Bridge to hypergraph functors *)
+
+(* Structure/Monoidal/HypergraphFunctor.v formalizes a deliberately weakened
+   version of Fong–Spivak's hypergraph functors: raw comparison isomorphisms
+   plus the four SCFA-preservation equations, WITHOUT the monoidal, unitor or
+   braid coherences (see the "Known scoping limitation" caveat there — the
+   weakened record is NOT in general a symmetric monoidal functor).  The
+   coherence-complete literature notion is exactly: a strong symmetric
+   monoidal functor — [SymmetricMonoidalFunctor] above — whose comparison
+   isomorphisms preserve the SCFA generators.
+
+   The bridge below packages any such functor as a [HypergraphFunctor], with
+   [pure_iso] and [ap_iso] as the comparison isomorphisms.  Only this
+   forgetful direction is sound; the converse is false by that file's own
+   caveat, since the record does not carry the coherences needed to
+   reconstitute a monoidal functor.
+
+   Be clear about how little is happening here: this is constructor
+   repackaging and nothing more.  The four preservation hypotheses are
+   literally the record's four hf_preserves_* fields, and the
+   [HypergraphFunctor] record has no field that could receive [braid_compat]
+   (nor the monoidal coherences), so the braided hypothesis [S] contributes
+   no checked content to the constructed value — the definition would
+   typecheck verbatim against a bare [MonoidalFunctor].  It is nevertheless
+   stated against the symmetric hypothesis to name the literature notion the
+   forgetting starts from.  In particular this bridge does NOT close
+   HypergraphFunctor.v's coherence gap: forgetting into the record loses the
+   coherences irrecoverably, and every consumer of the record remains
+   subject to the caveat there. *)
+
+Section HypergraphBridge.
+
+Context {C : Category}.
+Context `{SC : @SymmetricMonoidal C}.
+Context `{HG_C : @Hypergraph C SC}.
+
+Context {D : Category}.
+Context `{SD : @SymmetricMonoidal D}.
+Context `{HG_D : @Hypergraph D SD}.
+
+Context {F : C ⟶ D}.
+
+(* Over the symmetric bases SC and SD this hypothesis is precisely
+   [SymmetricMonoidalFunctor F]. *)
+Context `{S : @BraidedMonoidalFunctor C D _ _ F}.
+
+Program Definition SymmetricMonoidalFunctor_HypergraphFunctor
+  (preserves_mu : ∀ X : C,
+     fmap[F] (scfa_mu (scfa X)) ∘ to ap_iso ≈ scfa_mu (scfa (F X)))
+  (preserves_eta : ∀ X : C,
+     fmap[F] (scfa_eta (scfa X)) ∘ to pure_iso ≈ scfa_eta (scfa (F X)))
+  (preserves_delta : ∀ X : C,
+     from ap_iso ∘ fmap[F] (scfa_delta (scfa X)) ≈ scfa_delta (scfa (F X)))
+  (preserves_epsilon : ∀ X : C,
+     from pure_iso ∘ fmap[F] (scfa_epsilon (scfa X))
+       ≈ scfa_epsilon (scfa (F X))) :
+  HypergraphFunctor HG_C HG_D := {|
+  hf_functor := F;
+  hf_unit_iso := @pure_iso C D _ _ F _;
+  hf_tensor_iso := fun X Y => @ap_iso C D _ _ F _ X Y
+|}.
+
+End HypergraphBridge.

--- a/Functor/Structure/Monoidal/Strict.v
+++ b/Functor/Structure/Monoidal/Strict.v
@@ -1,0 +1,193 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Monoidal.Strict.
+Require Import Category.Functor.Structure.Monoidal.
+Require Import Category.Functor.Structure.Monoidal.Id.
+Require Import Category.Functor.Structure.Monoidal.Compose.
+
+Generalizable All Variables.
+
+(** * Strict monoidal functors
+
+    nLab: https://ncatlab.org/nlab/show/monoidal+functor
+    Wikipedia: https://en.wikipedia.org/wiki/Monoidal_functor
+
+    A strict monoidal functor is a strong monoidal functor whose comparison
+    maps are identities: the unit comparison η : I ≅ F I and the tensor
+    comparison μ_{x,y} : F x ⨂ F y ≅ F (x ⨂ y) are not merely invertible but
+    equal to [id], so that F preserves the tensor and unit on the nose.
+
+    As with [Structure/Monoidal/Strict.v] (strict monoidal categories), in
+    this library's setoid-based setting "strict" requires BOTH:
+
+      (a) object-level Leibniz equalities
+            [I = F I]  and  [F x ⨂ F y = F (x ⨂ y)];
+      (b) the comparison isomorphisms [pure_iso] and [ap_iso] coincide
+          (modulo those equalities) with [id].
+
+    Object-level equality (Leibniz [=]) is required because [obj] in
+    [Category] is a [Type], not a setoid; the comparison isos relate
+    distinct objects.  The comparisons then transport along those
+    equalities to give [id], stated in the explicit
+    [match e in _ = T return _ with eq_refl => id end] form — see the
+    "Formulation note" at the end of [Structure/Monoidal/Strict.v] for
+    the rationale behind this discipline.  The equality directions match
+    the [to] directions of [pure_iso : I ≅ F I] and
+    [ap_iso : F x ⨂ F y ≅ F (x ⨂ y)].
+
+    Strict monoidal functors compose ([Compose_StrictMonoidalFunctor]) and
+    include the identity ([Id_StrictMonoidalFunctor]), forming the wide
+    sub-2-category MonCat_strict of MonCat_strong.  They are the morphisms
+    of choice between PROPs, whose universal property is stated against
+    strict symmetric monoidal targets. *)
+
+Section StrictMonoidalFunctor.
+
+Context {C D : Category}.
+Context `{@Monoidal C}.
+Context `{@Monoidal D}.
+Context {F : C ⟶ D}.
+
+Class StrictMonoidalFunctor : Type := {
+  strict_functor_is_monoidal : @MonoidalFunctor C D _ _ F;
+
+  (** Object-level strictness. *)
+  strict_pure_obj : (@I D _) = F (@I C _);
+  strict_ap_obj {x y : C} : (F x ⨂ F y)%object = F (x ⨂ y)%object;
+
+  (** The comparison isomorphisms ARE the identity, transported. *)
+  strict_pure_iso_id :
+    to (@pure_iso _ _ _ _ F strict_functor_is_monoidal)
+      ≈ match strict_pure_obj in _ = T return (@I D _) ~> T
+        with eq_refl => id end;
+
+  strict_ap_iso_id {x y : C} :
+    to (@ap_iso _ _ _ _ F strict_functor_is_monoidal x y)
+      ≈ match @strict_ap_obj x y in _ = T return (F x ⨂ F y)%object ~> T
+        with eq_refl => id end
+}.
+#[export] Existing Instance strict_functor_is_monoidal.
+
+(* Strict ⇒ strong by field projection; strong ⇒ lax is the library's
+   existing [MonoidalFunctor_Is_Lax]. *)
+Coercion strict_functor_is_monoidal : StrictMonoidalFunctor >-> MonoidalFunctor.
+
+End StrictMonoidalFunctor.
+
+Arguments StrictMonoidalFunctor {C D _ _} F.
+
+(** ** Transport helpers
+
+    Composites and images of transported identities are again transported
+    identities, along the composite ([eq_trans]) and image ([f_equal])
+    equalities respectively.  These discharge the [Compose] instance below
+    and are reusable by downstream strictness proofs. *)
+
+Lemma fmap_match_id {C D : Category} (F : C ⟶ D) {x y : C} (e : x = y) :
+  fmap[F] (match e in _ = T return x ~> T with eq_refl => id end)
+    ≈ match f_equal F e in _ = T return F x ~> T with eq_refl => id end.
+Proof. destruct e; simpl; apply fmap_id. Qed.
+
+Lemma match_id_trans {C : Category} {x y z : C} (e1 : x = y) (e2 : y = z) :
+  (match e2 in _ = T return y ~> T with eq_refl => id end)
+    ∘ (match e1 in _ = T return x ~> T with eq_refl => id end)
+    ≈ match eq_trans e1 e2 in _ = T return x ~> T with eq_refl => id end.
+Proof. destruct e2, e1; simpl; cat. Qed.
+
+(** ** Closed-form [from] corollaries
+
+    As in [Structure/Monoidal/Strict.v], the [from] direction of each
+    comparison iso is the transported identity along the symmetric
+    equality; this is forced by uniqueness of inverses
+    ([transported_iso_from]), not extra structure. *)
+
+Section StrictMonoidalFunctorFrom.
+
+Context {C D : Category}.
+Context `{@Monoidal C}.
+Context `{@Monoidal D}.
+Context {F : C ⟶ D}.
+Context `{S : @StrictMonoidalFunctor C D _ _ F}.
+
+Corollary strict_pure_iso_from :
+  from (@pure_iso _ _ _ _ F strict_functor_is_monoidal)
+    ≈ match strict_pure_obj in _ = T return T ~> (@I D _)
+      with eq_refl => id end.
+Proof.
+  apply (transported_iso_from
+           strict_pure_obj
+           (@pure_iso _ _ _ _ F strict_functor_is_monoidal)).
+  apply strict_pure_iso_id.
+Qed.
+
+Corollary strict_ap_iso_from {x y : C} :
+  from (@ap_iso _ _ _ _ F strict_functor_is_monoidal x y)
+    ≈ match @strict_ap_obj _ _ _ _ F S x y in _ = T
+        return T ~> (F x ⨂ F y)%object
+      with eq_refl => id end.
+Proof.
+  apply (transported_iso_from
+           (@strict_ap_obj _ _ _ _ F S x y)
+           (@ap_iso _ _ _ _ F strict_functor_is_monoidal x y)).
+  apply strict_ap_iso_id.
+Qed.
+
+End StrictMonoidalFunctorFrom.
+
+(** ** Instances
+
+    The identity functor is strict (both object equalities are [eq_refl]
+    and the comparisons of [Id_MonoidalFunctor] are identities), and
+    strict monoidal functors compose (object equalities by
+    [eq_trans]/[f_equal]; the composite comparisons reduce with
+    [fmap_match_id] and [match_id_trans]).  These mirror the obligation
+    style of [Functor/Structure/Monoidal/{Id,Compose}.v]. *)
+
+#[local] Obligation Tactic := program_simpl.
+
+#[export] Program Instance Id_StrictMonoidalFunctor `{@Monoidal C} :
+  StrictMonoidalFunctor (Id[C]) := {
+  strict_functor_is_monoidal := Id_MonoidalFunctor;
+  strict_pure_obj := eq_refl;
+  strict_ap_obj := fun _ _ => eq_refl
+}.
+Next Obligation. reflexivity. Qed.
+Next Obligation. reflexivity. Qed.
+
+#[export] Program Instance Compose_StrictMonoidalFunctor
+  {C D E : Category}
+  `{@Monoidal C} `{@Monoidal D} `{@Monoidal E}
+  {G : D ⟶ E} {F : C ⟶ D}
+  `{SG : @StrictMonoidalFunctor D E _ _ G}
+  `{SF : @StrictMonoidalFunctor C D _ _ F} :
+  StrictMonoidalFunctor (G ◯ F) := {
+  strict_functor_is_monoidal :=
+    Compose_MonoidalFunctor
+      (@strict_functor_is_monoidal _ _ _ _ G SG)
+      (@strict_functor_is_monoidal _ _ _ _ F SF);
+  strict_pure_obj :=
+    eq_trans (@strict_pure_obj _ _ _ _ G SG)
+             (f_equal G (@strict_pure_obj _ _ _ _ F SF));
+  strict_ap_obj := fun x y =>
+    eq_trans (@strict_ap_obj _ _ _ _ G SG (F x) (F y))
+             (f_equal G (@strict_ap_obj _ _ _ _ F SF x y))
+}.
+Next Obligation.
+  unfold fobj_iso; simpl.
+  rewrite (@strict_pure_iso_id _ _ _ _ F SF).
+  rewrite (@strict_pure_iso_id _ _ _ _ G SG).
+  rewrite fmap_match_id.
+  apply match_id_trans.
+Qed.
+Next Obligation.
+  simpl.
+  pose proof (@strict_ap_iso_id _ _ _ _ F SF x y) as HF; simpl in HF.
+  pose proof (@strict_ap_iso_id _ _ _ _ G SG (F x) (F y)) as HG; simpl in HG.
+  rewrite HF, HG.
+  rewrite fmap_match_id.
+  apply match_id_trans.
+Qed.

--- a/Functor/Structure/Monoidal/Strict.v
+++ b/Functor/Structure/Monoidal/Strict.v
@@ -2,7 +2,6 @@ Require Import Category.Lib.
 Require Import Category.Theory.Category.
 Require Import Category.Theory.Isomorphism.
 Require Import Category.Theory.Functor.
-Require Import Category.Functor.Bifunctor.
 Require Import Category.Structure.Monoidal.
 Require Import Category.Structure.Monoidal.Strict.
 Require Import Category.Functor.Structure.Monoidal.

--- a/Structure/Monoidal/Braided/Proofs.v
+++ b/Structure/Monoidal/Braided/Proofs.v
@@ -37,9 +37,10 @@ Generalizable All Variables.
    braiding is packaged as an isomorphism; every consumer in this development
    is symmetric.)
 
-   This is exactly the coherence noted as missing at the end of
-   Monad/Strong.v (packaging the derived right strength of a strong monad
-   over a symmetric base needs ρ ≈ λ ∘ β), and it discharges the braid-unitor
+   This supplies the coherence needed to package the derived right strength
+   of a strong monad over a symmetric base (ρ ≈ λ ∘ β):
+   Monad/Strong/Symmetric.v consumes it to build [rstr_RightStrongFunctor]
+   and [rstr_RightStrongMonad].  It also discharges the braid-unitor
    compatibilities that a cartesian monoidal structure must satisfy.
 
    Beyond the braid-unitor coherence, this file hosts the shared
@@ -97,7 +98,7 @@ End IsoCancellation.
 
     The kit is exported, citable API: plain and mirror-image forms are
     included for completeness even where only one orientation currently has
-    an in-tree consumer (e.g. [bimap_id_fuse], [triangle_inverse_left]). *)
+    an in-tree consumer (e.g. [triangle_inverse_left]). *)
 
 Section MonoidalToolkit.
 
@@ -613,7 +614,8 @@ End BraidedUnitors.
     independent of the hypergraph stack.
 
     Mirror forms are kept as citable API even where currently unconsumed
-    in-tree: [braid_I_right], [braid_conjugate_right]. *)
+    in-tree: [braid_conjugate_right] (which itself consumes the otherwise
+    unconsumed [braid_I_right]). *)
 
 Section Interchange.
 

--- a/Structure/Monoidal/Braided/Proofs.v
+++ b/Structure/Monoidal/Braided/Proofs.v
@@ -1,0 +1,1077 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Monoidal.Proofs.
+Require Import Category.Structure.Monoidal.Symmetric.
+
+Generalizable All Variables.
+
+(* nLab: https://ncatlab.org/nlab/show/braided+monoidal+category
+
+   Derived coherence between the braiding and the unitors. In any braided
+   monoidal category the two unit isomorphisms are exchanged by the braiding:
+
+       rho ≈ lambda ∘ beta        ([braid_unit_left]),
+       lambda ≈ rho ∘ beta        ([braid_unit_right]),
+
+   i.e. ρ_x ≈ λ_x ∘ β_{x,I} and λ_x ≈ ρ_x ∘ β_{I,x}. This is Proposition 2.1
+   of Joyal & Street, "Braided tensor categories" (Adv. Math. 102, 1993). Like
+   the Kelly lemmas of Structure/Monoidal/Proofs.v, these are not part of the
+   braided data: they follow from the hexagon identity, the triangle identity,
+   and naturality of the braiding and the unitors.
+
+   The argument instantiates the first hexagon at (x, I, I), post-composes
+   with id ⨂ λ, and contracts both sides with the triangle identities and
+   naturality until the braid-free composite ρ remains; the auxiliary
+   tensorings by id[I] are then cancelled with [tensor_id_left_inj] and the
+   invertible structural maps.
+
+   The proofs are carried out for a *symmetric* monoidal category: this
+   library's [BraidedMonoidal] class exposes the braiding as a natural family
+   of morphisms without an inverse, so the cancellation of a trailing
+   [braid ⨂ id] is obtained from the symmetry law [braid_invol]. (In the
+   braided-but-not-symmetric case the same argument goes through once the
+   braiding is packaged as an isomorphism; every consumer in this development
+   is symmetric.)
+
+   This is exactly the coherence noted as missing at the end of
+   Monad/Strong.v (packaging the derived right strength of a strong monad
+   over a symmetric base needs ρ ≈ λ ∘ β), and it discharges the braid-unitor
+   compatibilities that a cartesian monoidal structure must satisfy.
+
+   Beyond the braid-unitor coherence, this file hosts the shared
+   monoidal/symmetric coherence toolkit consumed by the copy-discard stack
+   (the files under Structure/Monoidal/CopyDiscard) and the collapse theorems
+   (Structure/Monoidal/Collapse.v): iso-cancellation lemmas in
+   mid-composition ("cons") position, bimap fusion and associator-naturality
+   shuffles with solved pentagon and triangle forms, and the four-object
+   middle interchange [swap_inner] with its braiding, associativity and unit
+   coherences.  Everything is stated for a bare [Monoidal] or
+   [SymmetricMonoidal] structure — deliberately independent of the
+   copy-discard and hypergraph stacks, so later developments can import the
+   kit without dragging in those dependencies.  (The identification of
+   [swap_inner]'s diagonal with Hypergraph.v's [mid_swap_inv] lives in
+   Structure/Monoidal/CopyDiscard/Deterministic.v for exactly this
+   reason.) *)
+
+(* ------------------------------------------------------------------ *)
+
+(** ** Toolkit: iso cancellation in mid-composition position
+
+    Rewriting inside long composites constantly needs to cancel an adjacent
+    [to i ∘ from i] pair that is followed by a continuation [k]; these
+    "cons" forms keep every rewrite a single step. *)
+
+Section IsoCancellation.
+
+Context {C : Category}.
+
+Lemma cancel_from_to_cons {x y z : C} (i : x ≅ y) (k : z ~> x) :
+  i⁻¹ ∘ (to i ∘ k) ≈ k.
+Proof.
+  rewrite comp_assoc.
+  rewrite iso_from_to.
+  apply id_left.
+Qed.
+
+Lemma cancel_to_from_cons {x y z : C} (i : x ≅ y) (k : z ~> y) :
+  to i ∘ (i⁻¹ ∘ k) ≈ k.
+Proof.
+  rewrite comp_assoc.
+  rewrite iso_to_from.
+  apply id_left.
+Qed.
+
+End IsoCancellation.
+
+(* ------------------------------------------------------------------ *)
+
+(** ** Toolkit: monoidal shuffles
+
+    Bimap fusion/cancellation, associator naturality and derived pentagon
+    shapes, all stated in right-associated "cons" form so that they apply
+    by a single [rewrite] in the middle of a right-associated chain.
+
+    The kit is exported, citable API: plain and mirror-image forms are
+    included for completeness even where only one orientation currently has
+    an in-tree consumer (e.g. [bimap_id_fuse], [triangle_inverse_left]). *)
+
+Section MonoidalToolkit.
+
+Context {C : Category}.
+Context `{M : @Monoidal C}.
+
+Lemma bimap_id_cancel_cons {h x y z : C} (i : x ≅ y)
+      (k : z ~> (h ⨂ x)%object) :
+  (id[h] ⨂ i⁻¹) ∘ ((id[h] ⨂ to i) ∘ k) ≈ k.
+Proof.
+  rewrite comp_assoc.
+  rewrite <- bimap_comp.
+  rewrite iso_from_to, id_left, bimap_id_id.
+  apply id_left.
+Qed.
+
+Lemma bimap_cancel_right_cons {h x y z : C} (i : x ≅ y)
+      (k : z ~> (x ⨂ h)%object) :
+  (i⁻¹ ⨂ id[h]) ∘ ((to i ⨂ id[h]) ∘ k) ≈ k.
+Proof.
+  rewrite comp_assoc.
+  rewrite <- bimap_comp.
+  rewrite iso_from_to, id_left, bimap_id_id.
+  apply id_left.
+Qed.
+
+Lemma bimap_cancel_right {h x y : C} (i : x ≅ y) :
+  (i⁻¹ ⨂ id[h]) ∘ (to i ⨂ id[h]) ≈ id[(x ⨂ h)%object].
+Proof.
+  rewrite <- bimap_comp.
+  rewrite iso_from_to, id_left, bimap_id_id.
+  reflexivity.
+Qed.
+
+Lemma bimap_swap_cons {x y z w v : C} (f : x ~> y) (g : z ~> w)
+      (k : v ~> (z ⨂ x)%object) :
+  (id[w] ⨂ f) ∘ ((g ⨂ id[x]) ∘ k) ≈ (g ⨂ f) ∘ k.
+Proof.
+  rewrite comp_assoc.
+  rewrite bimap_id_left_right.
+  reflexivity.
+Qed.
+
+Lemma bimap_swap2_cons {x y z w v : C} (f : x ~> y) (g : z ~> w)
+      (k : v ~> (x ⨂ z)%object) :
+  (f ⨂ id[w]) ∘ ((id[x] ⨂ g) ∘ k) ≈ (id[y] ⨂ g) ∘ ((f ⨂ id[z]) ∘ k).
+Proof.
+  rewrite !comp_assoc.
+  rewrite bimap_id_right_left.
+  rewrite bimap_id_left_right.
+  reflexivity.
+Qed.
+
+Lemma bimap_id_fuse {h x y z : C} (p : y ~> z) (q : x ~> y) :
+  (id[h] ⨂ p) ∘ (id[h] ⨂ q) ≈ id[h] ⨂ (p ∘ q).
+Proof.
+  rewrite <- bimap_comp.
+  rewrite id_left.
+  reflexivity.
+Qed.
+
+Lemma bimap_id_fuse_cons {h x y z w : C} (p : y ~> z) (q : x ~> y)
+      (k : w ~> (h ⨂ x)%object) :
+  (id[h] ⨂ p) ∘ ((id[h] ⨂ q) ∘ k) ≈ (id[h] ⨂ (p ∘ q)) ∘ k.
+Proof.
+  rewrite comp_assoc.
+  rewrite <- bimap_comp.
+  rewrite id_left.
+  reflexivity.
+Qed.
+
+Lemma bimap_id_split_cons {h x y z w : C} (p : y ~> z) (q : x ~> y)
+      (k : w ~> (h ⨂ x)%object) :
+  (id[h] ⨂ (p ∘ q)) ∘ k ≈ (id[h] ⨂ p) ∘ ((id[h] ⨂ q) ∘ k).
+Proof. symmetry; apply bimap_id_fuse_cons. Qed.
+
+Lemma bimap_fuse_cons {x y z x' y' z' w : C}
+      (p : y ~> z) (q : y' ~> z') (r : x ~> y) (s : x' ~> y')
+      (k : w ~> (x ⨂ x')%object) :
+  (p ⨂ q) ∘ ((r ⨂ s) ∘ k) ≈ ((p ∘ r) ⨂ (q ∘ s)) ∘ k.
+Proof.
+  rewrite comp_assoc.
+  rewrite <- bimap_comp.
+  reflexivity.
+Qed.
+
+Lemma bimap_fuse_id_right {h x y z : C} (p : y ~> z) (r : x ~> y) :
+  (p ⨂ id[h]) ∘ (r ⨂ id[h]) ≈ (p ∘ r) ⨂ id[h].
+Proof.
+  rewrite <- bimap_comp.
+  rewrite id_left.
+  reflexivity.
+Qed.
+
+(** Associator naturality, cons forms. *)
+
+Lemma to_assoc_nat_cons {x y z w v u t : C}
+      (g : x ~> y) (h : z ~> w) (i : v ~> u)
+      (k : t ~> ((x ⨂ z) ⨂ v)%object) :
+  (g ⨂ (h ⨂ i)) ∘ (to tensor_assoc ∘ k)
+    ≈ to tensor_assoc ∘ (((g ⨂ h) ⨂ i) ∘ k).
+Proof.
+  rewrite !comp_assoc.
+  rewrite to_tensor_assoc_natural.
+  reflexivity.
+Qed.
+
+Lemma from_assoc_nat_cons {x y z w v u t : C}
+      (g : x ~> y) (h : z ~> w) (i : v ~> u)
+      (k : t ~> (x ⨂ (z ⨂ v))%object) :
+  ((g ⨂ h) ⨂ i) ∘ (tensor_assoc⁻¹ ∘ k)
+    ≈ tensor_assoc⁻¹ ∘ ((g ⨂ (h ⨂ i)) ∘ k).
+Proof.
+  rewrite !comp_assoc.
+  rewrite from_tensor_assoc_natural.
+  reflexivity.
+Qed.
+
+(* Naturality against a map in the third slot, the first two slots being a
+   fused identity. *)
+Lemma to_assoc_nat_id2_cons {u v x y w : C} (g : x ~> y)
+      (k : w ~> ((u ⨂ v) ⨂ x)%object) :
+  to tensor_assoc ∘ ((id[(u ⨂ v)%object] ⨂ g) ∘ k)
+    ≈ (id[u] ⨂ (id[v] ⨂ g)) ∘ (to tensor_assoc ∘ k).
+Proof.
+  spose (to_tensor_assoc_natural (id[u]) (id[v]) g) as X.
+  rewrite bimap_id_id in X.
+  rewrite !comp_assoc.
+  rewrite <- X.
+  rewrite <- !comp_assoc.
+  reflexivity.
+Qed.
+
+Lemma from_assoc_nat_id2_cons {u v x y w : C} (Z : x ~> y)
+      (k : w ~> (u ⨂ (v ⨂ x))%object) :
+  (id[(u ⨂ v)%object] ⨂ Z) ∘ (tensor_assoc⁻¹ ∘ k)
+    ≈ tensor_assoc⁻¹ ∘ ((id[u] ⨂ (id[v] ⨂ Z)) ∘ k).
+Proof.
+  spose (from_tensor_assoc_natural (id[u]) (id[v]) Z) as X.
+  rewrite bimap_id_id in X.
+  rewrite !comp_assoc.
+  rewrite X.
+  rewrite <- !comp_assoc.
+  reflexivity.
+Qed.
+
+(** Pentagon shapes.  [pentagon_a] is the pentagon axiom right-associated;
+    the [pentagon_solved*] family solves it for the various two-factor
+    associator composites that appear while normalizing. *)
+
+Lemma pentagon_a {u v w t : C} :
+  (id[u] ⨂ to tensor_assoc)
+    ∘ (to tensor_assoc ∘ (to tensor_assoc ⨂ id[t]))
+    ≈ to (@tensor_assoc C _ u v (w ⨂ t))
+        ∘ to (@tensor_assoc C _ (u ⨂ v) w t).
+Proof.
+  rewrite !comp_assoc.
+  apply pentagon_identity.
+Qed.
+
+Lemma pentagon_cons {u v w t z : C} (k : z ~> (((u ⨂ v) ⨂ w) ⨂ t)%object) :
+  (id[u] ⨂ to tensor_assoc)
+    ∘ (to tensor_assoc ∘ ((to tensor_assoc ⨂ id[t]) ∘ k))
+    ≈ to tensor_assoc ∘ (to tensor_assoc ∘ k).
+Proof.
+  rewrite !comp_assoc.
+  rewrite pentagon_identity.
+  rewrite <- !comp_assoc.
+  reflexivity.
+Qed.
+
+Lemma pentagon_solved {u v w t : C} :
+  to tensor_assoc ∘ (tensor_assoc⁻¹ ⨂ id[t])
+    ≈ tensor_assoc⁻¹
+        ∘ ((id[u] ⨂ to tensor_assoc)
+             ∘ to (@tensor_assoc C _ u (v ⨂ w) t)).
+Proof.
+  apply (iso_to_monic tensor_assoc).
+  rewrite (cancel_to_from_cons tensor_assoc).
+  rewrite <- pentagon_cons.
+  rewrite <- bimap_comp.
+  rewrite iso_to_from.
+  rewrite id_left.
+  rewrite bimap_id_id.
+  rewrite id_right.
+  reflexivity.
+Qed.
+
+Lemma pentagon_solved_cons {u v w t z : C}
+      (k : z ~> ((u ⨂ (v ⨂ w)) ⨂ t)%object) :
+  to tensor_assoc ∘ ((tensor_assoc⁻¹ ⨂ id[t]) ∘ k)
+    ≈ tensor_assoc⁻¹
+        ∘ ((id[u] ⨂ to tensor_assoc)
+             ∘ (to (@tensor_assoc C _ u (v ⨂ w) t) ∘ k)).
+Proof.
+  rewrite !comp_assoc.
+  comp_right.
+  rewrite <- !comp_assoc.
+  apply pentagon_solved.
+Qed.
+
+Lemma pentagon_solved2 {u v w t : C} :
+  (id[u] ⨂ to tensor_assoc) ∘ to (@tensor_assoc C _ u (v ⨂ w) t)
+    ≈ to tensor_assoc
+        ∘ (to tensor_assoc ∘ (tensor_assoc⁻¹ ⨂ id[t])).
+Proof.
+  rewrite <- pentagon_cons.
+  rewrite <- bimap_comp.
+  rewrite iso_to_from, id_left, bimap_id_id, id_right.
+  reflexivity.
+Qed.
+
+Lemma pentagon_solved2_cons {u v w t z : C}
+      (k : z ~> ((u ⨂ (v ⨂ w)) ⨂ t)%object) :
+  (id[u] ⨂ to tensor_assoc) ∘ (to (@tensor_assoc C _ u (v ⨂ w) t) ∘ k)
+    ≈ to tensor_assoc
+        ∘ (to tensor_assoc ∘ ((tensor_assoc⁻¹ ⨂ id[t]) ∘ k)).
+Proof.
+  rewrite !comp_assoc.
+  comp_right.
+  rewrite <- !comp_assoc.
+  apply pentagon_solved2.
+Qed.
+
+Lemma pentagon_solved3 {u v w t : C} :
+  to (@tensor_assoc C _ u (v ⨂ w) t) ∘ (to tensor_assoc ⨂ id[t])
+    ≈ (id[u] ⨂ tensor_assoc⁻¹)
+        ∘ (to tensor_assoc ∘ to (@tensor_assoc C _ (u ⨂ v) w t)).
+Proof.
+  rewrite <- pentagon_a.
+  rewrite (bimap_id_cancel_cons tensor_assoc).
+  reflexivity.
+Qed.
+
+Lemma pentagon_solved3_cons {u v w t z : C}
+      (k : z ~> (((u ⨂ v) ⨂ w) ⨂ t)%object) :
+  to (@tensor_assoc C _ u (v ⨂ w) t) ∘ ((to tensor_assoc ⨂ id[t]) ∘ k)
+    ≈ (id[u] ⨂ tensor_assoc⁻¹)
+        ∘ (to tensor_assoc ∘ (to tensor_assoc ∘ k)).
+Proof.
+  rewrite !comp_assoc.
+  comp_right.
+  rewrite <- !comp_assoc.
+  apply pentagon_solved3.
+Qed.
+
+Lemma pentagon_from_solved {u v w t : C} :
+  tensor_assoc⁻¹
+    ∘ ((id[u] ⨂ tensor_assoc⁻¹) ∘ to (@tensor_assoc C _ u v (w ⨂ t)))
+    ≈ (to tensor_assoc ⨂ id[t]) ∘ tensor_assoc⁻¹.
+Proof.
+  apply (iso_to_epic tensor_assoc).
+  rewrite <- !comp_assoc.
+  rewrite iso_from_to, id_right.
+  rewrite <- pentagon_a.
+  rewrite (bimap_id_cancel_cons tensor_assoc).
+  rewrite (cancel_from_to_cons tensor_assoc).
+  reflexivity.
+Qed.
+
+Lemma pentagon_from_solved_cons {u v w t z : C}
+      (k : z ~> ((u ⨂ v) ⨂ (w ⨂ t))%object) :
+  tensor_assoc⁻¹
+    ∘ ((id[u] ⨂ tensor_assoc⁻¹)
+         ∘ (to (@tensor_assoc C _ u v (w ⨂ t)) ∘ k))
+    ≈ (to tensor_assoc ⨂ id[t]) ∘ (tensor_assoc⁻¹ ∘ k).
+Proof.
+  rewrite !comp_assoc.
+  comp_right.
+  rewrite <- !comp_assoc.
+  apply pentagon_from_solved.
+Qed.
+
+(* The pentagon, solved for α⁻¹ ∘ (id ⨂ α). *)
+Lemma pentagon_step {a b c e : C} :
+  (@tensor_assoc C _ a b (c ⨂ e))⁻¹ ∘ id[a] ⨂ to (@tensor_assoc C _ b c e)
+    ≈ to (@tensor_assoc C _ (a ⨂ b) c e)
+        ∘ (@tensor_assoc C _ a b c)⁻¹ ⨂ id[e]
+        ∘ (@tensor_assoc C _ a (b ⨂ c) e)⁻¹.
+Proof.
+  apply (iso_to_epic (@tensor_assoc C _ a (b ⨂ c)%object e)).
+  rewrite <- !comp_assoc.
+  rewrite iso_from_to, id_right.
+  assert (Ha : to (@tensor_assoc C _ a b c) ⨂ id[e]
+                 ∘ ((@tensor_assoc C _ a b c)⁻¹ ⨂ id[e])
+                 ≈ id[((a ⨂ (b ⨂ c)) ⨂ e)%object]).
+  { rewrite <- bimap_comp.
+    rewrite iso_to_from, id_left.
+    apply bimap_id_id. }
+  rewrite <- (id_right (id[a] ⨂ to (@tensor_assoc C _ b c e) ∘ to tensor_assoc)).
+  rewrite <- Ha.
+  rewrite (comp_assoc _ (to tensor_assoc ⨂ id[e])).
+  rewrite pentagon_identity.
+  rewrite !comp_assoc.
+  rewrite iso_from_to, id_left.
+  reflexivity.
+Qed.
+
+(** Triangle identities solved for the inverse unitors. *)
+
+(* α ∘ (ρ⁻¹ ⨂ id) ≈ id ⨂ λ⁻¹ : u ⨂ v ~> u ⨂ (I ⨂ v). *)
+Lemma triangle_inverse_middle {u v : C} :
+  to tensor_assoc ∘ (unit_right⁻¹ ⨂ id[v])
+    ≈ id[u] ⨂ unit_left⁻¹.
+Proof.
+  transitivity ((id[u] ⨂ unit_left⁻¹)
+                  ∘ ((id[u] ⨂ unit_left)
+                       ∘ (to tensor_assoc ∘ (unit_right⁻¹ ⨂ id[v])))).
+  - rewrite (comp_assoc (id[u] ⨂ unit_left⁻¹)).
+    rewrite <- bimap_comp.
+    rewrite iso_from_to.
+    rewrite id_left.
+    rewrite bimap_id_id.
+    rewrite id_left.
+    reflexivity.
+  - rewrite (comp_assoc (id[u] ⨂ unit_left)).
+    rewrite <- triangle_identity.
+    rewrite <- bimap_comp.
+    rewrite iso_to_from.
+    rewrite id_left.
+    rewrite bimap_id_id.
+    rewrite id_right.
+    reflexivity.
+Qed.
+
+(* α ∘ (λ⁻¹ ⨂ id) ≈ λ⁻¹ : u ⨂ v ~> I ⨂ (u ⨂ v). *)
+Lemma triangle_inverse_left {u v : C} :
+  to tensor_assoc ∘ (unit_left⁻¹ ⨂ id[v])
+    ≈ (@unit_left C _ (u ⨂ v))⁻¹.
+Proof.
+  transitivity (unit_left⁻¹
+                  ∘ (unit_left
+                       ∘ (to tensor_assoc ∘ ((@unit_left C _ u)⁻¹ ⨂ id[v])))).
+  - rewrite (comp_assoc (unit_left⁻¹)).
+    rewrite iso_from_to.
+    rewrite id_left.
+    reflexivity.
+  - rewrite (comp_assoc unit_left).
+    rewrite <- triangle_identity_left.
+    rewrite <- bimap_comp.
+    rewrite iso_to_from.
+    rewrite id_left.
+    rewrite bimap_id_id.
+    rewrite id_right.
+    reflexivity.
+Qed.
+
+(* α ∘ ρ⁻¹ ≈ id ⨂ ρ⁻¹ : a ⨂ b ~> a ⨂ (b ⨂ I). *)
+Lemma tensor_assoc_unit_right {a b : C} :
+  to (@tensor_assoc C _ a b I) ∘ unit_right⁻¹ ≈ id[a] ⨂ unit_right⁻¹.
+Proof.
+  apply (iso_to_epic (@unit_right C _ (a ⨂ b)%object)).
+  rewrite <- comp_assoc.
+  rewrite iso_from_to, id_right.
+  rewrite bimap_triangle_right.
+  rewrite comp_assoc.
+  rewrite <- bimap_comp.
+  rewrite iso_from_to.
+  rewrite id_left.
+  rewrite bimap_id_id, id_left.
+  reflexivity.
+Qed.
+
+(* α⁻¹ ∘ (id ⨂ λ⁻¹) ≈ ρ⁻¹ ⨂ id : a ⨂ b ~> (a ⨂ I) ⨂ b. *)
+Lemma tensor_assoc_from_unit_left {a b : C} :
+  (@tensor_assoc C _ a I b)⁻¹ ∘ id[a] ⨂ unit_left⁻¹ ≈ unit_right⁻¹ ⨂ id[b].
+Proof.
+  apply (iso_to_monic (@tensor_assoc C _ a I b)).
+  rewrite comp_assoc, iso_to_from, id_left.
+  (* id ⨂ λ⁻¹ ≈ α ∘ (ρ⁻¹ ⨂ id) *)
+  assert (Hr : @unit_right C _ a ⨂ id[b] ∘ ((@unit_right C _ a)⁻¹ ⨂ id[b])
+                 ≈ id[(a ⨂ b)%object]).
+  { rewrite <- bimap_comp.
+    rewrite iso_to_from, id_left.
+    apply bimap_id_id. }
+  rewrite <- (id_right (id[a] ⨂ unit_left⁻¹)).
+  rewrite <- Hr.
+  rewrite comp_assoc.
+  rewrite triangle_identity.
+  rewrite !comp_assoc.
+  rewrite <- bimap_comp.
+  rewrite iso_from_to, id_left.
+  rewrite bimap_id_id, id_left.
+  reflexivity.
+Qed.
+
+(* Kelly's [unit_identity], inverted: λ_I⁻¹ ≈ ρ_I⁻¹. *)
+Lemma unit_identity_from :
+  (@unit_left C _ I)⁻¹ ≈ (@unit_right C _ I)⁻¹.
+Proof.
+  apply (iso_to_monic unit_left).
+  rewrite iso_to_from.
+  rewrite unit_identity.
+  rewrite iso_to_from.
+  reflexivity.
+Qed.
+
+End MonoidalToolkit.
+
+(* ------------------------------------------------------------------ *)
+
+Section BraidedUnitors.
+
+Context {C : Category}.
+Context `{S : @SymmetricMonoidal C}.
+
+(* In a symmetric monoidal category the braiding is self-inverse
+   ([braid_invol]), hence [braid ⨂ id] is invertible and in particular epic:
+   a trailing [braid ⨂ id] may be cancelled on the right. *)
+Lemma braid_id_cancel {x y z w} (f g : (y ⨂ x) ⨂ z ~> w) :
+  f ∘ braid ⨂ id[z] ≈ g ∘ braid ⨂ id[z] → f ≈ g.
+Proof.
+  intro H1.
+  assert (H2 : f ∘ braid ⨂ id[z] ∘ braid ⨂ id[z]
+                 ≈ g ∘ braid ⨂ id[z] ∘ braid ⨂ id[z])
+    by (rewrite H1; reflexivity).
+  rewrite <- !comp_assoc in H2.
+  rewrite <- !bimap_comp in H2.
+  rewrite !braid_invol in H2.
+  rewrite !id_left in H2.
+  rewrite !bimap_id_id in H2.
+  rewrite !id_right in H2.
+  exact H2.
+Qed.
+
+(* Joyal & Street, Proposition 2.1: the right unitor is the left unitor
+   composed with the braiding, ρ_x ≈ λ_x ∘ β_{x,I}. *)
+Theorem braid_unit_left {x : C} :
+  unit_left ∘ braid << x ⨂ I ~~> x >> unit_right.
+Proof.
+  apply tensor_id_left_inj.
+  apply (iso_to_epic tensor_assoc).
+  apply braid_id_cancel.
+  (* Expose the right-hand side of the hexagon at (x, I, I). *)
+  rewrite bimap_comp_id_left.
+  rewrite <- !comp_assoc.
+  rewrite (comp_assoc (id[I] ⨂ braid)).
+  rewrite <- hexagon_identity.
+  rewrite !comp_assoc.
+  (* Contract the left-hand side: triangle, braid naturality, then the
+     derived triangle ρ_{x ⨂ I} ≈ (id ⨂ ρ) ∘ α. *)
+  rewrite <- triangle_identity.
+  rewrite bimap_braid.
+  (* Contract the right-hand side to β ∘ ρ via ρ's naturality. *)
+  rewrite <- bimap_triangle_right.
+  rewrite <- to_unit_right_natural.
+  rewrite <- comp_assoc.
+  rewrite <- bimap_triangle_right.
+  reflexivity.
+Qed.
+
+(* The mirror coherence: λ_x ≈ ρ_x ∘ β_{I,x}, from [braid_unit_left] by
+   pre-composing with the braiding and cancelling via [braid_invol]. *)
+Theorem braid_unit_right {x : C} :
+  unit_right ∘ braid << I ⨂ x ~~> x >> unit_left.
+Proof.
+  rewrite <- braid_unit_left.
+  rewrite <- comp_assoc.
+  rewrite braid_invol.
+  apply id_right.
+Qed.
+
+(* [braid_unit_left] shuffled across the inverses: β_{x,I} ∘ ρ⁻¹ ≈ λ⁻¹. *)
+Corollary braid_unit_left_from {x : C} :
+  braid ∘ unit_right⁻¹ << x ~~> I ⨂ x >> unit_left⁻¹.
+Proof.
+  apply (iso_to_monic unit_left).
+  rewrite comp_assoc.
+  rewrite braid_unit_left.
+  rewrite !iso_to_from.
+  reflexivity.
+Qed.
+
+(* [braid_unit_right] shuffled across the inverses: β_{I,x} ∘ λ⁻¹ ≈ ρ⁻¹. *)
+Corollary braid_unit_right_from {x : C} :
+  braid ∘ unit_left⁻¹ << x ~~> x ⨂ I >> unit_right⁻¹.
+Proof.
+  apply (iso_to_monic unit_right).
+  rewrite comp_assoc.
+  rewrite braid_unit_right.
+  rewrite !iso_to_from.
+  reflexivity.
+Qed.
+
+(* On the unit object the braiding degenerates to the identity: combine
+   [braid_unit_left] at x := I with Kelly's [unit_identity] (λ_I ≈ ρ_I) and
+   cancel the monic λ_I. *)
+Corollary braid_I_I : braid << I ⨂ I ~~> I ⨂ I >> id.
+Proof.
+  apply (iso_to_monic unit_left).
+  rewrite braid_unit_left.
+  rewrite id_right.
+  symmetry.
+  apply unit_identity.
+Qed.
+
+End BraidedUnitors.
+
+(* ------------------------------------------------------------------ *)
+
+(** ** The middle interchange and its coherence
+
+    [swap_inner a b c d : (a ⨂ b) ⨂ (c ⨂ d) ~> (a ⨂ c) ⨂ (b ⨂ d)] braids
+    the two middle factors.  The three coherence laws [swap_inner_braid],
+    [swap_inner_assoc] (via the two nesting laws [swap_inner_nested] /
+    [swap_inner_nested2]) and [swap_inner_unit_left] /
+    [swap_inner_unit_right] are precisely the conditions making the
+    squaring functor [x ↦ x ⨂ x] of a symmetric monoidal category
+    symmetric (strong) monoidal.  The diagonal [swap_inner x x y y] is
+    definitionally Hypergraph.v's [mid_swap_inv]; that identification
+    ([swap_inner_diag]) and its corollaries live in
+    Structure/Monoidal/CopyDiscard/Deterministic.v, keeping this file
+    independent of the hypergraph stack.
+
+    Mirror forms are kept as citable API even where currently unconsumed
+    in-tree: [braid_I_right], [braid_conjugate_right]. *)
+
+Section Interchange.
+
+Context {C : Category}.
+Context `{S : @SymmetricMonoidal C}.
+
+(** Hexagon shapes. *)
+
+Lemma hexagon_a {u v w : C} :
+  to tensor_assoc ∘ (@braid C _ u (v ⨂ w)%object ∘ to tensor_assoc)
+    ≈ (id[v] ⨂ braid) ∘ (to tensor_assoc ∘ (braid ⨂ id[w])).
+Proof.
+  rewrite !comp_assoc.
+  apply hexagon_identity.
+Qed.
+
+(* Braiding an object out of a tensor on its right, solved form. *)
+Lemma hexagon_a_solved {u v w : C} :
+  @braid C _ u (v ⨂ w)%object
+    ≈ tensor_assoc⁻¹
+        ∘ ((id[v] ⨂ braid)
+             ∘ (to tensor_assoc
+                  ∘ ((@braid C _ u v ⨂ id[w]) ∘ tensor_assoc⁻¹))).
+Proof.
+  apply (iso_to_monic tensor_assoc).
+  rewrite (cancel_to_from_cons tensor_assoc).
+  apply (iso_to_epic tensor_assoc).
+  rewrite <- !comp_assoc.
+  rewrite iso_from_to, id_right.
+  rewrite !comp_assoc.
+  apply hexagon_identity.
+Qed.
+
+(* Braiding a tensor past an object, solved form. *)
+Lemma hexagon_b {u v w : C} :
+  @braid C _ (u ⨂ v)%object w
+    ≈ to tensor_assoc
+        ∘ ((@braid C _ u w ⨂ id[v])
+             ∘ (tensor_assoc⁻¹
+                  ∘ ((id[u] ⨂ @braid C _ v w) ∘ to tensor_assoc))).
+Proof.
+  apply (iso_from_monic tensor_assoc).
+  rewrite (cancel_from_to_cons tensor_assoc).
+  apply (iso_to_epic (iso_sym tensor_assoc)).
+  rewrite <- !comp_assoc.
+  rewrite iso_to_from.
+  rewrite id_right.
+  rewrite comp_assoc.
+  rewrite hexagon_identity_sym.
+  rewrite !comp_assoc.
+  reflexivity.
+Qed.
+
+(* The rotated hexagon of Symmetric.v, post-composed with the braiding it
+   rotates around: the two inner braids cancel by [braid_invol]. *)
+Lemma braid_rotate_cancel {u v w : C} :
+  to tensor_assoc ∘ (@braid C _ u v ⨂ id[w]) ∘ tensor_assoc⁻¹
+    ∘ @braid C _ (v ⨂ w)%object u
+    ≈ (id[v] ⨂ @braid C _ w u) ∘ to tensor_assoc.
+Proof.
+  rewrite hexagon_rotated.
+  rewrite <- comp_assoc.
+  rewrite braid_invol.
+  apply id_right.
+Qed.
+
+Lemma braid_rotate_cancel_cons {h u v w z : C}
+      (k : z ~> (h ⨂ ((v ⨂ w) ⨂ u))%object) :
+  (id[h] ⨂ to tensor_assoc)
+    ∘ ((id[h] ⨂ (@braid C _ u v ⨂ id[w]))
+         ∘ ((id[h] ⨂ tensor_assoc⁻¹)
+              ∘ ((id[h] ⨂ @braid C _ (v ⨂ w)%object u) ∘ k)))
+    ≈ (id[h] ⨂ (id[v] ⨂ @braid C _ w u))
+        ∘ ((id[h] ⨂ to tensor_assoc) ∘ k).
+Proof.
+  rewrite !comp_assoc.
+  normal.
+  comp_right.
+  bimap_left.
+  apply braid_rotate_cancel.
+Qed.
+
+(** Braiding against the unit object, solved for the braid. *)
+
+Lemma braid_I_left {x : C} :
+  @braid C _ I x ≈ unit_right⁻¹ ∘ unit_left.
+Proof.
+  apply (iso_to_monic unit_right).
+  rewrite braid_unit_right.
+  rewrite comp_assoc.
+  rewrite iso_to_from; cat.
+Qed.
+
+Lemma braid_I_right {x : C} :
+  @braid C _ x I ≈ unit_left⁻¹ ∘ unit_right.
+Proof.
+  apply (iso_to_monic unit_left).
+  rewrite braid_unit_left.
+  rewrite comp_assoc.
+  rewrite iso_to_from; cat.
+Qed.
+
+(* The middle conjugate of [swap_inner I I x x]: braiding I past x between
+   two associators is a unitor shuffle. *)
+Lemma braid_conjugate_left {x : C} :
+  to tensor_assoc ∘ (@braid C _ I x ⨂ id[x]) ∘ tensor_assoc⁻¹
+    ≈ (id[x] ⨂ unit_left⁻¹) ∘ unit_left.
+Proof.
+  rewrite braid_I_left.
+  rewrite bimap_comp_id_right.
+  rewrite comp_assoc.
+  rewrite triangle_inverse_middle.
+  rewrite <- comp_assoc.
+  rewrite <- bimap_triangle_left.
+  reflexivity.
+Qed.
+
+(* Mirror image, kept as citable API (see the section header). *)
+Lemma braid_conjugate_right {x : C} :
+  to tensor_assoc ∘ (@braid C _ x I ⨂ id[I]) ∘ tensor_assoc⁻¹
+    ≈ unit_left⁻¹ ∘ (id[x] ⨂ unit_left).
+Proof.
+  rewrite braid_I_right.
+  rewrite bimap_comp_id_right.
+  rewrite comp_assoc.
+  rewrite triangle_inverse_left.
+  rewrite <- comp_assoc.
+  rewrite <- inverse_triangle_identity.
+  reflexivity.
+Qed.
+
+(** *** The interchange of four objects *)
+
+Definition swap_inner (a b c d : C) :
+  (a ⨂ b) ⨂ (c ⨂ d) ~> (a ⨂ c) ⨂ (b ⨂ d) :=
+  (@tensor_assoc C _ a c (b ⨂ d))⁻¹
+    ∘ bimap id[a] (to (@tensor_assoc C _ c b d))
+    ∘ bimap id[a] (bimap (@braid C _ b c) id[d])
+    ∘ bimap id[a] ((@tensor_assoc C _ b c d)⁻¹)
+    ∘ to (@tensor_assoc C _ a b (c ⨂ d)).
+
+Lemma swap_inner_unfold {a b c d : C} :
+  (@tensor_assoc C _ a c (b ⨂ d))⁻¹
+    ∘ bimap id[a] (to (@tensor_assoc C _ c b d))
+    ∘ bimap id[a] (bimap (@braid C _ b c) id[d])
+    ∘ bimap id[a] ((@tensor_assoc C _ b c d)⁻¹)
+    ∘ to (@tensor_assoc C _ a b (c ⨂ d))
+    ≈ swap_inner a b c d.
+Proof. reflexivity. Qed.
+
+(* Naturality of the interchange in its first argument. *)
+Lemma swap_inner_nat1 {a a' b c d : C} (f : a ~> a') :
+  ((f ⨂ id[c]) ⨂ id[(b ⨂ d)%object]) ∘ swap_inner a b c d
+    ≈ swap_inner a' b c d ∘ ((f ⨂ id[b]) ⨂ id[(c ⨂ d)%object]).
+Proof.
+  unfold swap_inner.
+  rewrite <- !comp_assoc.
+  rewrite from_assoc_nat_cons.
+  rewrite bimap_id_id.
+  rewrite !bimap_swap2_cons.
+  spose (to_tensor_assoc_natural f (id[b]) (id[(c ⨂ d)%object])) as X1.
+  rewrite bimap_id_id in X1.
+  rewrite X1.
+  reflexivity.
+Qed.
+
+(** Compatibility of the interchange with the braiding: braiding the two
+    tensor pairs and interchanging equals interchanging and braiding
+    pairwise. *)
+Lemma swap_inner_braid {a b c d : C} :
+  swap_inner c d a b ∘ braid
+    ≈ (@braid C _ a c ⨂ @braid C _ b d) ∘ swap_inner a b c d.
+Proof.
+  apply (iso_to_epic tensor_assoc).
+  unfold swap_inner.
+  rewrite <- !comp_assoc.
+  rewrite hexagon_a.
+  rewrite braid_rotate_cancel_cons.
+  rewrite hexagon_b.
+  rewrite !bimap_comp_id_right.
+  rewrite pentagon_cons.
+  rewrite to_assoc_nat_cons.
+  rewrite bimap_id_id.
+  rewrite (cancel_from_to_cons tensor_assoc).
+  rewrite <- to_assoc_nat_cons.
+  rewrite bimap_id_id.
+  rewrite bimap_swap_cons.
+  rewrite <- pentagon_a.
+  rewrite (bimap_id_cancel_cons tensor_assoc).
+  rewrite to_assoc_nat_cons.
+  comp_left.
+  rewrite !comp_assoc.
+  comp_right.
+  comp_right.
+  rewrite pentagon_solved.
+  rewrite !comp_assoc.
+  reflexivity.
+Qed.
+
+(** The first nesting law: interchanging under a fixed leading tensorand
+    equals interchanging with the merged pair.  Pure pentagon bookkeeping
+    (the braid inside is inert). *)
+Lemma swap_inner_nested {u v w e f : C} :
+  tensor_assoc⁻¹ ∘ ((id[u] ⨂ swap_inner v w e f) ∘ to tensor_assoc)
+    ≈ (to tensor_assoc ⨂ id[(w ⨂ f)%object])
+        ∘ (swap_inner (u ⨂ v) w e f ∘ (tensor_assoc⁻¹ ⨂ id[(e ⨂ f)%object])).
+Proof.
+  unfold swap_inner.
+  rewrite <- !comp_assoc.
+  rewrite !bimap_comp_id_left.
+  rewrite <- !comp_assoc.
+  rewrite pentagon_solved2.
+  rewrite !to_assoc_nat_cons.
+  rewrite !bimap_id_id.
+  rewrite pentagon_from_solved_cons.
+  reflexivity.
+Qed.
+
+Lemma swap_inner_nested_cons {u v w e f z : C}
+      (k : z ~> ((u ⨂ (v ⨂ w)) ⨂ (e ⨂ f))%object) :
+  tensor_assoc⁻¹
+    ∘ ((id[u] ⨂ swap_inner v w e f) ∘ (to tensor_assoc ∘ k))
+    ≈ (to tensor_assoc ⨂ id[(w ⨂ f)%object])
+        ∘ (swap_inner (u ⨂ v) w e f
+             ∘ ((tensor_assoc⁻¹ ⨂ id[(e ⨂ f)%object]) ∘ k)).
+Proof.
+  rewrite !comp_assoc.
+  comp_right.
+  rewrite <- !comp_assoc.
+  apply swap_inner_nested.
+Qed.
+
+(* [swap_inner_nested] solved for the merged interchange. *)
+Lemma swap_inner_unnest {u v w e f : C} :
+  swap_inner (u ⨂ v) w e f
+    ≈ (tensor_assoc⁻¹ ⨂ id[(w ⨂ f)%object])
+        ∘ (tensor_assoc⁻¹
+             ∘ ((id[u] ⨂ swap_inner v w e f)
+                  ∘ (to tensor_assoc
+                       ∘ (to tensor_assoc ⨂ id[(e ⨂ f)%object])))).
+Proof.
+  rewrite swap_inner_nested_cons.
+  rewrite (bimap_cancel_right_cons tensor_assoc).
+  rewrite (bimap_cancel_right tensor_assoc).
+  rewrite id_right.
+  reflexivity.
+Qed.
+
+(** The second nesting law: merging the second tensorand of the first
+    pair.  Again pure pentagon bookkeeping around [hexagon_b]. *)
+Lemma swap_inner_nested2 {u v w e f : C} :
+  swap_inner u v e (w ⨂ f)
+    ∘ (to tensor_assoc ∘ swap_inner (u ⨂ v) w e f)
+    ≈ (id[(u ⨂ e)%object] ⨂ to tensor_assoc)
+        ∘ (swap_inner u (v ⨂ w) e f ∘ (to tensor_assoc ⨂ id[(e ⨂ f)%object])).
+Proof.
+  unfold swap_inner.
+  rewrite <- !comp_assoc.
+  rewrite (cancel_to_from_cons tensor_assoc).
+  rewrite !to_assoc_nat_id2_cons.
+  rewrite hexagon_b.
+  rewrite !bimap_comp_id_right.
+  rewrite !bimap_id_split_cons.
+  rewrite (bimap_id_fuse_cons (to tensor_assoc ⨂ id[f]) (tensor_assoc⁻¹)).
+  rewrite <- pentagon_from_solved.
+  rewrite !bimap_id_split_cons.
+  rewrite pentagon_solved2_cons.
+  rewrite (bimap_cancel_right tensor_assoc).
+  rewrite id_right.
+  rewrite from_assoc_nat_id2_cons.
+  comp_left.
+  rewrite !bimap_id_fuse_cons.
+  rewrite !comp_assoc.
+  comp_right.
+  comp_right.
+  bimap_left.
+  rewrite <- !comp_assoc.
+  rewrite pentagon_cons.
+  comp_left.
+  rewrite <- to_assoc_nat_cons.
+  rewrite bimap_id_id.
+  comp_left.
+  rewrite pentagon_solved_cons.
+  comp_left.
+  comp_left.
+  rewrite <- to_assoc_nat_cons.
+  rewrite (cancel_to_from_cons tensor_assoc).
+  reflexivity.
+Qed.
+
+Lemma swap_inner_nested2_cons {u v w e f z : C}
+      (k : z ~> (((u ⨂ v) ⨂ w) ⨂ (e ⨂ f))%object) :
+  swap_inner u v e (w ⨂ f)
+    ∘ (to tensor_assoc ∘ (swap_inner (u ⨂ v) w e f ∘ k))
+    ≈ (id[(u ⨂ e)%object] ⨂ to tensor_assoc)
+        ∘ (swap_inner u (v ⨂ w) e f
+             ∘ ((to tensor_assoc ⨂ id[(e ⨂ f)%object]) ∘ k)).
+Proof.
+  rewrite !comp_assoc.
+  comp_right.
+  rewrite <- !comp_assoc.
+  apply swap_inner_nested2.
+Qed.
+
+(** The core coherence behind associativity: interchanging with a merged
+    leading pair equals interchanging with a merged middle pair. *)
+Lemma swap_inner_core {b c d e f : C} :
+  to tensor_assoc
+    ∘ ((@braid C _ b (c ⨂ e)%object ⨂ id[(d ⨂ f)%object])
+         ∘ ((to tensor_assoc ⨂ id[(d ⨂ f)%object])
+              ∘ swap_inner (b ⨂ c) d e f))
+    ≈ (id[(c ⨂ e)%object] ⨂ to tensor_assoc)
+        ∘ (swap_inner c (b ⨂ d) e f
+             ∘ ((to tensor_assoc ⨂ id[(e ⨂ f)%object])
+                  ∘ (((@braid C _ b c ⨂ id[d]) ⨂ id[(e ⨂ f)%object])))).
+Proof.
+  rewrite hexagon_a_solved.
+  rewrite !bimap_comp_id_right.
+  rewrite <- !comp_assoc.
+  rewrite (bimap_cancel_right_cons tensor_assoc).
+  rewrite pentagon_solved_cons.
+  rewrite <- to_assoc_nat_cons.
+  rewrite pentagon_solved3_cons.
+  rewrite (swap_inner_nat1 braid).
+  rewrite !comp_assoc.
+  rewrite swap_inner_unfold.
+  rewrite <- !comp_assoc.
+  rewrite swap_inner_nested2_cons.
+  reflexivity.
+Qed.
+
+(* Left side of the associativity hexagon, reduced to nested form. *)
+Lemma swap_inner_assoc_l {a b c d e f : C} :
+  swap_inner a b (c ⨂ e) (d ⨂ f)
+    ∘ ((id[(a ⨂ b)%object] ⨂ swap_inner c d e f) ∘ to tensor_assoc)
+    ≈ tensor_assoc⁻¹
+        ∘ ((id[a]
+              ⨂ (to tensor_assoc
+                   ∘ ((@braid C _ b (c ⨂ e)%object ⨂ id[(d ⨂ f)%object])
+                        ∘ ((to tensor_assoc ⨂ id[(d ⨂ f)%object])
+                             ∘ (swap_inner (b ⨂ c) d e f
+                                  ∘ (tensor_assoc⁻¹ ⨂ id[(e ⨂ f)%object]))))))
+             ∘ (to tensor_assoc ∘ (to tensor_assoc ⨂ id[(e ⨂ f)%object]))).
+Proof.
+  unfold swap_inner at 1.
+  rewrite <- !comp_assoc.
+  rewrite to_assoc_nat_id2_cons.
+  rewrite <- pentagon_a.
+  rewrite !bimap_id_fuse_cons.
+  rewrite <- !comp_assoc.
+  rewrite swap_inner_nested.
+  reflexivity.
+Qed.
+
+(* Right side of the associativity hexagon, reduced to nested form. *)
+Lemma swap_inner_assoc_r {a b c d e f : C} :
+  (to tensor_assoc ⨂ to tensor_assoc)
+    ∘ (swap_inner (a ⨂ c) (b ⨂ d) e f
+         ∘ (swap_inner a b c d ⨂ id[(e ⨂ f)%object]))
+    ≈ tensor_assoc⁻¹
+        ∘ ((id[a]
+              ⨂ ((id[(c ⨂ e)%object] ⨂ to tensor_assoc)
+                   ∘ (swap_inner c (b ⨂ d) e f
+                        ∘ ((to tensor_assoc ⨂ id[(e ⨂ f)%object])
+                             ∘ (((@braid C _ b c ⨂ id[d]) ⨂ id[(e ⨂ f)%object])
+                                  ∘ (tensor_assoc⁻¹ ⨂ id[(e ⨂ f)%object]))))))
+             ∘ (to tensor_assoc ∘ (to tensor_assoc ⨂ id[(e ⨂ f)%object]))).
+Proof.
+  rewrite swap_inner_unnest.
+  rewrite <- !comp_assoc.
+  rewrite (bimap_fuse_cons (to tensor_assoc) (to tensor_assoc) (tensor_assoc⁻¹)).
+  rewrite iso_to_from.
+  rewrite id_right.
+  rewrite from_assoc_nat_id2_cons.
+  rewrite (bimap_fuse_id_right (to tensor_assoc) (swap_inner a b c d)).
+  unfold swap_inner at 2.
+  rewrite <- !comp_assoc.
+  rewrite (cancel_to_from_cons tensor_assoc).
+  rewrite !bimap_comp_id_right.
+  rewrite <- !to_assoc_nat_cons.
+  rewrite !bimap_id_fuse_cons.
+  rewrite <- !comp_assoc.
+  reflexivity.
+Qed.
+
+(** Associativity of the interchange — the associativity hexagon for the
+    squaring functor's monoidal structure. *)
+Theorem swap_inner_assoc {a b c d e f : C} :
+  swap_inner a b (c ⨂ e) (d ⨂ f)
+    ∘ ((id[(a ⨂ b)%object] ⨂ swap_inner c d e f) ∘ to tensor_assoc)
+    ≈ (to tensor_assoc ⨂ to tensor_assoc)
+        ∘ (swap_inner (a ⨂ c) (b ⨂ d) e f
+             ∘ (swap_inner a b c d ⨂ id[(e ⨂ f)%object])).
+Proof.
+  rewrite swap_inner_assoc_l.
+  rewrite swap_inner_assoc_r.
+  comp_left.
+  rewrite !comp_assoc.
+  comp_right.
+  comp_right.
+  bimap_left.
+  comp_right.
+  rewrite <- !comp_assoc.
+  apply swap_inner_core.
+Qed.
+
+(** *** Unit coherence of the interchange *)
+
+(* The unit coherence, left form: conjugating [swap_inner I I x x] by the
+   canonical unit isomorphisms is the left unitor. *)
+Lemma swap_inner_unit_left {x : C} :
+  (unit_left ⨂ unit_left) ∘ swap_inner I I x x
+    ∘ (unit_left⁻¹ ⨂ id[(x ⨂ x)%object])
+    ≈ @unit_left C _ (x ⨂ x).
+Proof.
+  unfold swap_inner.
+  normal.
+  rewrite braid_conjugate_left.
+  rewrite unit_identity_from.
+  rewrite <- !comp_assoc.
+  rewrite triangle_inverse_middle.
+  assert (E : (id[I] ⨂ ((id[x] ⨂ (@unit_left C _ x)⁻¹) ∘ unit_left))
+                ∘ (id[I] ⨂ (@unit_left C _ (x ⨂ x))⁻¹)
+                ≈ id[I] ⨂ (id[x] ⨂ (@unit_left C _ x)⁻¹)).
+  { rewrite <- bimap_comp_id_left.
+    bimap_left.
+    rewrite <- comp_assoc.
+    rewrite iso_to_from.
+    apply id_right. }
+  rewrite E; clear E.
+  rewrite <- from_tensor_assoc_natural.
+  rewrite bimap_id_id.
+  rewrite comp_assoc.
+  rewrite <- bimap_comp.
+  rewrite iso_to_from.
+  rewrite id_right.
+  rewrite <- bimap_triangle_left.
+  reflexivity.
+Qed.
+
+(* The unit coherence, right form, derived from the left form through the
+   braid compatibility. *)
+Lemma swap_inner_unit_right {x : C} :
+  (unit_right ⨂ unit_right) ∘ swap_inner x x I I
+    ∘ (id[(x ⨂ x)%object] ⨂ unit_left⁻¹)
+    ≈ @unit_right C _ (x ⨂ x).
+Proof.
+  rewrite <- (id_right (swap_inner x x I I)).
+  rewrite <- (braid_invol (x := (x ⨂ x)%object) (y := (I ⨂ I)%object)).
+  rewrite (comp_assoc (swap_inner x x I I)).
+  rewrite swap_inner_braid.
+  rewrite <- !comp_assoc.
+  rewrite <- bimap_braid.
+  rewrite bimap_fuse_cons.
+  rewrite !braid_unit_right.
+  rewrite !comp_assoc.
+  rewrite swap_inner_unit_left.
+  apply braid_unit_left.
+Qed.
+
+End Interchange.

--- a/Structure/Monoidal/Collapse.v
+++ b/Structure/Monoidal/Collapse.v
@@ -1,0 +1,539 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Theory.Naturality.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Monoidal.Proofs.
+Require Import Category.Structure.Monoidal.Braided.
+Require Import Category.Structure.Monoidal.Symmetric.
+Require Import Category.Structure.Monoidal.Braided.Proofs.
+Require Import Category.Structure.Monoidal.Relevance.
+Require Import Category.Structure.Monoidal.Semicartesian.
+Require Import Category.Structure.Monoidal.Semicartesian.Proofs.
+Require Import Category.Structure.Monoidal.CompactClosed.
+Require Import Category.Structure.Monoidal.Heunen_Vicary.
+Require Import Category.Theory.Algebra.Monoid.
+Require Import Category.Theory.Algebra.Comonoid.
+Require Import Category.Theory.Algebra.Frobenius.
+
+Generalizable All Variables.
+
+(** * Collapse theorems for over-structured tensors
+
+    Two classical "no-go" results delimiting how much algebraic structure a
+    monoidal category can carry before it degenerates.  Both are theorems
+    about *seam discipline*: they are the mathematical reason copying
+    (comonoid/Frobenius) structure must be withheld from a tensor that is
+    already cartesian, and uniform copying must be withheld from a tensor
+    that is compact closed.
+
+    1. Frobenius collapse: a Frobenius object in a semicartesian (in
+       particular, cartesian) monoidal category is isomorphic to the unit.
+
+    2. Abramsky's no-cloning theorem (arXiv:0910.2401): in a compact closed
+       category, uniform copying — a natural, monoidal, coassociative,
+       cocommutative diagonal, i.e. exactly a [RelevanceMonoidal] structure —
+       forces the braiding at every diagonal square to be the identity.
+
+    nLab: https://ncatlab.org/nlab/show/Frobenius+algebra
+    nLab: https://ncatlab.org/nlab/show/no-cloning+theorem *)
+
+(** ** Frobenius objects collapse in (semi)cartesian monoidal categories
+
+    Let (X, μ, η, δ, ε) be a Frobenius algebra in a monoidal category whose
+    unit I is terminal ([SemicartesianMonoidal]).  Terminality identifies ε
+    with the discard map, so the comonoid counit laws say precisely that the
+    projections retract δ.  Projecting the Frobenius law
+
+        (μ ⨂ id) ∘ α⁻¹ ∘ (id ⨂ δ) ≈ δ ∘ μ
+
+    with proj_right then collapses the multiplication: μ ≈ proj_right (in
+    generalized-element notation, μ(x, y) = y).  Evaluating the monoid's
+    right unit law at that equation yields η ∘ ε ≈ id, and ε ∘ η ≈ id[I]
+    holds by terminality, so ε : X ≅ I : η.
+
+    The cartesian case (Fox's setting, where the tensor is the product) is
+    the instance used by the seam-discipline arguments: a cartesian colour
+    cannot host a Frobenius algebra on any object except (up to iso) the
+    unit.  Note the proof below never uses the diagonal: semicartesian
+    suffices. *)
+
+Section FrobeniusCollapse.
+
+Context {C : Category}.
+Context `{M : @Monoidal C}.
+Context `{SM : @SemicartesianMonoidal C M}.
+
+(* The counit of any comonoid is the discard map (both live in the terminal
+   hom-set X ~> I), so the left counit law makes proj_right retract delta. *)
+Lemma proj_right_delta {X : C} (Co : Comonoid X) :
+  proj_right ∘ delta[Co] ≈ id[X].
+Proof.
+  unfold proj_right.
+  rewrite <- comp_assoc.
+  rewrite (unit_terminal (@eliminate C M SM X) epsilon[Co]).
+  rewrite (delta_counit_left (Comonoid := Co)).
+  apply iso_to_from.
+Qed.
+
+(* Mirror image: proj_left retracts delta via the right counit law. *)
+Lemma proj_left_delta {X : C} (Co : Comonoid X) :
+  proj_left ∘ delta[Co] ≈ id[X].
+Proof.
+  unfold proj_left.
+  rewrite <- comp_assoc.
+  rewrite (unit_terminal (@eliminate C M SM X) epsilon[Co]).
+  rewrite (delta_counit_right (Comonoid := Co)).
+  apply iso_to_from.
+Qed.
+
+Section FrobeniusObject.
+
+Context {X : C}.
+Context (F : @Frobenius C M X).
+
+(* Projecting the left Frobenius law with proj_right collapses the
+   multiplication to the right projection: μ(x, y) = y on generalized
+   elements.  (Dually, the right Frobenius law would give μ ≈ proj_left.) *)
+Lemma frobenius_mu_collapse : mu[F] ≈ @proj_right C M SM X X.
+Proof.
+  rewrite <- (id_left (mu[F])).
+  rewrite <- (proj_right_delta F).
+  rewrite <- comp_assoc.
+  rewrite <- (frob_law_left (Frobenius := F)).
+  rewrite !comp_assoc.
+  rewrite proj_right_natural.
+  rewrite id_left.
+  rewrite <- proj_right_right.
+  rewrite <- comp_assoc.
+  rewrite proj_right_natural.
+  rewrite comp_assoc.
+  rewrite (proj_right_delta F).
+  apply id_left.
+Qed.
+
+(* The monoid's right unit law μ ∘ (id ⨂ η) ≈ ρ evaluated at
+   μ ≈ proj_right forces η to be a two-sided inverse of ε on X. *)
+Lemma frobenius_eta_epsilon : eta[F] ∘ epsilon[F] ≈ id[X].
+Proof using C F M SM X.
+  pose proof (mu_unit_right (Monoid := F)) as MU.
+  rewrite frobenius_mu_collapse in MU.
+  rewrite proj_right_natural in MU.
+  rewrite (unit_terminal epsilon[F] (proj_right ∘ unit_right⁻¹)).
+  rewrite comp_assoc.
+  rewrite MU.
+  apply iso_to_from.
+Qed.
+
+(* A Frobenius object in a semicartesian monoidal category is isomorphic to
+   the monoidal unit, with the counit and unit of the Frobenius structure as
+   the two directions. *)
+Theorem frobenius_collapse_semicartesian : X ≅ I.
+Proof using C F M SM X.
+  isomorphism.
+  - exact (epsilon[F]).
+  - exact (eta[F]).
+  - apply unit_terminal.
+  - apply frobenius_eta_epsilon.
+Qed.
+
+End FrobeniusObject.
+
+End FrobeniusCollapse.
+
+(* The cartesian instance (§2 #7): in a cartesian monoidal category — where
+   the tensor is the categorical product — every Frobenius object collapses
+   to the terminal unit.  This is the load-bearing form for seam-discipline
+   rule 2: no special commutative Frobenius structure can live on a colour
+   whose ambient tensor is cartesian. *)
+Theorem frobenius_collapse {C : Category} `{H : @CartesianMonoidal C} {X : C}
+        (F : @Frobenius C _ X) : X ≅ I.
+Proof.
+  exact (frobenius_collapse_semicartesian F).
+Qed.
+
+(** ** Abramsky's no-cloning theorem
+
+    Abramsky, "No-Cloning in categorical quantum mechanics" (arXiv:0910.2401),
+    §4.  Uniform copying in a symmetric monoidal category is a monoidal
+    natural diagonal that is coassociative and cocommutative — precisely the
+    [RelevanceMonoidal] structure: [diagonal_natural] (naturality),
+    [diagonal_unit] (∆I = λ⁻¹) and [diagonal_braid2] (monoidality),
+    [diagonal_tensor_assoc] (coassociativity), [braid_diagonal]
+    (cocommutativity).
+
+    The theorem: if such a category is moreover compact closed, the braiding
+    σ_{x,x} on every diagonal square is the identity ("the twist map is the
+    identity", the boxed Second Step of op. cit.), from which Abramsky's
+    Theorem 11 (every endomorphism is a scalar multiple of the identity)
+    follows.  The proof formalized here reorganizes the paper's Lemma 13:
+
+    1. Copying the cup η : I ~> x* ⨂ x and regrouping by colour shows the
+       two-cup state braid2 ∘ (η ⨂ η) ∘ λ⁻¹ *is* the copied state
+       (∆x* ⨂ ∆x) ∘ η          ([cups_mid_diagonal]);
+
+    2. cocommutativity of ∆x therefore lets the two x-wires of the two-cup
+       state be swapped silently  ([cups_mid_braid]) — the "confusion of
+       entanglements";
+
+    3. capping each input x-wire against one of the two duals turns that
+       silent swap into σ ∘ - on the outputs ([close_braid]), while a double
+       yanking evaluates the closure of the two-cup state to the braiding
+       itself ([close_cups_mid]); combining gives σ ≈ σ ∘ σ ≈ id. *)
+
+Section NoCloning.
+
+Context {C : Category}.
+Context `{R : @RelevanceMonoidal C}.
+Context `{CC : @CompactClosed C (@relevance_is_symmetric C R)}.
+
+(* Naturality of the diagonal, in rewriting form: ∆ is a natural
+   transformation from the identity functor to the squaring functor. *)
+Lemma diagonal_natural' {a b : C} (f : a ~> b) :
+  f ⨂ f ∘ ∆a ≈ ∆b ∘ f.
+Proof.
+  spose (@diagonal_natural C R) as X0.
+  apply X0.
+Qed.
+
+(* The middle-four interchange is involutive: swapping the middle two
+   factors twice is the identity.  (The two instances have their middle
+   arguments transposed.) *)
+Lemma braid2_invol {a b c e : C} :
+  @braid2 C R a c b e ∘ @braid2 C R a b c e ≈ id[((a ⨂ b) ⨂ (c ⨂ e))%object].
+Proof.
+  unfold braid2.
+  rewrite <- !comp_assoc.
+  rewrite (comp_assoc (to tensor_assoc) (tensor_assoc⁻¹)).
+  rewrite iso_to_from, id_left.
+  normal.
+  rewrite <- (comp_assoc _ (tensor_assoc⁻¹) (to tensor_assoc)).
+  rewrite iso_from_to, id_right.
+  rewrite <- (comp_assoc _ (braid ⨂ id) (braid ⨂ id)).
+  rewrite <- bimap_comp.
+  rewrite braid_invol, id_left.
+  rewrite bimap_id_id, id_right.
+  rewrite iso_to_from, bimap_id_id, id_right.
+  apply iso_from_to.
+Qed.
+
+(* [braid2] is a definitional field of [RelevanceMonoidal]; statements of
+   other fields (e.g. [diagonal_braid2]) carry its body inlined.  This fold
+   lemma lets those occurrences be rewritten back to the named form. *)
+Lemma braid2_unfold {a b c e : C} :
+  @braid2 C R a b c e ≈
+  tensor_assoc⁻¹ ∘ id ⨂ (tensor_assoc ∘ braid ⨂ id ∘ tensor_assoc⁻¹)
+    ∘ tensor_assoc.
+Proof. reflexivity. Qed.
+
+(* The generic monoidal coherences the argument below leans on —
+   [unit_identity_from] (λ_I⁻¹ ≈ ρ_I⁻¹), the solved triangle forms
+   [tensor_assoc_unit_right] and [tensor_assoc_from_unit_left], and the
+   solved pentagon [pentagon_step] — are imported from the shared toolkit
+   in Structure/Monoidal/Braided/Proofs.v, where they are stated for any
+   [Monoidal] category. *)
+
+Section Cloning.
+
+Context {x : C}.
+
+Notation d := (dual x).
+
+(* The two parallel cups η ⨂ η, as a single state of (x* ⨂ x) ⨂ (x* ⨂ x). *)
+Definition cups : I ~> ((d ⨂ x) ⨂ (d ⨂ x))%object :=
+  cc_unit x ⨂ cc_unit x ∘ unit_left⁻¹.
+
+(* The same state regrouped by colour, as a state of (x* ⨂ x* ) ⨂ (x ⨂ x). *)
+Definition cups_mid : I ~> ((d ⨂ d) ⨂ (x ⨂ x))%object :=
+  braid2 ∘ cups.
+
+(* Naturality of ∆ at the cup, with ∆I = λ⁻¹: copying the cup is the
+   diagonal of the cup.  This is the upper square of Abramsky's Lemma 13. *)
+Lemma cups_diagonal : cups ≈ ∆(d ⨂ x) ∘ cc_unit x.
+Proof.
+  unfold cups.
+  rewrite <- diagonal_unit.
+  apply diagonal_natural'.
+Qed.
+
+(* Regrouped by colour, the two-cup state is the tensor of the two
+   componentwise diagonals: monoidality of ∆ ([diagonal_braid2]) cancels
+   against the regrouping via [braid2_invol]. *)
+Lemma cups_mid_diagonal : cups_mid ≈ ∆d ⨂ ∆x ∘ cc_unit x.
+Proof.
+  unfold cups_mid.
+  rewrite cups_diagonal.
+  rewrite diagonal_braid2.
+  rewrite <- braid2_unfold.
+  rewrite !comp_assoc.
+  rewrite braid2_invol.
+  now rewrite id_left.
+Qed.
+
+(* Cocommutativity of ∆x, tensored on the right: the two x-wires of the
+   regrouped two-cup state can be swapped silently.  This is the state-level
+   "confusion of entanglements". *)
+Lemma cups_mid_braid :
+  id[(d ⨂ d)%object] ⨂ braid ∘ cups_mid ≈ cups_mid.
+Proof.
+  rewrite !cups_mid_diagonal.
+  rewrite comp_assoc.
+  rewrite <- bimap_comp.
+  rewrite braid_diagonal, id_left.
+  reflexivity.
+Qed.
+
+(* The two-cup state built sequentially: the second cup is tensored to the
+   right of the first. *)
+Lemma cups_split :
+  cups ≈ id[(d ⨂ x)%object] ⨂ cc_unit x ∘ unit_right⁻¹ ∘ cc_unit x.
+Proof.
+  unfold cups.
+  rewrite unit_identity_from.
+  rewrite <- bimap_id_left_right.
+  rewrite <- comp_assoc.
+  rewrite from_unit_right_natural.
+  rewrite comp_assoc.
+  reflexivity.
+Qed.
+
+(* A single yanking stage: cap the leading x against the leading dual and
+   pass the remainder through.  [bend] at Z := x, precomposed with a cup, is
+   the left snake identity. *)
+Definition bend {Z : C} : (x ⨂ (d ⨂ Z))%object ~> Z :=
+  unit_left ∘ cc_counit x ⨂ id[Z] ∘ tensor_assoc⁻¹.
+
+(* bend is natural in the pass-through component. *)
+Lemma bend_natural {Z Z' : C} (q : Z ~> Z') :
+  bend ∘ id[x] ⨂ (id[d] ⨂ q) ≈ q ∘ bend.
+Proof.
+  unfold bend.
+  rewrite <- comp_assoc.
+  rewrite <- from_tensor_assoc_natural.
+  rewrite bimap_id_id.
+  rewrite (comp_assoc (unit_left ∘ cc_counit x ⨂ id[Z'])
+             (id[(x ⨂ d)%object] ⨂ q) (tensor_assoc⁻¹)).
+  rewrite <- (comp_assoc unit_left (cc_counit x ⨂ id[Z'])
+                (id[(x ⨂ d)%object] ⨂ q)).
+  rewrite bimap_id_right_left.
+  rewrite <- bimap_id_left_right.
+  rewrite comp_assoc.
+  rewrite <- to_unit_left_natural.
+  rewrite <- !comp_assoc.
+  reflexivity.
+Qed.
+
+(* The left snake identity, phrased with [bend]. *)
+Lemma bend_snake : bend ∘ id[x] ⨂ cc_unit x ∘ unit_right⁻¹ ≈ id[x].
+Proof.
+  unfold bend.
+  apply snake_left.
+Qed.
+
+(* A corollary of the second hexagon: braiding a whole pair past x and then
+   swapping inside the left factor is braiding the two inner x-wires. *)
+Lemma braid_pass {y : C} :
+  braid ⨂ id[x] ∘ tensor_assoc⁻¹ ∘ @braid C _ (y ⨂ x)%object x
+    ≈ tensor_assoc⁻¹ ∘ id[y] ⨂ braid ∘ tensor_assoc.
+Proof.
+  pose proof (@hexagon_identity_sym C _ y x x) as HX.
+  assert (HX' : (@tensor_assoc C _ x y x)⁻¹ ∘ @braid C _ (y ⨂ x)%object x
+                  ≈ braid ⨂ id[x] ∘ tensor_assoc⁻¹ ∘ id[y] ⨂ braid
+                      ∘ tensor_assoc).
+  { rewrite <- HX.
+    rewrite <- !comp_assoc.
+    rewrite iso_from_to, id_right.
+    reflexivity. }
+  rewrite <- comp_assoc.
+  rewrite HX'.
+  rewrite !comp_assoc.
+  rewrite <- bimap_comp.
+  rewrite braid_invol, id_left.
+  rewrite bimap_id_id, id_left.
+  reflexivity.
+Qed.
+
+(* Passing a wire over a freshly inserted cup from the right equals passing
+   it under from the left: the hexagon absorbs the crossing.  (In Abramsky's
+   diagrams this is how the crossing of the "confused" cups is normalized.) *)
+Lemma cup_pass :
+  tensor_assoc ∘ braid ⨂ id[x] ∘ tensor_assoc⁻¹ ∘ id[x] ⨂ cc_unit x
+      ∘ unit_right⁻¹
+    ≈ id[d] ⨂ braid ∘ tensor_assoc ∘ cc_unit x ⨂ id[x] ∘ unit_left⁻¹.
+Proof.
+  rewrite <- braid_unit_right_from.
+  rewrite comp_assoc.
+  rewrite <- (comp_assoc _ (id[x] ⨂ cc_unit x) (@braid C _ I x)).
+  rewrite bimap_braid.
+  rewrite <- (comp_assoc (to tensor_assoc) (braid ⨂ id[x]) (tensor_assoc⁻¹)).
+  rewrite (comp_assoc _ (@braid C _ (d ⨂ x)%object x) (cc_unit x ⨂ id[x])).
+  rewrite <- (comp_assoc (to tensor_assoc) (braid ⨂ id[x] ∘ tensor_assoc⁻¹)
+                (@braid C _ (d ⨂ x)%object x)).
+  rewrite braid_pass.
+  rewrite !comp_assoc.
+  rewrite iso_to_from, id_left.
+  reflexivity.
+Qed.
+
+(* The α-normalized two-cup state, sequentially: first cup at the head, the
+   second inserted inside it, with the crossing pushed onto the x-wires by
+   [cup_pass].  This is the state that the two-stage closure below consumes
+   snake by snake. *)
+Lemma cups_mid_nested :
+  to tensor_assoc ∘ cups_mid
+    ≈ id[d] ⨂ (id[d] ⨂ braid ∘ tensor_assoc ∘ cc_unit x ⨂ id[x]
+                 ∘ unit_left⁻¹)
+        ∘ cc_unit x.
+Proof.
+  unfold cups_mid.
+  rewrite cups_split.
+  rewrite braid2_unfold.
+  rewrite !comp_assoc.
+  rewrite iso_to_from, id_left.
+  rewrite <- (@bimap_id_id C C C (@tensor C _) d x).
+  rewrite <- (comp_assoc _ (to tensor_assoc) ((id[d] ⨂ id[x]) ⨂ cc_unit x)).
+  rewrite <- to_tensor_assoc_natural.
+  rewrite <- !comp_assoc.
+  rewrite (comp_assoc (to tensor_assoc) (unit_right⁻¹) (cc_unit x)).
+  rewrite tensor_assoc_unit_right.
+  normal.
+  rewrite cup_pass.
+  reflexivity.
+Qed.
+
+(* The left snake identity, solved for the inverse unitor. *)
+Lemma snake_left_from :
+  cc_counit x ⨂ id[x] ∘ tensor_assoc⁻¹ ∘ id[x] ⨂ cc_unit x ∘ unit_right⁻¹
+    ≈ unit_left⁻¹.
+Proof.
+  apply (iso_to_monic unit_left).
+  rewrite iso_to_from.
+  rewrite !comp_assoc.
+  apply snake_left.
+Qed.
+
+(* Yanking with a spectator: inserting a cup beside a wire and capping it
+   against the leading input is the identity on both wires. *)
+Lemma spectator_snake :
+  bend ∘ id[x] ⨂ (tensor_assoc ∘ cc_unit x ⨂ id[x] ∘ unit_left⁻¹)
+    ≈ id[(x ⨂ x)%object].
+Proof.
+  unfold bend.
+  rewrite !bimap_comp_id_left.
+  rewrite !comp_assoc.
+  rewrite <- (comp_assoc _ (tensor_assoc⁻¹) (id[x] ⨂ to tensor_assoc)).
+  rewrite pentagon_step.
+  rewrite !comp_assoc.
+  rewrite <- (comp_assoc _ (tensor_assoc⁻¹) (id[x] ⨂ (cc_unit x ⨂ id[x]))).
+  rewrite <- from_tensor_assoc_natural.
+  rewrite !comp_assoc.
+  rewrite <- (comp_assoc _ (tensor_assoc⁻¹) (id[x] ⨂ unit_left⁻¹)).
+  rewrite tensor_assoc_from_unit_left.
+  rewrite <- (@bimap_id_id C C C (@tensor C _) x x).
+  rewrite <- (comp_assoc unit_left (cc_counit x ⨂ (id[x] ⨂ id[x]))
+                (to tensor_assoc)).
+  rewrite to_tensor_assoc_natural.
+  rewrite !comp_assoc.
+  normal.
+  rewrite snake_left_from.
+  rewrite <- triangle_identity_left.
+  normal.
+  rewrite iso_to_from.
+  normal.
+  reflexivity.
+Qed.
+
+(* The two-input closure: tensor a colour-grouped state next to the two
+   inputs and cap each input in turn against the state's dual wires; the
+   state's two x-wires are the outputs. *)
+Definition close (v : I ~> ((d ⨂ d) ⨂ (x ⨂ x))%object) :
+  (x ⨂ x)%object ~> (x ⨂ x)%object :=
+  bend ∘ id[x] ⨂ (bend ∘ id[x] ⨂ (to tensor_assoc ∘ v) ∘ unit_right⁻¹).
+
+#[local] Instance close_respects : Proper (equiv ==> equiv) close.
+Proof.
+  proper.
+  unfold close.
+  rewrites.
+  reflexivity.
+Qed.
+
+(* A braid on the x-wires of the state emerges from the closure as a braid
+   on its outputs. *)
+Lemma close_braid (v : I ~> ((d ⨂ d) ⨂ (x ⨂ x))%object) :
+  close (id[(d ⨂ d)%object] ⨂ braid ∘ v) ≈ braid ∘ close v.
+Proof.
+  unfold close.
+  rewrite (comp_assoc (to tensor_assoc) (id[(d ⨂ d)%object] ⨂ braid) v).
+  rewrite <- (@bimap_id_id C C C (@tensor C _) d d).
+  rewrite <- to_tensor_assoc_natural.
+  rewrite <- (comp_assoc (id[d] ⨂ (id[d] ⨂ braid)) (to tensor_assoc) v).
+  rewrite (bimap_comp_id_left (id[d] ⨂ (id[d] ⨂ braid)) (to tensor_assoc ∘ v)).
+  rewrite (comp_assoc bend (id[x] ⨂ (id[d] ⨂ (id[d] ⨂ braid)))).
+  rewrite bend_natural.
+  rewrite <- (comp_assoc (id[d] ⨂ braid) bend (id[x] ⨂ (to tensor_assoc ∘ v))).
+  rewrite <- (comp_assoc (id[d] ⨂ braid)
+                (bend ∘ id[x] ⨂ (to tensor_assoc ∘ v)) unit_right⁻¹).
+  rewrite (bimap_comp_id_left (id[d] ⨂ braid)
+             (bend ∘ id[x] ⨂ (to tensor_assoc ∘ v) ∘ unit_right⁻¹)).
+  rewrite (comp_assoc bend (id[x] ⨂ (id[d] ⨂ braid))).
+  rewrite bend_natural.
+  rewrite <- comp_assoc.
+  reflexivity.
+Qed.
+
+(* Double yanking: closing the colour-grouped two-cup state evaluates to
+   the braiding — the first input caps the first cup and flows out on the
+   second output, and conversely. *)
+Lemma close_cups_mid : close cups_mid ≈ braid.
+Proof.
+  unfold close.
+  rewrite cups_mid_nested.
+  rewrite (bimap_comp_id_left
+             (id[d] ⨂ (id[d] ⨂ braid ∘ tensor_assoc ∘ cc_unit x ⨂ id[x]
+                         ∘ unit_left⁻¹))
+             (cc_unit x)).
+  rewrite (comp_assoc bend
+             (id[x] ⨂ (id[d] ⨂ (id[d] ⨂ braid ∘ tensor_assoc
+                                  ∘ cc_unit x ⨂ id[x] ∘ unit_left⁻¹)))).
+  rewrite bend_natural.
+  rewrite <- (comp_assoc _ bend (id[x] ⨂ cc_unit x)).
+  rewrite <- (comp_assoc _ (bend ∘ id[x] ⨂ cc_unit x) unit_right⁻¹).
+  rewrite bend_snake.
+  rewrite id_right.
+  rewrite <- !comp_assoc.
+  rewrite (bimap_comp_id_left (id[d] ⨂ braid)
+             (to tensor_assoc ∘ (cc_unit x ⨂ id[x] ∘ unit_left⁻¹))).
+  rewrite comp_assoc.
+  rewrite bend_natural.
+  rewrite <- comp_assoc.
+  rewrite (comp_assoc (to tensor_assoc) (cc_unit x ⨂ id[x]) (unit_left⁻¹)).
+  rewrite spectator_snake.
+  rewrite id_right.
+  reflexivity.
+Qed.
+
+(* §2 #6 — Abramsky's no-cloning theorem (arXiv:0910.2401, Theorem 11,
+   second step): in a compact closed category with uniform copying, the
+   braiding on every diagonal square is the identity.  The copied two-cup
+   state is silently swap-invariant ([cups_mid_braid]); pushing the swap
+   through the closure ([close_braid]) and evaluating ([close_cups_mid])
+   forces σ ≈ σ ∘ σ ≈ id. *)
+Theorem no_cloning : @braid C _ x x ≈ id[(x ⨂ x)%object].
+Proof using C CC R x.
+  pose proof close_cups_mid as E1.
+  assert (E2 : close cups_mid ≈ braid ∘ close cups_mid).
+  { transitivity (close (id[(d ⨂ d)%object] ⨂ braid ∘ cups_mid)).
+    - symmetry.
+      now rewrite cups_mid_braid.
+    - apply close_braid. }
+  rewrite E1 in E2.
+  rewrite braid_invol in E2.
+  exact E2.
+Qed.
+
+End Cloning.
+
+End NoCloning.

--- a/Structure/Monoidal/CopyDiscard.v
+++ b/Structure/Monoidal/CopyDiscard.v
@@ -1,0 +1,118 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Monoidal.Braided.
+Require Import Category.Structure.Monoidal.Symmetric.
+Require Import Category.Structure.Monoidal.Hypergraph.
+Require Import Category.Theory.Algebra.Comonoid.
+Require Import Category.Theory.Algebra.CommutativeComonoid.
+
+Generalizable All Variables.
+
+(** * Copy-discard (gs-monoidal) categories
+
+    A copy-discard category — also called a gs-monoidal category ("garbage
+    and sharing") — is a symmetric monoidal category [(C, ⨂, I, σ)] equipped
+    with a chosen commutative comonoid
+
+      copy[X]    : X ~> X ⨂ X      (comultiplication, "duplicate the wire")
+      discard[X] : X ~> I          (counit, "delete the wire")
+
+    on every object, such that the comonoid on [X ⨂ Y] is canonically
+    assembled from those on [X] and [Y] (via the middle-interchange
+    isomorphism), and the comonoid on [I] is the trivial one.
+
+    THE defining negative space of this class: there is deliberately NO
+    naturality condition on [copy] or [discard].  A morphism [f] need not
+    satisfy [copy ∘ f ≈ (f ⨂ f) ∘ copy] nor [discard ∘ f ≈ discard]; the
+    two squares together are precisely what single out the DETERMINISTIC
+    morphisms (Cho–Jacobs; see CopyDiscard/Deterministic.v).  The two
+    omissions carry different weight.  Imposing the discard square on ALL
+    morphisms is exactly semicartesianness — it says any map into [I]
+    agrees with [discard], i.e. [I] is terminal — which is the Markov case,
+    not a degeneracy: Structure/Monoidal/Markov.v derives [discard_natural]
+    for every morphism as a corollary of [unit_terminal].  Imposing the
+    copy square on ALL morphisms makes [copy] a natural diagonal, yielding
+    [RelevanceMonoidal]'s naturality together with the counits that class
+    lacks; imposing both squares globally is Fox's theorem territory: the
+    structure collapses to cartesian monoidal (see Heunen_Vicary.v and
+    Markov/Fox.v).  This class is therefore INCOMPARABLE with
+    [RelevanceMonoidal], not below it: [CopyDiscard] carries counits that
+    [RelevanceMonoidal] lacks, while [RelevanceMonoidal] carries the
+    naturality that [CopyDiscard] deliberately drops.  What both strengthen
+    is the bare per-object [CommutativeComonoid] supply with no coherence
+    at all.
+
+    Accordingly [RelevanceMonoidal] is NOT a source of instances for this
+    class: its diagonal comes with no counit whatsoever, so the comonoid
+    counit laws [(ε ⨂ id) ∘ δ ≈ λ⁻¹] are underivable there.  The sound
+    generic instances — from [CartesianMonoidal] (Fox's projection laws
+    supply the counits) and from [Hypergraph] (forget the monoid half of
+    each SCFA) — live in Structure/Monoidal/CopyDiscard/Proofs.v.
+
+    The class shape mirrors Hypergraph.v's SCFA supply verbatim: a
+    per-object structure field, canonical-tensor coherence, and unit
+    coherence, reusing [canonical_tensor_delta] / [canonical_tensor_epsilon]
+    (stated there for plain [Comonoid] arguments; [CommutativeComonoid]
+    coerces).
+
+    nLab:      https://ncatlab.org/nlab/show/copy-discard+category
+    Reference: Cho & Jacobs, "Disintegration and Bayesian inversion via
+               string diagrams", MSCS 29(7):938–971, 2019 (arXiv:1709.00322)
+    Reference: Fritz, "A synthetic approach to Markov kernels, conditional
+               independence and theorems on sufficient statistics",
+               Adv. Math. 370:107239, 2020 (arXiv:1908.07021), §2
+    Reference: Corradini & Gadducci, "An algebraic presentation of term
+               graphs, via gs-monoidal categories", Appl. Categ. Structures
+               7(4):299–331, 1999 *)
+
+Section CopyDiscard.
+
+Context {C : Category}.
+Context `{S : @SymmetricMonoidal C}.
+
+Class CopyDiscard : Type := {
+  cd_comonoid (X : C) : CommutativeComonoid X;
+
+  (* Tensor coherence: the comonoid on [X ⨂ Y] agrees with the canonical
+     one assembled from those on [X] and [Y] through [mid_swap_inv]
+     (Hypergraph.v):  δ_{X⨂Y} ≈ mid_swap_inv ∘ (δ_X ⨂ δ_Y). *)
+  cd_tensor_delta (X Y : C) :
+    ccomon_delta (cd_comonoid (X ⨂ Y))
+      ≈ canonical_tensor_delta (cd_comonoid X) (cd_comonoid Y);
+
+  (* ε_{X⨂Y} ≈ unit_left ∘ (ε_X ⨂ ε_Y). *)
+  cd_tensor_epsilon (X Y : C) :
+    ccomon_epsilon (cd_comonoid (X ⨂ Y))
+      ≈ canonical_tensor_epsilon (cd_comonoid X) (cd_comonoid Y);
+
+  (* Unit coherence: the comonoid on [I] is the trivial one,
+     δ_I ≈ unit_left⁻¹ and ε_I ≈ id (cf. scfa_unit_delta/epsilon). *)
+  cd_unit_delta   : ccomon_delta   (cd_comonoid I) ≈ from (@unit_left C _ I);
+  cd_unit_epsilon : ccomon_epsilon (cd_comonoid I) ≈ id[I]
+}.
+
+(* [cd_comonoid] is deliberately NOT an [Existing Instance] (mirroring
+   [scfa] in Hypergraph.v): typeclass resolution must never invent a
+   comonoid structure on an object; access it via the projections below. *)
+
+Definition copy `{CopyDiscard} (X : C) : X ~> (X ⨂ X)%object :=
+  ccomon_delta (cd_comonoid X).
+
+Definition discard `{CopyDiscard} (X : C) : X ~> I :=
+  ccomon_epsilon (cd_comonoid X).
+
+End CopyDiscard.
+
+Arguments cd_comonoid {C S _} X.
+Arguments copy {C S _} X.
+Arguments discard {C S _} X.
+Arguments CopyDiscard C {S}.
+
+Notation "copy[ X ]" := (copy X)
+  (at level 9, format "copy[ X ]") : morphism_scope.
+Notation "discard[ X ]" := (discard X)
+  (at level 9, format "discard[ X ]") : morphism_scope.

--- a/Structure/Monoidal/CopyDiscard/Deterministic.v
+++ b/Structure/Monoidal/CopyDiscard/Deterministic.v
@@ -1,0 +1,437 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Monoidal.Proofs.
+Require Import Category.Structure.Monoidal.Braided.
+Require Import Category.Structure.Monoidal.Braided.Proofs.
+Require Import Category.Structure.Monoidal.Symmetric.
+Require Import Category.Structure.Monoidal.Hypergraph.
+Require Import Category.Structure.Monoidal.CopyDiscard.
+Require Import Category.Structure.Monoidal.CopyDiscard.Proofs.
+Require Import Category.Theory.Algebra.Comonoid.
+Require Import Category.Theory.Algebra.CommutativeComonoid.
+Require Import Category.Theory.Algebra.Comonoid.Hom.
+Require Import Category.Construction.Subcategory.
+
+Generalizable All Variables.
+
+(** * Deterministic morphisms in a copy-discard category
+
+    A [CopyDiscard] category deliberately imposes NO naturality on [copy] and
+    [discard]: a general morphism need not commute with duplication or
+    deletion.  Following Cho–Jacobs, a morphism [f : x ~> y] is
+    DETERMINISTIC when it does commute with both, i.e. when it is a comonoid
+    homomorphism between the canonical comonoids:
+
+      copy[y] ∘ f ≈ (f ⨂ f) ∘ copy[x]        (copying the output of [f]
+                                               is running [f] twice on a
+                                               copied input)
+      discard[y] ∘ f ≈ discard[x]             (running [f] and discarding
+                                               is just discarding)
+
+    In a Markov category these two squares single out exactly the morphisms
+    that carry no randomness.  Deterministic morphisms contain the
+    identities and are closed under composition and under ⨂; all the
+    structural isomorphisms of the symmetric monoidal base — braiding,
+    unitors, associator — are deterministic.  Consequently the deterministic
+    morphisms form a wide (lluf) subcategory [Det] of [C], packaged here
+    through [Construction/Subcategory.v].
+
+    The structural-morphism proofs are instances of the classical fact that
+    the squaring functor [x ↦ x ⨂ x] of a symmetric monoidal category is
+    itself symmetric (strong) monoidal, with structure map the middle
+    interchange [(a ⨂ b) ⨂ (c ⨂ d) ≅ (a ⨂ c) ⨂ (b ⨂ d)].  That
+    interchange, [swap_inner], and its coherence laws ([swap_inner_braid],
+    [swap_inner_assoc], [swap_inner_unit_left] / [swap_inner_unit_right])
+    are developed for any symmetric monoidal category in the shared toolkit
+    of Structure/Monoidal/Braided/Proofs.v; this file identifies its
+    diagonal with Hypergraph.v's [mid_swap_inv] ([swap_inner_diag]) and
+    restates the coherences in the [mid_swap_inv] form the determinism
+    proofs consume ([mid_swap_inv_braid], [mid_swap_inv_assoc],
+    [mid_swap_inv_unit_left] / [mid_swap_inv_unit_right]).
+
+    The structural determinism lemmas are direct coherence chases at the
+    canonical [cd_comonoid] supply.  The [Comonoid_Iso] transport of
+    Theory/Algebra/Comonoid/Hom.v cannot be used for them: determinism
+    demands a [ComonoidHom] between the canonical comonoids at BOTH
+    endpoints, whereas transporting a comonoid along a structural
+    isomorphism only produces homomorphisms into the transported comonoid
+    [Comonoid_Iso i _], which is not the canonical one.
+
+    The headline citation-ready facts are [copy_natural_on_deterministic]
+    and [discard_natural_on_deterministic]: copy/discard ARE natural once
+    restricted to deterministic morphisms.
+
+    nLab:      https://ncatlab.org/nlab/show/Markov+category
+    Reference: Cho & Jacobs, "Disintegration and Bayesian inversion via
+               string diagrams", MSCS 29(7):938–971, 2019
+               (arXiv:1709.00322), §2
+    Reference: Fritz, "A synthetic approach to Markov kernels, conditional
+               independence and theorems on sufficient statistics",
+               Adv. Math. 370:107239, 2020 (arXiv:1908.07021), §10 *)
+
+(* ------------------------------------------------------------------ *)
+
+(** ** Diagonal corollaries of the interchange
+
+    The four-object middle interchange [swap_inner] and its coherence laws
+    are developed for any symmetric monoidal category in the shared toolkit
+    of Structure/Monoidal/Braided/Proofs.v.  Its diagonal
+    [swap_inner x x y y] is definitionally Hypergraph.v's [mid_swap_inv]
+    ([swap_inner_diag]); the corollaries below restate the interchange
+    coherences in [mid_swap_inv] form, which is the shape the determinism
+    proofs consume.  This is the only place the toolkit meets the
+    hypergraph vocabulary — Braided/Proofs.v itself stays independent of
+    the hypergraph stack. *)
+
+Section MidSwapCoherence.
+
+Context {C : Category}.
+Context `{S : @SymmetricMonoidal C}.
+
+(* [mid_swap_inv] (Hypergraph.v) is the diagonal of the interchange. *)
+Lemma swap_inner_diag (x y : C) : swap_inner x x y y ≈ mid_swap_inv x y.
+Proof. reflexivity. Qed.
+
+Corollary mid_swap_inv_braid {x y : C} :
+  mid_swap_inv y x ∘ braid
+    ≈ (@braid C _ x y ⨂ @braid C _ x y) ∘ mid_swap_inv x y.
+Proof.
+  rewrite <- !swap_inner_diag.
+  apply swap_inner_braid.
+Qed.
+
+Corollary mid_swap_inv_assoc {x y z : C} :
+  mid_swap_inv x (y ⨂ z)
+    ∘ ((id[(x ⨂ x)%object] ⨂ mid_swap_inv y z) ∘ to tensor_assoc)
+    ≈ (to tensor_assoc ⨂ to tensor_assoc)
+        ∘ (mid_swap_inv (x ⨂ y) z ∘ (mid_swap_inv x y ⨂ id[(z ⨂ z)%object])).
+Proof.
+  rewrite <- !swap_inner_diag.
+  apply swap_inner_assoc.
+Qed.
+
+(* The unit coherence, left form: conjugating [mid_swap_inv I x] by the
+   canonical unit isomorphisms is the left unitor. *)
+Corollary mid_swap_inv_unit_left {x : C} :
+  (unit_left ⨂ unit_left) ∘ mid_swap_inv I x
+    ∘ (unit_left⁻¹ ⨂ id[(x ⨂ x)%object])
+    ≈ @unit_left C _ (x ⨂ x).
+Proof.
+  rewrite <- swap_inner_diag.
+  apply swap_inner_unit_left.
+Qed.
+
+(* The unit coherence, right form. *)
+Corollary mid_swap_inv_unit_right {x : C} :
+  (unit_right ⨂ unit_right) ∘ mid_swap_inv x I
+    ∘ (id[(x ⨂ x)%object] ⨂ unit_left⁻¹)
+    ≈ @unit_right C _ (x ⨂ x).
+Proof.
+  rewrite <- swap_inner_diag.
+  apply swap_inner_unit_right.
+Qed.
+
+End MidSwapCoherence.
+
+(* ------------------------------------------------------------------ *)
+
+(** ** Deterministic morphisms *)
+
+Section Deterministic.
+
+Context {C : Category}.
+Context `{S : @SymmetricMonoidal C}.
+Context `{CD : @CopyDiscard C S}.
+
+(* A morphism is deterministic when it is a comonoid homomorphism between
+   the canonical copy/discard comonoids (Cho–Jacobs, Definition 2.2 of
+   arXiv:1709.00322 in the Markov setting). *)
+Definition deterministic {x y : C} (f : x ~> y) : Type :=
+  ComonoidHom (cd_comonoid x) (cd_comonoid y) f.
+
+Lemma deterministic_id {x : C} : deterministic (id[x]).
+Proof. apply ComonoidHom_id. Qed.
+
+Lemma deterministic_comp {x y z : C} {f : y ~> z} {g : x ~> y} :
+  deterministic f → deterministic g → deterministic (f ∘ g).
+Proof. apply ComonoidHom_comp. Qed.
+
+Lemma deterministic_equiv {x y : C} {f g : x ~> y} :
+  f ≈ g → deterministic f → deterministic g.
+Proof. apply ComonoidHom_equiv. Qed.
+
+(** The headline: copy and discard ARE natural once restricted to
+    deterministic morphisms.  These are the two squares whose breakdown for
+    general morphisms is the defining negative space of [CopyDiscard]. *)
+
+Theorem copy_natural_on_deterministic {x y : C} (f : x ~> y) :
+  deterministic f → copy[y] ∘ f ≈ (f ⨂ f) ∘ copy[x].
+Proof. intro F. exact (@hom_delta _ _ _ _ _ _ _ F). Qed.
+
+Theorem discard_natural_on_deterministic {x y : C} (f : x ~> y) :
+  deterministic f → discard[y] ∘ f ≈ discard[x].
+Proof. intro F. exact (@hom_epsilon _ _ _ _ _ _ _ F). Qed.
+
+(* Closure under the tensor: the δ-square pastes through
+   [mid_swap_inv_natural], the ε-square through the unit. *)
+Lemma deterministic_tensor {x x' y y' : C} {f : x ~> y} {f' : x' ~> y'} :
+  deterministic f → deterministic f' → deterministic (f ⨂ f').
+Proof.
+  intros [Fd Fe] [Fd' Fe'].
+  split.
+  - change (copy[(y ⨂ y')%object] ∘ (f ⨂ f')
+              ≈ ((f ⨂ f') ⨂ (f ⨂ f')) ∘ copy[(x ⨂ x')%object]).
+    rewrite !copy_tensor.
+    rewrite <- comp_assoc.
+    rewrite <- bimap_comp.
+    rewrite Fd, Fd'.
+    rewrite bimap_comp.
+    rewrite comp_assoc.
+    rewrite mid_swap_inv_natural.
+    rewrite <- comp_assoc.
+    reflexivity.
+  - change (discard[(y ⨂ y')%object] ∘ (f ⨂ f')
+              ≈ discard[(x ⨂ x')%object]).
+    rewrite !discard_tensor.
+    rewrite <- comp_assoc.
+    rewrite <- bimap_comp.
+    rewrite Fe, Fe'.
+    reflexivity.
+Qed.
+
+(* The inverse of a deterministic isomorphism is deterministic. *)
+Lemma deterministic_iso_from {x y : C} (i : x ≅ y) :
+  deterministic (to i) → deterministic (i⁻¹).
+Proof.
+  intros [Fd Fe].
+  split.
+  - rewrite <- (id_left (delta[ccomon_comonoid] ∘ i⁻¹)).
+    rewrite <- bimap_id_id.
+    rewrite <- (iso_from_to i).
+    rewrite bimap_comp.
+    rewrite <- !comp_assoc.
+    rewrite (comp_assoc (to i ⨂ to i)).
+    rewrite <- Fd.
+    rewrite <- !comp_assoc.
+    rewrite iso_to_from, id_right.
+    reflexivity.
+  - rewrite <- Fe.
+    rewrite <- comp_assoc.
+    rewrite iso_to_from, id_right.
+    reflexivity.
+Qed.
+
+(** Rewrite-friendly forms of the unit coherence fields. *)
+
+Corollary copy_unit : copy[I] ≈ (@unit_left C _ I)⁻¹.
+Proof. exact cd_unit_delta. Qed.
+
+Corollary discard_unit : discard[I] ≈ id[I].
+Proof. exact cd_unit_epsilon. Qed.
+
+(** *** The structural isomorphisms are deterministic *)
+
+(* Braiding: the δ-square is the interchange/braid compatibility, the
+   ε-square degenerates through [braid_I_I]. *)
+
+Lemma copy_braid {x y : C} :
+  copy[(y ⨂ x)%object] ∘ braid ≈ (braid ⨂ braid) ∘ copy[(x ⨂ y)%object].
+Proof.
+  rewrite !copy_tensor.
+  rewrite <- !comp_assoc.
+  rewrite bimap_braid.
+  rewrite (comp_assoc (mid_swap_inv y x)).
+  rewrite mid_swap_inv_braid.
+  rewrite <- !comp_assoc.
+  reflexivity.
+Qed.
+
+Lemma discard_braid {x y : C} :
+  discard[(y ⨂ x)%object] ∘ braid ≈ discard[(x ⨂ y)%object].
+Proof.
+  rewrite !discard_tensor.
+  rewrite <- comp_assoc.
+  rewrite bimap_braid.
+  rewrite comp_assoc.
+  rewrite braid_I_I.
+  rewrite id_right.
+  reflexivity.
+Qed.
+
+Theorem deterministic_braid {x y : C} : deterministic (@braid C _ x y).
+Proof.
+  split.
+  - exact copy_braid.
+  - exact discard_braid.
+Qed.
+
+(* Left unitor. *)
+
+Lemma copy_unit_left {x : C} :
+  copy[x] ∘ unit_left
+    ≈ (unit_left ⨂ unit_left) ∘ copy[(I ⨂ x)%object].
+Proof.
+  rewrite copy_tensor.
+  rewrite copy_unit.
+  rewrite to_unit_left_natural.
+  rewrite <- (bimap_id_right_left ((@unit_left C _ I)⁻¹) (copy x)).
+  rewrite !comp_assoc.
+  comp_right.
+  symmetry.
+  apply mid_swap_inv_unit_left.
+Qed.
+
+Lemma discard_unit_left {x : C} :
+  discard[x] ∘ unit_left ≈ discard[(I ⨂ x)%object].
+Proof.
+  rewrite discard_tensor.
+  rewrite discard_unit.
+  rewrite to_unit_left_natural.
+  reflexivity.
+Qed.
+
+Theorem deterministic_unit_left_to {x : C} :
+  deterministic (to (@unit_left C _ x)).
+Proof.
+  split.
+  - exact copy_unit_left.
+  - exact discard_unit_left.
+Qed.
+
+Theorem deterministic_unit_left_from {x : C} :
+  deterministic ((@unit_left C _ x)⁻¹).
+Proof. exact (deterministic_iso_from _ deterministic_unit_left_to). Qed.
+
+(* Right unitor. *)
+
+Lemma copy_unit_right {x : C} :
+  copy[x] ∘ unit_right
+    ≈ (unit_right ⨂ unit_right) ∘ copy[(x ⨂ I)%object].
+Proof.
+  rewrite copy_tensor.
+  rewrite copy_unit.
+  rewrite to_unit_right_natural.
+  rewrite <- (bimap_id_left_right ((@unit_left C _ I)⁻¹) (copy x)).
+  rewrite !comp_assoc.
+  comp_right.
+  symmetry.
+  apply mid_swap_inv_unit_right.
+Qed.
+
+Lemma discard_unit_right {x : C} :
+  discard[x] ∘ unit_right ≈ discard[(x ⨂ I)%object].
+Proof.
+  rewrite discard_tensor.
+  rewrite discard_unit.
+  rewrite to_unit_right_natural.
+  rewrite <- unit_identity.
+  reflexivity.
+Qed.
+
+Theorem deterministic_unit_right_to {x : C} :
+  deterministic (to (@unit_right C _ x)).
+Proof.
+  split.
+  - exact copy_unit_right.
+  - exact discard_unit_right.
+Qed.
+
+Theorem deterministic_unit_right_from {x : C} :
+  deterministic ((@unit_right C _ x)⁻¹).
+Proof. exact (deterministic_iso_from _ deterministic_unit_right_to). Qed.
+
+(* Associator: the δ-square is the associativity hexagon of the
+   interchange, the ε-square a triangle-and-Kelly computation. *)
+
+Lemma copy_tensor_assoc {x y z : C} :
+  copy[(x ⨂ (y ⨂ z))%object] ∘ to tensor_assoc
+    ≈ (to tensor_assoc ⨂ to tensor_assoc) ∘ copy[((x ⨂ y) ⨂ z)%object].
+Proof.
+  rewrite !copy_tensor.
+  assert (E1 : (copy x ⨂ (mid_swap_inv y z ∘ (copy y ⨂ copy z)))
+                 ≈ (id[(x ⨂ x)%object] ⨂ mid_swap_inv y z)
+                     ∘ (copy x ⨂ (copy y ⨂ copy z))).
+  { rewrite <- bimap_comp.
+    rewrite id_left.
+    reflexivity. }
+  rewrite E1; clear E1.
+  assert (E2 : ((mid_swap_inv x y ∘ (copy x ⨂ copy y)) ⨂ copy z)
+                 ≈ (mid_swap_inv x y ⨂ id[(z ⨂ z)%object])
+                     ∘ ((copy x ⨂ copy y) ⨂ copy z)).
+  { rewrite <- bimap_comp.
+    rewrite id_left.
+    reflexivity. }
+  rewrite E2; clear E2.
+  spose (to_tensor_assoc_natural (copy x) (copy y) (copy z)) as X.
+  rewrite <- !comp_assoc.
+  rewrite X; clear X.
+  rewrite !comp_assoc.
+  comp_right.
+  rewrite <- !comp_assoc.
+  apply mid_swap_inv_assoc.
+Qed.
+
+Lemma discard_tensor_assoc {x y z : C} :
+  discard[(x ⨂ (y ⨂ z))%object] ∘ to tensor_assoc
+    ≈ discard[((x ⨂ y) ⨂ z)%object].
+Proof.
+  rewrite !discard_tensor.
+  assert (E1 : (discard x ⨂ (unit_left ∘ (discard y ⨂ discard z)))
+                 ≈ (id[I] ⨂ to (@unit_left C _ I))
+                     ∘ (discard x ⨂ (discard y ⨂ discard z))).
+  { rewrite <- bimap_comp.
+    rewrite id_left.
+    reflexivity. }
+  rewrite E1; clear E1.
+  assert (E2 : ((unit_left ∘ (discard x ⨂ discard y)) ⨂ discard z)
+                 ≈ (to (@unit_left C _ I) ⨂ id[I])
+                     ∘ ((discard x ⨂ discard y) ⨂ discard z)).
+  { rewrite <- bimap_comp.
+    rewrite id_left.
+    reflexivity. }
+  rewrite E2; clear E2.
+  spose (to_tensor_assoc_natural (discard x) (discard y) (discard z)) as X.
+  rewrite <- !comp_assoc.
+  rewrite X; clear X.
+  rewrite !comp_assoc.
+  comp_right.
+  rewrite <- !comp_assoc.
+  rewrite <- triangle_identity.
+  rewrite <- unit_identity.
+  reflexivity.
+Qed.
+
+Theorem deterministic_tensor_assoc_to {x y z : C} :
+  deterministic (to (@tensor_assoc C _ x y z)).
+Proof.
+  split.
+  - exact copy_tensor_assoc.
+  - exact discard_tensor_assoc.
+Qed.
+
+Theorem deterministic_tensor_assoc_from {x y z : C} :
+  deterministic ((@tensor_assoc C _ x y z)⁻¹).
+Proof. exact (deterministic_iso_from _ deterministic_tensor_assoc_to). Qed.
+
+(** *** The wide deterministic subcategory (Cho–Jacobs [Det]) *)
+
+Program Definition DeterministicSub : Subcategory C := {|
+  sobj  := fun _ => poly_unit;
+  shom  := fun x y _ _ f => deterministic f;
+  scomp := fun _ _ _ _ _ _ _ _ df dg => deterministic_comp df dg;
+  sid   := fun _ _ => deterministic_id
+|}.
+
+Definition Det : Category := Sub C DeterministicSub.
+
+Lemma Det_wide : Wide C DeterministicSub.
+Proof. intro x; exact ttt. Qed.
+
+(* The inclusion Det ⟶ C is the generic (faithful) [Incl C DeterministicSub]
+   from Construction/Subcategory.v. *)
+
+End Deterministic.

--- a/Structure/Monoidal/CopyDiscard/Proofs.v
+++ b/Structure/Monoidal/CopyDiscard/Proofs.v
@@ -1,0 +1,245 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Monoidal.Symmetric.
+Require Import Category.Structure.Monoidal.CopyDiscard.
+Require Import Category.Structure.Monoidal.Relevance.
+Require Import Category.Structure.Monoidal.Semicartesian.
+Require Import Category.Structure.Monoidal.Heunen_Vicary.
+Require Import Category.Structure.Monoidal.Heunen_Vicary.Proofs.
+Require Import Category.Structure.Monoidal.Hypergraph.
+Require Import Category.Theory.Algebra.Comonoid.
+Require Import Category.Theory.Algebra.CommutativeComonoid.
+Require Import Category.Theory.Algebra.Frobenius.
+Require Import Category.Theory.Algebra.CommutativeFrobenius.
+Require Import Category.Theory.Algebra.SpecialCommutativeFrobenius.
+
+Generalizable All Variables.
+
+(** * Copy-discard categories: lemma kit and sound generic instances
+
+    Derived facts about the [CopyDiscard] class of
+    Structure/Monoidal/CopyDiscard.v:
+
+    - naturality of the middle-interchange map [mid_swap_inv] in both
+      of its (diagonal) arguments — the workhorse behind closure of
+      deterministic morphisms under ⨂;
+    - the bridge identifying [RelevanceMonoidal]'s [braid2] at
+      (x, x, y, y) with [mid_swap_inv x y];
+    - rewrite-friendly forms of the tensor-coherence fields
+      ([copy_tensor], [discard_tensor]);
+    - the two SOUND generic instances:
+        [CD_of_Cartesian]  : CartesianMonoidal ⇒ CopyDiscard
+          (Fox's projection laws proj_*_diagonal supply the comonoid
+          counit laws), and
+        [CD_of_Hypergraph] : Hypergraph ⇒ CopyDiscard
+          (forget the monoid half of each SCFA; the coherence fields
+          are literally the scfa_tensor and scfa_unit fields).
+
+    There is deliberately NO instance from [RelevanceMonoidal] (with or
+    without [SemicartesianMonoidal]): a relevance diagonal comes with no
+    counit whatsoever, and the comonoid counit laws
+    [(ε ⨂ id) ∘ δ ≈ λ⁻¹] are exactly Fox's [proj_right_diagonal] /
+    [proj_left_diagonal] axioms — underivable without them.
+
+    Reference: Fritz, "A synthetic approach to Markov kernels ..."
+               (arXiv:1908.07021), §2
+    Reference: Fox, "Coalgebras and cartesian categories",
+               Comm. Algebra 4(7):665–667, 1976 *)
+
+Section MidSwapNatural.
+
+Context {C : Category}.
+Context `{S : @SymmetricMonoidal C}.
+
+(* Naturality of the middle-four interchange at the diagonal: tensoring
+   f with itself and f' with itself commutes past [mid_swap_inv].  The
+   proof is the same associator/braid chase as [braid2_natural] in
+   Structure/Monoidal/Relevance.v, restated here because [braid2] is a
+   [RelevanceMonoidal] field while [mid_swap_inv] needs only symmetry. *)
+Lemma mid_swap_inv_natural {x x' y y'} (f : x ~> y) (f' : x' ~> y') :
+  mid_swap_inv y y' ∘ ((f ⨂ f) ⨂ (f' ⨂ f'))
+    ≈ ((f ⨂ f') ⨂ (f ⨂ f')) ∘ mid_swap_inv x x'.
+Proof.
+  unfold mid_swap_inv.
+  (* Pull (f ⨂ f) ⨂ (f' ⨂ f') through the rightmost associator. *)
+  rewrite <- !comp_assoc.
+  rewrite <- to_tensor_assoc_natural.
+  (* Pull ((f ⨂ f') ⨂ (f ⨂ f')) through the leftmost inverse associator
+     on the right-hand side. *)
+  normal.
+  rewrite from_tensor_assoc_natural.
+  normal.
+  comp_right.
+  comp_left.
+  (* Remaining: the conjugated inner braid against f ⨂ (f' ⨂ f'). *)
+  normal.
+  bimap_left.
+  rewrite to_tensor_assoc_natural.
+  rewrite <- !comp_assoc.
+  rewrite <- from_tensor_assoc_natural.
+  comp_left.
+  comp_right.
+  normal.
+  bimap_right.
+  symmetry.
+  apply bimap_braid.
+Qed.
+
+End MidSwapNatural.
+
+Section Braid2Bridge.
+
+Context {C : Category}.
+Context `{R : @RelevanceMonoidal C}.
+
+(* [RelevanceMonoidal]'s middle-four interchange [braid2], instantiated
+   at (x, x, y, y), is definitionally the same composite as
+   [mid_swap_inv x y] — the only difference is that [braid2] tensors
+   id[x] against the three inner maps at once, while [mid_swap_inv]
+   distributes the tensoring.  Expand with [bimap_comp_id_left]. *)
+Lemma braid2_mid_swap_inv (x y : C) :
+  @braid2 C R x x y y ≈ mid_swap_inv x y.
+Proof.
+  unfold braid2, mid_swap_inv.
+  rewrite !bimap_comp_id_left.
+  rewrite !comp_assoc.
+  reflexivity.
+Qed.
+
+End Braid2Bridge.
+
+Section CopyDiscardRewrites.
+
+Context {C : Category}.
+Context `{S : @SymmetricMonoidal C}.
+
+(* The tensor-coherence fields of [CopyDiscard], unfolded through
+   [canonical_tensor_delta] / [canonical_tensor_epsilon] into directly
+   rewritable equations. *)
+
+Corollary copy_tensor `{CD : @CopyDiscard C S} (X Y : C) :
+  copy[(X ⨂ Y)%object] ≈ mid_swap_inv X Y ∘ (copy[X] ⨂ copy[Y]).
+Proof.
+  unfold copy.
+  rewrite cd_tensor_delta.
+  unfold canonical_tensor_delta.
+  reflexivity.
+Qed.
+
+Corollary discard_tensor `{CD : @CopyDiscard C S} (X Y : C) :
+  discard[(X ⨂ Y)%object]
+    ≈ to (@unit_left C _ I) ∘ (discard[X] ⨂ discard[Y]).
+Proof.
+  unfold discard.
+  rewrite cd_tensor_epsilon.
+  unfold canonical_tensor_epsilon.
+  reflexivity.
+Qed.
+
+End CopyDiscardRewrites.
+
+Section CDCartesian.
+
+Context {C : Category}.
+Context `{H : @CartesianMonoidal C}.
+
+(* SOUND instance 1: in a cartesian monoidal category the natural
+   diagonal ∆ (Relevance) and the terminal-unit discard [eliminate]
+   (Semicartesian) form a commutative comonoid on every object — the
+   counit laws are Fox's proj_*_diagonal axioms, packaged by
+   [eliminate_left_diagonal] / [eliminate_right_diagonal] in
+   Structure/Monoidal/Heunen_Vicary/Proofs.v — and the comonoid supply
+   is coherent with the tensor and the unit. *)
+Program Definition CD_of_Cartesian :
+  @CopyDiscard C (@relevance_is_symmetric C (@cartesian_is_relevance C H)) := {|
+  cd_comonoid := fun X =>
+    {| ccomon_comonoid :=
+         {| delta   := @diagonal C _ X;
+            epsilon := @eliminate C _ _ X |} |}
+|}.
+Next Obligation.
+  (* delta_coassoc: reorient diagonal_tensor_assoc by cancelling α. *)
+  rewrite <- comp_assoc.
+  rewrite diagonal_tensor_assoc.
+  rewrite !comp_assoc.
+  rewrite iso_from_to, id_left.
+  reflexivity.
+Qed.
+Next Obligation.
+  (* delta_counit_left: (ε ⨂ id) ∘ ∆ ≈ λ⁻¹ is Fox's proj_right_diagonal. *)
+  apply eliminate_left_diagonal.
+Qed.
+Next Obligation.
+  (* delta_counit_right: (id ⨂ ε) ∘ ∆ ≈ ρ⁻¹ is Fox's proj_left_diagonal. *)
+  apply eliminate_right_diagonal.
+Qed.
+Next Obligation.
+  (* cocommutativity: braid ∘ ∆ ≈ ∆. *)
+  apply braid_diagonal.
+Qed.
+Next Obligation.
+  (* cd_tensor_delta: ∆ on a tensor is the canonical comonoid.  This is
+     diagonal_braid2 composed with the braid2 ≈ mid_swap_inv bridge; the
+     [braid2] let-field arrives inlined in diagonal_braid2's statement,
+     so we replay the expansion of [braid2_mid_swap_inv] directly. *)
+  unfold ccomon_delta, canonical_tensor_delta; simpl.
+  rewrite diagonal_braid2.
+  comp_right.
+  unfold mid_swap_inv.
+  rewrite !bimap_comp_id_left.
+  rewrite !comp_assoc.
+  reflexivity.
+Qed.
+Next Obligation.
+  (* cd_tensor_epsilon: both sides are maps into the terminal unit. *)
+  apply unit_terminal.
+Qed.
+Next Obligation.
+  (* cd_unit_delta: ∆ at I is the canonical iso I ≅ I ⨂ I. *)
+  apply diagonal_unit.
+Qed.
+Next Obligation.
+  (* cd_unit_epsilon: both sides are maps into the terminal unit. *)
+  apply unit_terminal.
+Qed.
+
+End CDCartesian.
+
+Section CDHypergraph.
+
+Context {C : Category}.
+Context `{S : @SymmetricMonoidal C}.
+Context `{H : @Hypergraph C S}.
+
+(* SOUND instance 2: a hypergraph category supplies a special
+   commutative Frobenius algebra on every object; forgetting the monoid
+   half of each SCFA leaves exactly a coherent commutative-comonoid
+   supply.  The four coherence obligations are literally the
+   scfa_tensor_delta/epsilon and scfa_unit_delta/epsilon fields. *)
+Program Definition CD_of_Hypergraph : @CopyDiscard C S := {|
+  cd_comonoid := fun X =>
+    {| ccomon_comonoid :=
+         @frob_comonoid C _ X
+           (@cfrob_frobenius C S X (@scfa_commutative C S X (scfa X)));
+       delta_cocommutative_of_ccomon :=
+         @delta_cocommutative C S X (@scfa_commutative C S X (scfa X)) |}
+|}.
+Next Obligation.
+  (* cd_tensor_delta ≈ scfa_tensor_delta, up to unfolding projections. *)
+  apply scfa_tensor_delta.
+Qed.
+Next Obligation.
+  apply scfa_tensor_epsilon.
+Qed.
+Next Obligation.
+  apply scfa_unit_delta.
+Qed.
+Next Obligation.
+  apply scfa_unit_epsilon.
+Qed.
+
+End CDHypergraph.

--- a/Structure/Monoidal/Markov.v
+++ b/Structure/Monoidal/Markov.v
@@ -1,0 +1,198 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Monoidal.Symmetric.
+Require Import Category.Structure.Monoidal.Semicartesian.
+Require Import Category.Structure.Monoidal.CopyDiscard.
+Require Import Category.Structure.Monoidal.CopyDiscard.Proofs.
+Require Import Category.Structure.Monoidal.Heunen_Vicary.
+Require Import Category.Theory.Algebra.Comonoid.
+Require Import Category.Theory.Algebra.CommutativeComonoid.
+
+Generalizable All Variables.
+
+(** * Markov categories
+
+    A Markov category (Fritz, arXiv:1908.07021, §2) is a copy-discard
+    (gs-monoidal) category whose monoidal unit [I] is terminal: a symmetric
+    monoidal category equipped with a coherent commutative-comonoid supply
+    [copy]/[discard] on every object ([CopyDiscard]) together with a
+    [SemicartesianMonoidal] structure — a morphism [eliminate : x ~> I] for
+    every [x], any two such morphisms agreeing ([unit_terminal]).
+
+    Reading: a morphism [x ~> y] is a synthetic Markov kernel (a "channel")
+    from [x] to [y]; a morphism [I ~> x] is a state (a "distribution") on
+    [x]; [copy] duplicates and [discard] deletes an input.
+
+    The class is redundancy-free, following Fritz's formulation: it carries
+    NO axiom identifying [discard] with [eliminate] and NO naturality axiom
+    for [discard].  In a semicartesian category ANY two morphisms into [I]
+    agree, so both facts are corollaries ([markov_discard_eliminate],
+    [discard_natural]), not axioms.
+
+    What is deliberately absent is naturality of [copy]: a morphism [f]
+    satisfying [copy ∘ f ≈ (f ⨂ f) ∘ copy] is precisely a DETERMINISTIC
+    morphism (Cho–Jacobs; see CopyDiscard/Deterministic.v), and by Fox's
+    theorem demanding this of every morphism collapses the category to a
+    cartesian monoidal one (see Markov/Fox.v).  Conversely every cartesian
+    monoidal category is a Markov category — [Markov_of_Cartesian] below —
+    in which "all kernels are deterministic": the degenerate, probability-
+    free case.
+
+    nLab:      https://ncatlab.org/nlab/show/Markov+category
+    Reference: Fritz, "A synthetic approach to Markov kernels, conditional
+               independence and theorems on sufficient statistics",
+               Adv. Math. 370:107239, 2020 (arXiv:1908.07021), §2
+    Reference: Cho & Jacobs, "Disintegration and Bayesian inversion via
+               string diagrams", MSCS 29(7):938–971, 2019
+               (arXiv:1709.00322) *)
+
+Section Markov.
+
+Context {C : Category}.
+Context `{S : @SymmetricMonoidal C}.
+
+Class MarkovCategory : Type := {
+  (* The copy-discard structure: a commutative comonoid on every object,
+     coherent with the tensor and the unit (but NOT natural). *)
+  markov_is_cd : @CopyDiscard C S;
+
+  (* The unit [I] is terminal (the category is semicartesian / affine):
+     synthetically, "probability distributions are normalized". *)
+  markov_semicartesian :
+    @SemicartesianMonoidal C
+      (@braided_is_monoidal C (@symmetric_is_braided C S))
+}.
+#[export] Existing Instance markov_is_cd.
+
+Coercion markov_is_cd : MarkovCategory >-> CopyDiscard.
+
+(* [markov_semicartesian] is deliberately NOT an [Existing Instance]:
+   downstream files select it explicitly (mirroring how [cd_comonoid] is
+   accessed by projection), keeping typeclass resolution from picking a
+   semicartesian structure the caller did not ask for. *)
+
+Context `{M : MarkovCategory}.
+
+(* Discarding IS eliminating: both are morphisms into the terminal [I].
+   Some presentations of Markov categories take this identification as an
+   axiom; in Fritz's redundancy-free formulation it is a corollary of
+   terminality. *)
+Corollary markov_discard_eliminate {x : C} :
+  discard[x] ≈ @eliminate C _ markov_semicartesian x.
+Proof. apply (@unit_terminal C _ markov_semicartesian). Qed.
+
+(* Naturality of discard — "delete after doing anything is delete" — is
+   likewise a corollary of terminality, never an axiom. *)
+Corollary discard_natural {x y : C} (f : x ~> y) :
+  discard[y] ∘ f ≈ discard[x].
+Proof. apply (@unit_terminal C _ markov_semicartesian). Qed.
+
+(** ** States and marginals
+
+    Vocabulary for the probability track: a [state] on [x] is a morphism
+    out of the unit, and the marginals of a joint state are obtained by
+    discarding one factor of the tensor (the projections of
+    Semicartesian.v).  The lemmas below are phrased through [state]. *)
+
+Definition state (x : C) : Type := I ~> x.
+
+(* Normalization: every state has total mass one. *)
+Lemma state_discard {x : C} (s : state x) :
+  discard[x] ∘ s ≈ id[I].
+Proof. apply (@unit_terminal C _ markov_semicartesian). Qed.
+
+Definition marginal_left {x y : C} (s : state (x ⨂ y)%object) : state x :=
+  @proj_left C _ markov_semicartesian x y ∘ s.
+
+Definition marginal_right {x y : C} (s : state (x ⨂ y)%object) : state y :=
+  @proj_right C _ markov_semicartesian x y ∘ s.
+
+#[export] Program Instance marginal_left_respects {x y : C} :
+  Proper (equiv ==> equiv) (@marginal_left x y).
+Next Obligation.
+  proper.
+  unfold marginal_left.
+  rewrites.
+  reflexivity.
+Qed.
+
+#[export] Program Instance marginal_right_respects {x y : C} :
+  Proper (equiv ==> equiv) (@marginal_right x y).
+Next Obligation.
+  proper.
+  unfold marginal_right.
+  rewrites.
+  reflexivity.
+Qed.
+
+(* Copying then discarding one of the two copies is the identity: the
+   comonoid counit laws, with [eliminate] traded for [discard] by
+   terminality of [I]. *)
+
+Lemma proj_left_copy {x : C} :
+  @proj_left C _ markov_semicartesian x x ∘ copy[x] ≈ id[x].
+Proof.
+  unfold proj_left.
+  rewrite <- markov_discard_eliminate.
+  rewrite <- comp_assoc.
+  unfold copy, discard, ccomon_delta, ccomon_epsilon.
+  rewrite delta_counit_right.
+  apply iso_to_from.
+Qed.
+
+Lemma proj_right_copy {x : C} :
+  @proj_right C _ markov_semicartesian x x ∘ copy[x] ≈ id[x].
+Proof.
+  unfold proj_right.
+  rewrite <- markov_discard_eliminate.
+  rewrite <- comp_assoc.
+  unfold copy, discard, ccomon_delta, ccomon_epsilon.
+  rewrite delta_counit_left.
+  apply iso_to_from.
+Qed.
+
+(* Both marginals of a copied state recover the state: copying is a
+   (synthetic) diagonal coupling. *)
+
+Lemma marginal_left_copy {x : C} (s : state x) :
+  marginal_left (copy[x] ∘ s) ≈ s.
+Proof.
+  unfold marginal_left.
+  rewrite comp_assoc.
+  rewrite proj_left_copy.
+  apply id_left.
+Qed.
+
+Lemma marginal_right_copy {x : C} (s : state x) :
+  marginal_right (copy[x] ∘ s) ≈ s.
+Proof.
+  unfold marginal_right.
+  rewrite comp_assoc.
+  rewrite proj_right_copy.
+  apply id_left.
+Qed.
+
+End Markov.
+
+Arguments MarkovCategory C {S}.
+
+Section MarkovCartesian.
+
+Context {C : Category}.
+Context `{H : @CartesianMonoidal C}.
+
+(* Every cartesian monoidal category is a Markov category: Fox's
+   projection laws make the diagonal and [eliminate] a coherent comonoid
+   supply ([CD_of_Cartesian]), and the unit is terminal by definition. *)
+Program Definition Markov_of_Cartesian :
+  @MarkovCategory C
+    (@relevance_is_symmetric C (@cartesian_is_relevance C H)) := {|
+  markov_is_cd := @CD_of_Cartesian C H;
+  markov_semicartesian := @cartesian_is_semicartesian C H
+|}.
+
+End MarkovCartesian.

--- a/Structure/Monoidal/Markov/Fox.v
+++ b/Structure/Monoidal/Markov/Fox.v
@@ -1,0 +1,248 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Monoidal.Symmetric.
+Require Import Category.Structure.Monoidal.Relevance.
+Require Import Category.Structure.Monoidal.Semicartesian.
+Require Import Category.Structure.Monoidal.Heunen_Vicary.
+Require Import Category.Structure.Monoidal.Braided.Proofs.
+Require Import Category.Structure.Monoidal.Hypergraph.
+Require Import Category.Structure.Monoidal.CopyDiscard.
+Require Import Category.Structure.Monoidal.CopyDiscard.Proofs.
+Require Import Category.Structure.Monoidal.CopyDiscard.Deterministic.
+Require Import Category.Structure.Monoidal.Markov.
+Require Import Category.Theory.Algebra.Comonoid.
+Require Import Category.Theory.Algebra.CommutativeComonoid.
+
+Generalizable All Variables.
+
+(** * Fox's theorem: Markov categories with all morphisms deterministic
+
+    Fox's theorem (Fox 1976; Heunen–Vicary 2012, p. 84) delimits the
+    boundary between synthetic probability and ordinary (cartesian)
+    computation:
+
+    - a Markov category in which EVERY morphism is deterministic — i.e.
+      copying commutes with every morphism — is cartesian monoidal
+      ([all_deterministic_cartesian]); and, conversely,
+    - in a cartesian monoidal category every morphism is deterministic
+      with respect to the canonical diagonal/discard supply
+      ([cartesian_all_deterministic]).
+
+    Both directions together say that the copy-discard structure of a
+    Markov category carries genuine probabilistic content exactly when
+    copy-naturality breaks down somewhere; demanding it globally collapses the
+    tensor to a categorical product.  This grounds the "cartesianization
+    obstruction": no interesting Markov category factors through a
+    cartesian one without killing its nondeterminism.
+
+    The forward direction assembles a [RelevanceMonoidal] from the copy
+    supply — naturality of the diagonal being exactly the determinism
+    hypothesis — and discharges [CartesianMonoidal]'s remaining fields:
+
+      proj_left_diagonal / proj_right_diagonal
+        — the comonoid counit laws traded across terminality of [I]
+          ([proj_left_copy] / [proj_right_copy], Markov.v);
+      unit_left_braid / unit_right_braid
+        — the derived braid–unitor coherences [braid_unit_left] /
+          [braid_unit_right] of Structure/Monoidal/Braided/Proofs.v
+          (Joyal–Street Prop. 2.1), the load-bearing import.
+
+    Since in a Markov category the ε-triangle [discard ∘ f ≈ discard]
+    holds for free (terminality of [I]), determinism there is equivalent
+    to the copy square alone ([markov_deterministic_iff_copy]); this is
+    why the forward direction needs nothing beyond copy-naturality.
+
+    The packaging corollary [markov_all_deterministic_iff_cartesian]
+    states the equivalence in existential form: a category carries a
+    Markov structure whose morphisms are all deterministic iff it carries
+    a cartesian monoidal structure.  The two roundtrip corollaries pin
+    down that the forward construction preserves the supply: the copy
+    and discard induced by the produced cartesian structure agree with
+    the original ones.
+
+    nLab:      https://ncatlab.org/nlab/show/Markov+category
+    Reference: Fox, "Coalgebras and cartesian categories",
+               Comm. Algebra 4(7):665–667, 1976
+    Reference: Heunen & Vicary, "Categories for Quantum Theory",
+               Oxford UP, 2019, §4.3 (Fox's theorem, p. 84 of the 2012
+               lecture notes)
+    Reference: Fritz, "A synthetic approach to Markov kernels ..."
+               (arXiv:1908.07021), §10 *)
+
+Section Fox.
+
+Context {C : Category}.
+Context `{S : @SymmetricMonoidal C}.
+
+Section AllDeterministicCartesian.
+
+Context `{M : @MarkovCategory C S}.
+
+(** ** Determinism in a Markov category is the copy square alone
+
+    The ε-triangle of a comonoid homomorphism is automatic when the unit
+    is terminal, so a morphism of a Markov category is deterministic as
+    soon as it commutes with copying (Fritz, Definition 10.1). *)
+
+Lemma markov_deterministic_of_copy {x y : C} (f : x ~> y) :
+  copy[y] ∘ f ≈ (f ⨂ f) ∘ copy[x] → deterministic f.
+Proof.
+  intro Hcopy.
+  split.
+  - exact Hcopy.
+  - apply (@unit_terminal C _ markov_semicartesian).
+Qed.
+
+Corollary markov_deterministic_iff_copy {x y : C} (f : x ~> y) :
+  deterministic f ↔ (copy[y] ∘ f ≈ (f ⨂ f) ∘ copy[x]).
+Proof.
+  split.
+  - exact (copy_natural_on_deterministic f).
+  - exact (markov_deterministic_of_copy f).
+Qed.
+
+(** ** All morphisms deterministic ⇒ cartesian monoidal *)
+
+Context (D : ∀ x y (f : x ~> y), deterministic f).
+
+(* The copy supply becomes a natural diagonal: naturality is the
+   determinism hypothesis, and the remaining coherence fields are the
+   comonoid laws of the supply re-oriented. *)
+Program Definition Relevance_of_deterministic : @RelevanceMonoidal C := {|
+  relevance_is_symmetric := S;
+  diagonal := fun x => copy[x]
+|}.
+Next Obligation.
+  (* diagonal_natural: exactly the δ-square of the determinism
+     hypothesis, read right-to-left. *)
+  symmetry.
+  apply (copy_natural_on_deterministic _ (D _ _ _)).
+Qed.
+Next Obligation.
+  (* diagonal_unit: the unit-coherence field of the supply. *)
+  apply copy_unit.
+Qed.
+Next Obligation.
+  (* diagonal_tensor_assoc: coassociativity of the comonoid on x,
+     solved for the forward associator. *)
+  unfold copy, ccomon_delta.
+  rewrite <- comp_assoc.
+  rewrite delta_coassoc.
+  rewrite !comp_assoc.
+  rewrite iso_to_from.
+  rewrite id_left.
+  reflexivity.
+Qed.
+Next Obligation.
+  (* braid_diagonal: cocommutativity of the supply. *)
+  unfold copy, ccomon_delta.
+  apply delta_cocommutative_of_ccomon.
+Qed.
+Next Obligation.
+  (* diagonal_braid2: the tensor-coherence field, with [braid2]
+     recognized as [mid_swap_inv] (cf. braid2_mid_swap_inv). *)
+  rewrite copy_tensor.
+  comp_right.
+  unfold mid_swap_inv.
+  rewrite !bimap_comp_id_left.
+  rewrite !comp_assoc.
+  reflexivity.
+Qed.
+
+Program Definition all_deterministic_cartesian : @CartesianMonoidal C := {|
+  cartesian_is_relevance     := Relevance_of_deterministic;
+  cartesian_is_semicartesian := markov_semicartesian
+|}.
+Next Obligation.
+  (* proj_left_diagonal: the right counit law across terminality. *)
+  apply proj_left_copy.
+Qed.
+Next Obligation.
+  (* proj_right_diagonal: the left counit law across terminality. *)
+  apply proj_right_copy.
+Qed.
+Next Obligation.
+  (* unit_left_braid: Joyal–Street ρ ≈ λ ∘ β (Braided/Proofs.v). *)
+  apply braid_unit_left.
+Qed.
+Next Obligation.
+  (* unit_right_braid: the mirror coherence λ ≈ ρ ∘ β. *)
+  apply braid_unit_right.
+Qed.
+
+(** ** Roundtrip: the produced cartesian structure carries the original
+    supply
+
+    The copy-discard structure induced by [all_deterministic_cartesian]
+    (via [CD_of_Cartesian]) has the same copy — definitionally — and the
+    same discard — by terminality — as the Markov category we started
+    from.  Fox's construction loses nothing. *)
+
+Corollary all_deterministic_cartesian_copy {x : C} :
+  @copy C S (@CD_of_Cartesian C all_deterministic_cartesian) x ≈ copy[x].
+Proof. reflexivity. Qed.
+
+Corollary all_deterministic_cartesian_discard {x : C} :
+  @discard C S (@CD_of_Cartesian C all_deterministic_cartesian) x
+    ≈ discard[x].
+Proof. apply (@unit_terminal C _ markov_semicartesian). Qed.
+
+End AllDeterministicCartesian.
+
+(** ** Cartesian monoidal ⇒ all morphisms deterministic *)
+
+Section CartesianDeterministic.
+
+Context `{H : @CartesianMonoidal C}.
+
+(* Every morphism of a cartesian monoidal category is a comonoid
+   homomorphism for the canonical diagonal/discard supply: the δ-square
+   is naturality of the diagonal, and the ε-triangle is terminality of
+   the unit.  "All kernels are deterministic": the degenerate,
+   probability-free reading of a cartesian category as a Markov one. *)
+Theorem cartesian_all_deterministic :
+  ∀ x y (f : x ~> y), @deterministic C _ (@CD_of_Cartesian C H) x y f.
+Proof.
+  intros x y f.
+  split.
+  - symmetry; apply diagonal_natural.
+  - apply unit_terminal.
+Qed.
+
+End CartesianDeterministic.
+
+End Fox.
+
+(** ** Packaging: Fox's theorem as an equivalence
+
+    A category carries a Markov structure in which every morphism is
+    deterministic precisely when it carries a cartesian monoidal
+    structure.  The forward direction is [all_deterministic_cartesian];
+    the backward direction equips the category with the canonical Markov
+    structure of its cartesian one ([Markov_of_Cartesian]) and observes
+    that all morphisms are deterministic there. *)
+
+Section FoxPackaging.
+
+Context {C : Category}.
+
+Corollary markov_all_deterministic_iff_cartesian :
+  (∃ (S : @SymmetricMonoidal C) (M : @MarkovCategory C S),
+     ∀ x y (f : x ~> y), @deterministic C S (@markov_is_cd C S M) x y f)
+    ↔ @CartesianMonoidal C.
+Proof.
+  split.
+  - intros [S' [M' D]].
+    exact (@all_deterministic_cartesian C S' M' D).
+  - intro H.
+    exists (@relevance_is_symmetric C (@cartesian_is_relevance C H)).
+    exists (@Markov_of_Cartesian C H).
+    intros x y f.
+    exact (@cartesian_all_deterministic C H x y f).
+Qed.
+
+End FoxPackaging.

--- a/Theory/Algebra/Comonoid/Hom.v
+++ b/Theory/Algebra/Comonoid/Hom.v
@@ -1,0 +1,231 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Theory.Algebra.Comonoid.
+
+Generalizable All Variables.
+
+(** * Comonoid homomorphisms and the category of internal comonoids *)
+
+(* nLab: https://ncatlab.org/nlab/show/comonoid
+
+   Given internal comonoids (x, delta[Cx], epsilon[Cx]) and
+   (y, delta[Cy], epsilon[Cy]) in a monoidal category (C, ⨂, I), a morphism
+   f : x ~> y is a comonoid homomorphism when it commutes with the
+   comultiplications and counits:
+
+     comultiplication square   delta[Cy] ∘ f ≈ (f ⨂ f) ∘ delta[Cx]
+     counit triangle           epsilon[Cy] ∘ f ≈ epsilon[Cx]
+
+   This is the exact arrow-reversed mirror of [MonoidHom] in
+   Theory/Algebra/Monoid/Hom.v.  Comonoid homomorphisms contain the
+   identities and are closed under composition, so internal comonoids and
+   their homomorphisms form a category Comon(C), packaged with sigma objects
+   and homs exactly as [Mon] is — morphism equivalence is equivalence of the
+   underlying C-morphisms — and projecting out the underlying object and
+   morphism gives the forgetful functor Comon(C) ⟶ C, faithful by
+   construction ([Comon_Forget_Faithful]).
+
+   Beyond its algebraic role, this class is the predicate behind
+   *determinism* in categorical probability: in a category where every
+   object carries a canonical copy/discard comonoid, Cho–Jacobs
+   (arXiv:1709.00322) call a morphism deterministic precisely when it is a
+   comonoid homomorphism between the canonical comonoids — copying the
+   output of f is the same as running f twice on a copied input, and
+   discarding the output is the same as discarding the input.
+   Structure/Monoidal/CopyDiscard/Deterministic.v instantiates this class at
+   those canonical comonoids.
+
+   The [Comonoid_Iso] transport at the end moves a comonoid structure across
+   an isomorphism i : x ≅ y by conjugation; both components of i then become
+   comonoid homomorphisms — with respect to the TRANSPORTED structure on the
+   codomain.  It is provided as standalone infrastructure and currently has
+   no in-tree consumer.  In particular,
+   Structure/Monoidal/CopyDiscard/Deterministic.v does NOT use it: the
+   determinism of the structural isomorphisms demands a [ComonoidHom]
+   between the canonical comonoids at BOTH endpoints, whereas the transport
+   only yields homomorphisms into [Comonoid_Iso i Cx], so those lemmas are
+   proved there by direct coherence chases at the canonical supply. *)
+
+Section ComonoidHom.
+
+Context {C : Category}.
+Context `{M : @Monoidal C}.
+
+Class ComonoidHom {x y : C} (Cx : Comonoid x) (Cy : Comonoid y)
+      (f : x ~> y) : Type := {
+  (* f preserves comultiplication: δ ∘ f ≈ (f ⨂ f) ∘ δ *)
+  hom_delta   : delta[Cy] ∘ f ≈ (f ⨂ f) ∘ delta[Cx];
+  (* f preserves the counit: ε ∘ f ≈ ε *)
+  hom_epsilon : epsilon[Cy] ∘ f ≈ epsilon[Cx]
+}.
+
+(* The identity is a comonoid homomorphism. *)
+Lemma ComonoidHom_id {x} (Cx : Comonoid x) : ComonoidHom Cx Cx id.
+Proof. split; cat. Qed.
+
+(* Comonoid homomorphisms are closed under composition: paste the two
+   preservation squares, fusing (f ⨂ f) ∘ (g ⨂ g) into (f ∘ g) ⨂ (f ∘ g)
+   by the interchange law [bimap_comp]. *)
+Lemma ComonoidHom_comp {x y z} {Cx : Comonoid x} {Cy : Comonoid y}
+      {Cz : Comonoid z} {f : y ~> z} {g : x ~> y} :
+  ComonoidHom Cy Cz f → ComonoidHom Cx Cy g → ComonoidHom Cx Cz (f ∘ g).
+Proof.
+  intros F G.
+  split.
+  - rewrite comp_assoc.
+    rewrite (@hom_delta _ _ _ _ _ F).
+    rewrite <- comp_assoc.
+    rewrite (@hom_delta _ _ _ _ _ G).
+    rewrite comp_assoc.
+    now rewrite <- bimap_comp.
+  - rewrite comp_assoc.
+    rewrite (@hom_epsilon _ _ _ _ _ F).
+    apply (@hom_epsilon _ _ _ _ _ G).
+Qed.
+
+(* Being a comonoid homomorphism transports along ≈ (bimap respects ≈). *)
+Lemma ComonoidHom_equiv {x y} {Cx : Comonoid x} {Cy : Comonoid y}
+      {f g : x ~> y} :
+  f ≈ g → ComonoidHom Cx Cy f → ComonoidHom Cx Cy g.
+Proof.
+  intros E F.
+  split.
+  - rewrite <- E.
+    apply (@hom_delta _ _ _ _ _ F).
+  - rewrite <- E.
+    apply (@hom_epsilon _ _ _ _ _ F).
+Qed.
+
+(* Transport of a comonoid structure across an isomorphism i : x ≅ y, by
+   conjugation: copy on y is "carry back along i⁻¹, copy on x, carry both
+   halves forward along i", and discard on y is "carry back, discard".  The
+   laws are those of Cx conjugated by i; each proof cancels the inner
+   [from i ∘ to i], applies the corresponding law of Cx, and transports the
+   result across the naturality square of the relevant structural map. *)
+
+#[local] Obligation Tactic := intros.
+
+Program Definition Comonoid_Iso {x y : C} (i : x ≅ y) (Cx : Comonoid x) :
+  Comonoid y := {|
+  delta   := (to i ⨂ to i) ∘ delta[Cx] ∘ from i;
+  epsilon := epsilon[Cx] ∘ from i
+|}.
+Next Obligation.
+  (* coassociativity: cancel the conjugating iso on the right, then it is
+     [delta_coassoc] of Cx pushed across the associator's naturality. *)
+  apply (iso_to_epic i).
+  rewrite <- !comp_assoc.
+  rewrite iso_from_to, id_right.
+  normal.
+  rewrite <- !comp_assoc.
+  rewrite iso_from_to, id_right.
+  normal.
+  assert (E : ((to i ⨂ to i) ∘ delta[Cx]) ⨂ to i
+                ≈ ((to i ⨂ to i) ⨂ to i) ∘ (delta[Cx] ⨂ id)).
+  { rewrite <- bimap_comp; cat. }
+  rewrite E; clear E.
+  rewrite <- comp_assoc.
+  rewrite (@delta_coassoc _ _ _ Cx).
+  normal.
+  rewrite from_tensor_assoc_natural.
+  rewrite <- !comp_assoc.
+  normal.
+  reflexivity.
+Qed.
+Next Obligation.
+  (* left counit: cancel the conjugating iso, apply [delta_counit_left] of
+     Cx, and close with naturality of the left unitor's inverse. *)
+  apply (iso_to_epic i).
+  rewrite <- !comp_assoc.
+  rewrite iso_from_to, id_right.
+  normal.
+  rewrite <- !comp_assoc.
+  rewrite iso_from_to, id_right.
+  normal.
+  assert (E : epsilon[Cx] ⨂ to i ≈ (id ⨂ to i) ∘ (epsilon[Cx] ⨂ id)).
+  { rewrite <- bimap_comp; cat. }
+  rewrite E; clear E.
+  rewrite <- comp_assoc.
+  rewrite (@delta_counit_left _ _ _ Cx).
+  apply from_unit_left_natural.
+Qed.
+Next Obligation.
+  (* right counit: mirror of the previous obligation. *)
+  apply (iso_to_epic i).
+  rewrite <- !comp_assoc.
+  rewrite iso_from_to, id_right.
+  normal.
+  rewrite <- !comp_assoc.
+  rewrite iso_from_to, id_right.
+  normal.
+  assert (E : to i ⨂ epsilon[Cx] ≈ (to i ⨂ id) ∘ (id ⨂ epsilon[Cx])).
+  { rewrite <- bimap_comp; cat. }
+  rewrite E; clear E.
+  rewrite <- comp_assoc.
+  rewrite (@delta_counit_right _ _ _ Cx).
+  apply from_unit_right_natural.
+Qed.
+
+#[local] Obligation Tactic := cat_simpl.
+
+(* Both components of the isomorphism are comonoid homomorphisms with
+   respect to the transported structure. *)
+Lemma ComonoidHom_Iso_to {x y} (i : x ≅ y) (Cx : Comonoid x) :
+  ComonoidHom Cx (Comonoid_Iso i Cx) (to i).
+Proof.
+  split; simpl.
+  - rewrite <- !comp_assoc.
+    rewrite iso_from_to; cat.
+  - rewrite <- comp_assoc.
+    rewrite iso_from_to; cat.
+Qed.
+
+Lemma ComonoidHom_Iso_from {x y} (i : x ≅ y) (Cx : Comonoid x) :
+  ComonoidHom (Comonoid_Iso i Cx) Cx (from i).
+Proof.
+  split; simpl.
+  - symmetry.
+    rewrite comp_assoc.
+    normal.
+    rewrite !iso_from_to; cat.
+  - reflexivity.
+Qed.
+
+(* The category Comon(C) of internal comonoids in C: objects are objects of
+   C equipped with a comonoid structure, morphisms are C-morphisms equipped
+   with a proof of homomorphy, and equivalence is equivalence of the
+   underlying morphisms — the same sigma packaging as [Mon] and [Sub] in
+   Construction/Subcategory.v. *)
+Program Definition Comon : Category := {|
+  obj     := { x : C & Comonoid x };
+  hom     := fun X Y => { f : `1 X ~> `1 Y & ComonoidHom `2 X `2 Y f };
+  homset  := fun _ _ => {| equiv := fun f g => `1 f ≈ `1 g |};
+  id      := fun X => (id; ComonoidHom_id `2 X);
+  compose := fun _ _ _ f g => (`1 f ∘ `1 g; ComonoidHom_comp `2 f `2 g)
+|}.
+
+(* The forgetful functor Comon(C) ⟶ C projects out the underlying object
+   and morphism; it is faithful by construction ([Comon_Forget_Faithful]
+   below). *)
+Program Definition Comon_Forget : Comon ⟶ C := {|
+  fobj := fun X => `1 X;
+  fmap := fun _ _ f => `1 f
+|}.
+
+(* Faithfulness is definitional: morphism equivalence in Comon(C) IS
+   equivalence of the underlying C-morphisms, which is what [fmap] projects
+   out. *)
+#[export] Instance Comon_Forget_Faithful : Faithful Comon_Forget.
+Proof.
+  constructor.
+  intros X Y f g E.
+  exact E.
+Qed.
+
+End ComonoidHom.
+
+Arguments Comon C {M}.

--- a/Theory/Algebra/Monoid/Hom.v
+++ b/Theory/Algebra/Monoid/Hom.v
@@ -1,0 +1,111 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Theory.Algebra.Monoid.
+
+Generalizable All Variables.
+
+(** * Monoid homomorphisms and the category of internal monoids *)
+
+(* nLab: https://ncatlab.org/nlab/show/monoid+in+a+monoidal+category
+
+   Given internal monoids (x, mu[Mx], eta[Mx]) and (y, mu[My], eta[My]) in a
+   monoidal category (C, ⨂, I), a morphism f : x ~> y is a monoid
+   homomorphism when it commutes with the multiplications and units:
+
+     multiplication square   f ∘ mu[Mx] ≈ mu[My] ∘ (f ⨂ f)
+     unit triangle           f ∘ eta[Mx] ≈ eta[My]
+
+   Monoid homomorphisms contain the identities and are closed under
+   composition, so internal monoids and their homomorphisms form a category
+   Mon(C), packaged here with sigma objects and homs — the same pattern as
+   [Sub] in Construction/Subcategory.v, where morphism equivalence is
+   equivalence of the underlying C-morphisms.  Projecting out the underlying
+   object and morphism gives the forgetful functor Mon(C) ⟶ C, faithful by
+   construction ([Mon_Forget_Faithful]). *)
+
+Section MonoidHom.
+
+Context {C : Category}.
+Context `{M : @Monoidal C}.
+
+Class MonoidHom {x y : C} (Mx : Monoid x) (My : Monoid y) (f : x ~> y) :
+  Type := {
+  (* f preserves multiplication: f ∘ μ ≈ μ ∘ (f ⨂ f) *)
+  hom_mu  : f ∘ mu[Mx] ≈ mu[My] ∘ (f ⨂ f);
+  (* f preserves the unit: f ∘ η ≈ η *)
+  hom_eta : f ∘ eta[Mx] ≈ eta[My]
+}.
+
+(* The identity is a monoid homomorphism. *)
+Lemma MonoidHom_id {x} (Mx : Monoid x) : MonoidHom Mx Mx id.
+Proof. split; cat. Qed.
+
+(* Monoid homomorphisms are closed under composition: paste the two
+   preservation squares, fusing (f ⨂ f) ∘ (g ⨂ g) into (f ∘ g) ⨂ (f ∘ g)
+   by the interchange law [bimap_comp]. *)
+Lemma MonoidHom_comp {x y z} {Mx : Monoid x} {My : Monoid y} {Mz : Monoid z}
+      {f : y ~> z} {g : x ~> y} :
+  MonoidHom My Mz f → MonoidHom Mx My g → MonoidHom Mx Mz (f ∘ g).
+Proof.
+  intros F G.
+  split.
+  - rewrite <- comp_assoc.
+    rewrite (@hom_mu _ _ _ _ _ G).
+    rewrite comp_assoc.
+    rewrite (@hom_mu _ _ _ _ _ F).
+    rewrite <- comp_assoc.
+    now rewrite <- bimap_comp.
+  - rewrite <- comp_assoc.
+    rewrite (@hom_eta _ _ _ _ _ G).
+    apply (@hom_eta _ _ _ _ _ F).
+Qed.
+
+(* Being a monoid homomorphism transports along ≈ (bimap respects ≈). *)
+Lemma MonoidHom_equiv {x y} {Mx : Monoid x} {My : Monoid y} {f g : x ~> y} :
+  f ≈ g → MonoidHom Mx My f → MonoidHom Mx My g.
+Proof.
+  intros E F.
+  split.
+  - rewrite <- E.
+    apply (@hom_mu _ _ _ _ _ F).
+  - rewrite <- E.
+    apply (@hom_eta _ _ _ _ _ F).
+Qed.
+
+(* The category Mon(C) of internal monoids in C: objects are objects of C
+   equipped with a monoid structure, morphisms are C-morphisms equipped with
+   a proof of homomorphy, and equivalence is equivalence of the underlying
+   morphisms — exactly the sigma packaging of [Sub] in
+   Construction/Subcategory.v. *)
+Program Definition Mon : Category := {|
+  obj     := { x : C & Monoid x };
+  hom     := fun X Y => { f : `1 X ~> `1 Y & MonoidHom `2 X `2 Y f };
+  homset  := fun _ _ => {| equiv := fun f g => `1 f ≈ `1 g |};
+  id      := fun X => (id; MonoidHom_id `2 X);
+  compose := fun _ _ _ f g => (`1 f ∘ `1 g; MonoidHom_comp `2 f `2 g)
+|}.
+
+(* The forgetful functor Mon(C) ⟶ C projects out the underlying object and
+   morphism; it is faithful by construction ([Mon_Forget_Faithful] below). *)
+Program Definition Mon_Forget : Mon ⟶ C := {|
+  fobj := fun X => `1 X;
+  fmap := fun _ _ f => `1 f
+|}.
+
+(* Faithfulness is definitional: morphism equivalence in Mon(C) IS
+   equivalence of the underlying C-morphisms, which is what [fmap] projects
+   out. *)
+#[export] Instance Mon_Forget_Faithful : Faithful Mon_Forget.
+Proof.
+  constructor.
+  intros X Y f g E.
+  exact E.
+Qed.
+
+End MonoidHom.
+
+Arguments Mon C {M}.

--- a/_CoqProject
+++ b/_CoqProject
@@ -81,6 +81,7 @@ Functor/Structure/Monoidal.v
 Functor/Structure/Monoidal/Compose.v
 Functor/Structure/Monoidal/Id.v
 Functor/Structure/Monoidal/Pure.v
+Functor/Structure/Monoidal/Strict.v
 Functor/Structure/Terminal.v
 Functor/Traversable.v
 Functor/Traversable/Product.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -78,6 +78,7 @@ Functor/Structure/Cartesian.v
 Functor/Structure/Cartesian/Closed.v
 Functor/Structure/Constant.v
 Functor/Structure/Monoidal.v
+Functor/Structure/Monoidal/Braided.v
 Functor/Structure/Monoidal/Compose.v
 Functor/Structure/Monoidal/Id.v
 Functor/Structure/Monoidal/Pure.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -216,6 +216,7 @@ Structure/Monoidal/CopyDiscard.v
 Structure/Monoidal/CopyDiscard/Proofs.v
 Structure/Monoidal/CopyDiscard/Deterministic.v
 Structure/Monoidal/Internal/Product.v
+Structure/Monoidal/Markov.v
 Structure/Monoidal/Naturality.v
 Structure/Monoidal/Product.v
 Structure/Monoidal/Proofs.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -243,6 +243,7 @@ Theory/Algebra.v
 Theory/Algebra/Monoid.v
 Theory/Algebra/Monoid/Hom.v
 Theory/Algebra/Comonoid.v
+Theory/Algebra/Comonoid/Hom.v
 Theory/Algebra/CommutativeMonoid.v
 Theory/Algebra/CommutativeComonoid.v
 Theory/Algebra/Frobenius.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -213,6 +213,7 @@ Structure/Monoidal/Closed.v
 Structure/Monoidal/Commutative.v
 Structure/Monoidal/Compose.v
 Structure/Monoidal/CopyDiscard.v
+Structure/Monoidal/CopyDiscard/Proofs.v
 Structure/Monoidal/Internal/Product.v
 Structure/Monoidal/Naturality.v
 Structure/Monoidal/Product.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -210,6 +210,7 @@ Structure/Monoidal/Heunen_Vicary.v
 Structure/Monoidal/Heunen_Vicary/Cartesian.v
 Structure/Monoidal/Heunen_Vicary/Proofs.v
 Structure/Monoidal/Closed.v
+Structure/Monoidal/Collapse.v
 Structure/Monoidal/Commutative.v
 Structure/Monoidal/Compose.v
 Structure/Monoidal/CopyDiscard.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -241,6 +241,7 @@ Theory.v
 Theory/Adjunction.v
 Theory/Algebra.v
 Theory/Algebra/Monoid.v
+Theory/Algebra/Monoid/Hom.v
 Theory/Algebra/Comonoid.v
 Theory/Algebra/CommutativeMonoid.v
 Theory/Algebra/CommutativeComonoid.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -212,6 +212,7 @@ Structure/Monoidal/Heunen_Vicary/Proofs.v
 Structure/Monoidal/Closed.v
 Structure/Monoidal/Commutative.v
 Structure/Monoidal/Compose.v
+Structure/Monoidal/CopyDiscard.v
 Structure/Monoidal/Internal/Product.v
 Structure/Monoidal/Naturality.v
 Structure/Monoidal/Product.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -25,6 +25,7 @@ Construction/Funny/Hom.v
 Construction/Funny/Closed.v
 Construction/Groupoid.v
 Construction/Opposite.v
+Construction/Opposite/Monoidal.v
 Construction/Product.v
 Construction/Product/Comma.v
 Construction/Slice.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -214,6 +214,7 @@ Structure/Monoidal/Commutative.v
 Structure/Monoidal/Compose.v
 Structure/Monoidal/CopyDiscard.v
 Structure/Monoidal/CopyDiscard/Proofs.v
+Structure/Monoidal/CopyDiscard/Deterministic.v
 Structure/Monoidal/Internal/Product.v
 Structure/Monoidal/Naturality.v
 Structure/Monoidal/Product.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -217,6 +217,7 @@ Structure/Monoidal/CopyDiscard/Proofs.v
 Structure/Monoidal/CopyDiscard/Deterministic.v
 Structure/Monoidal/Internal/Product.v
 Structure/Monoidal/Markov.v
+Structure/Monoidal/Markov/Fox.v
 Structure/Monoidal/Naturality.v
 Structure/Monoidal/Product.v
 Structure/Monoidal/Proofs.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -201,6 +201,7 @@ Structure/Monoid.v
 Structure/Monoidal.v
 Structure/Monoidal/Balanced.v
 Structure/Monoidal/Braided.v
+Structure/Monoidal/Braided/Proofs.v
 Structure/Monoidal/Cartesian.v
 Structure/Monoidal/Heunen_Vicary.v
 Structure/Monoidal/Heunen_Vicary/Cartesian.v


### PR DESCRIPTION
## Summary

First of a four-PR stack formalizing the applied-category-theory floor identified by the Ares gap analysis. **Merge order: this PR first; each subsequent phase PR is based on its predecessor.**

12 new files (~3,900 lines), 17 commits:

- **The Markov stack**: `Structure/Monoidal/CopyDiscard.v` — gs-monoidal categories (per-object commutative-comonoid supply with deliberately *no* naturality); `CopyDiscard/Deterministic.v` — deterministic := comonoid homomorphism, closure laws, the wide subcategory `Det(C)`, copy/discard natural exactly on it, and `copy`/`discard` themselves deterministic; `Markov.v` — redundancy-free `CopyDiscard + Semicartesian` (Fritz); **Fox's theorem both directions** (`Markov/Fox.v`) as a Type-level `iffT` with supply-preserving round trips.
- **Cross-cutting enablers**: the braid-unitor coherences `ρ ≈ λ∘β` (`Braided/Proofs.v` — closing the gap `Monad/Strong.v` documented); strict/braided/symmetric monoidal *functor* classes with `Id`/`Compose`; `Mon(C)`/`Comon(C)` with hom classes; `Monoidal/Braided/Symmetric` on `C^op` with Comonoid ⟷ Monoid-in-`C^op` duality transfer; Frobenius-collapse and no-cloning no-go results.

Deliberately absent: a `Relevance ⇒ CopyDiscard` instance — it is unsound (Relevance lacks counit compatibility); reviewers confirmed the code refuses it.

## Verification

- Zero `Admitted`/axioms; every principal artifact reports *Closed under the global context*
- Two independent clean-rebuild verifications + full `make`, `nix build`, `nix flake check`
- Adversarial per-file review with 3-vote refutation panels; all confirmed findings fixed
- `make todo` silent on all new files

Caveat: developed on Rocq 9.1; the `coq-ci.yml` Docker jobs build 8.19/8.20 — worth watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011k7xm8t5nbGeDDYvSpkuDP