### PR TITLE
Phase 4: the effects stack — premonoidal, Freyd, Kleisli, thunkability, graded monads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ Example: `f ∘[C] g` specifies category C when needed.
 - **Structure/Monoidal.v**: Tensor products with coherence
 - **Structure/Monoidal/CopyDiscard.v**: Copy/discard (gs-monoidal) categories — comonoid supply with no naturality; deterministic morphisms and the wide subcategory Det in CopyDiscard/Deterministic.v
 - **Structure/Monoidal/Markov.v**: Markov categories (copy/discard + semicartesian); Fox's theorem in Markov/Fox.v (all-deterministic ⟺ cartesian)
+- **Structure/Premonoidal.v**: Premonoidal categories over Structure/Binoidal.v — centre Z(C) as a monoidal wide subcategory (Binoidal/Central.v, Premonoidal/Centre.v), Monoidal ⟺ all-central premonoidal (Premonoidal/Monoidal.v), Freyd/effectful categories (Premonoidal/Freyd.v); Kleisli premonoidal structure and thunkability in Monad/Kleisli/{Premonoidal,Commutative}.v and Monad/Thunkable.v; graded monads in Monad/Graded.v; strict premonoidal = monoid in (StrictCat, □) in Instance/StrictCat/Premonoid.v
 - **Structure/Limit.v**: Limits and colimits
 
 ### Constructions (External Combinators)

--- a/Instance/StrictCat/Premonoid.v
+++ b/Instance/StrictCat/Premonoid.v
@@ -1,0 +1,251 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Theory.Naturality.
+Require Import Category.Construction.Product.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Instance.One.
+Require Import Category.Instance.StrictCat.
+Require Import Category.Instance.StrictCat.Terminal.
+Require Import Category.Construction.Funny.
+Require Import Category.Construction.Funny.StrictEq.
+Require Import Category.Construction.Funny.Bifunctor.
+Require Import Category.Construction.Funny.Unitors.
+Require Import Category.Construction.Funny.Swap.
+Require Import Category.Construction.Funny.Associator.
+Require Import Category.Instance.StrictCat.Funny.
+Require Import Category.Structure.Terminal.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Monoidal.Braided.
+Require Import Category.Structure.Monoidal.Symmetric.
+Require Import Category.Structure.Monoidal.Semicartesian.
+Require Import Category.Structure.Monoid.
+Require Import Category.Structure.Binoidal.
+
+Generalizable All Variables.
+
+(** * Strict premonoidal structures as monoid objects in (StrictCat, □)
+
+    The funny bridge: a strict premonoidal structure on a category [c] is
+    precisely a monoid object in the symmetric monoidal category
+    [(StrictCat, □, 1)] of Instance/StrictCat/Funny.v.  This is the funny
+    counterpart of the classical fact that a monoid in [(Cat, ∏, 1)] is a
+    strict monoidal category:
+
+      - the multiplication [mappend : c □ c ⟶ c] is a tensor that is
+        functorial in each variable SEPARATELY — by the funny tensor's
+        universal property (Construction/Funny.v: a functor out of [c □ c]
+        is exactly a [SepFunctorial] assignment), with no interchange law
+        relating the two partial actions.  This "separately functorial,
+        jointly not" tensor is the binoidal core of a premonoidal category
+        in the sense of Power–Robinson ("Premonoidal categories and notions
+        of computation", MSCS 7(5), 1997); see also nLab, "funny tensor
+        product" and "premonoidal category";
+      - the unit [mempty : 1 ⟶ c] picks out the tensor unit object;
+      - the monoid laws, read in StrictCat's strict hom-setoid
+        [Functor_StrictEq_Setoid], say that unitality and associativity of
+        the tensor hold on the nose, the comparison data being the funny
+        unitors (Construction/Funny/Unitors.v) and the funny associator
+        (Construction/Funny/Associator.v).  Strictness makes all of
+        Power–Robinson's central coherence isomorphisms identities, so no
+        centrality conditions need to be stated: this is the STRICT case of
+        the premonoidal notion whose general, iso-weakened form lives in
+        Structure/Premonoidal.v.
+
+    The record [StrictPremonoidal] below spells out the three monoid laws in
+    unfolded form (the field types ARE the types of [mempty_left],
+    [mempty_right] and [mappend_assoc] at [(StrictCat, Funny_Monoidal, c)],
+    up to definitional unfolding), so the two constructions
+
+      [StrictPremonoidal_of_Monoid]  and  [Monoid_of_StrictPremonoidal]
+
+    are pure repackagings, and all four data-projection round trips hold by
+    [reflexivity].  The extractions [StrictPremonoidal_Binoidal] and
+    [StrictPremonoidal_SepFunctorial] connect the multiplication to the
+    [Binoidal] class of Structure/Binoidal.v and to the funny tensor's
+    universal property, again definitionally on the generating steps.
+
+    Universe scope.  [Funny_Monoidal@{u} : Monoidal@{u Set}] pins
+    StrictCat's member categories to [Category@{Set Set Set}].  Re-declaring
+    the instance at a rigid universe [v] is blocked: the compiled unitors of
+    Construction/Funny/Unitors.v carry a minimized [Set] level, and
+    [Build_Monoidal] at member level [v] reports the constraint [Set = v] as
+    unsatisfiable (probe ProbeFunnyPoly.v — re-verified this session by
+    recompiling the probe, which reproduces "Cannot enforce Set = v" at the
+    [Build_Monoidal] unitor field; an earlier .vo of the probe was stale).
+    Everything below therefore holds for [Set]-small carrier categories;
+    lifting the restriction requires re-declaring the unitors with explicit
+    universe binders in Construction/Funny/Unitors.v, which is outside this
+    phase's envelope. *)
+
+#[local] Obligation Tactic := idtac.
+
+(** ** Strict premonoidal structures
+
+    The three law fields are stated as strict equalities of functors, i.e.
+    in [Functor_StrictEq_Setoid]: their right-hand sides are the funny
+    unitors and associator, exactly as in the unfolded [MonoidObject] laws
+    at [(StrictCat, Funny_Monoidal, c)].  In particular
+
+      [to (@Funny_unit_left c)]  is definitionally [Funny_unit_left_to],
+      [to (@Funny_unit_right c)] is definitionally [Funny_unit_right_to],
+      [to (@Funny_assoc c c c)]  is definitionally [FunnyAssocTo],
+
+    and [FunnyBimap F G] is definitionally [bimap[FunnyTensor] F G], so the
+    types below convert to the [mempty_left]/[mempty_right]/[mappend_assoc]
+    types on the nose.  The law fields are Type-valued (a
+    [Functor_StrictEq_Setoid] equivalence is a sigma of an object-equality
+    family and transported morphism agreement), which is why the round trips
+    below compare the DATA projections and not whole records. *)
+
+Record StrictPremonoidal (c : Category) : Type := {
+  sp_tensor : (c □ c) ⟶ c;
+  sp_unit   : _1 ⟶ c;
+
+  (* left unit law: tensoring with the unit on the left is the left funny
+     unitor, strictly *)
+  sp_unit_left :
+    @equiv _ (@Functor_StrictEq_Setoid (_1 □ c) c)
+      (sp_tensor ◯ FunnyBimap sp_unit Id[c])
+      (to (@Funny_unit_left c));
+
+  (* right unit law: tensoring with the unit on the right is the right funny
+     unitor, strictly *)
+  sp_unit_right :
+    @equiv _ (@Functor_StrictEq_Setoid (c □ _1) c)
+      (sp_tensor ◯ FunnyBimap Id[c] sp_unit)
+      (to (@Funny_unit_right c));
+
+  (* associativity: the two reassociated double tensors agree across the
+     funny associator, strictly *)
+  sp_assoc :
+    @equiv _ (@Functor_StrictEq_Setoid ((c □ c) □ c) c)
+      (sp_tensor ◯ FunnyBimap sp_tensor Id[c])
+      ((sp_tensor ◯ FunnyBimap Id[c] sp_tensor) ◯ to (@Funny_assoc c c c))
+}.
+
+Arguments sp_tensor {c} _.
+Arguments sp_unit {c} _.
+Arguments sp_unit_left {c} _.
+Arguments sp_unit_right {c} _.
+Arguments sp_assoc {c} _.
+
+(** ** The correspondence
+
+    Both directions are pure repackagings: the record fields were stated as
+    the unfolded monoid-object laws, so each construction is an explicit
+    constructor application whose arguments typecheck by conversion alone. *)
+
+Definition StrictPremonoidal_of_Monoid {c : Category}
+  (m : @MonoidObject StrictCat Funny_Monoidal c) : StrictPremonoidal c :=
+  @Build_StrictPremonoidal c
+    mappend[m]
+    mempty[m]
+    (@mempty_left StrictCat Funny_Monoidal c m)
+    (@mempty_right StrictCat Funny_Monoidal c m)
+    (@mappend_assoc StrictCat Funny_Monoidal c m).
+
+Definition Monoid_of_StrictPremonoidal {c : Category}
+  (p : StrictPremonoidal c) : @MonoidObject StrictCat Funny_Monoidal c :=
+  @Build_MonoidObject StrictCat Funny_Monoidal c
+    (sp_unit p)
+    (sp_tensor p)
+    (sp_unit_left p)
+    (sp_unit_right p)
+    (sp_assoc p).
+
+(** ** Round trips
+
+    The two constructions are mutually inverse on the data.  The law fields
+    are Type-valued [Functor_StrictEq] witnesses, so a record-level equality
+    is not the right statement; the four data-projection equalities below
+    are, and each holds by [reflexivity] because both constructions are
+    constructor applications and projections compute. *)
+
+Lemma roundtrip_mempty {c : Category}
+  (m : @MonoidObject StrictCat Funny_Monoidal c) :
+  mempty[Monoid_of_StrictPremonoidal (StrictPremonoidal_of_Monoid m)]
+    = mempty[m].
+Proof. reflexivity. Qed.
+
+Lemma roundtrip_mappend {c : Category}
+  (m : @MonoidObject StrictCat Funny_Monoidal c) :
+  mappend[Monoid_of_StrictPremonoidal (StrictPremonoidal_of_Monoid m)]
+    = mappend[m].
+Proof. reflexivity. Qed.
+
+Lemma roundtrip_sp_unit {c : Category} (p : StrictPremonoidal c) :
+  sp_unit (StrictPremonoidal_of_Monoid (Monoid_of_StrictPremonoidal p))
+    = sp_unit p.
+Proof. reflexivity. Qed.
+
+Lemma roundtrip_sp_tensor {c : Category} (p : StrictPremonoidal c) :
+  sp_tensor (StrictPremonoidal_of_Monoid (Monoid_of_StrictPremonoidal p))
+    = sp_tensor p.
+Proof. reflexivity. Qed.
+
+(** ** The binoidal payoff
+
+    A functor out of [c □ c] is exactly a separately-functorial tensor, so a
+    strict premonoidal structure yields a [Binoidal] structure on its
+    carrier: the two one-argument tensoring functors are the composites of
+    [sp_tensor] with the funny injections [FunnyL]/[FunnyR].  Since
+    [fobj[FunnyL d] x ≡ (x, d)] and [fmap[FunnyL d] f ≡ lstep f] hold
+    definitionally (Construction/Funny.v), the [AFunctor] index of each
+    injection matches [λ x, fobj[sp_tensor p] (x, y')] up to beta, and the
+    whole instance is assembled with no proof obligations. *)
+
+Definition StrictPremonoidal_Binoidal {c : Category}
+  (p : StrictPremonoidal c) : @Binoidal c :=
+  @Build_Binoidal c
+    (fun x y : c => fobj[sp_tensor p] (x, y))
+    (fun y' : c => ToAFunctor (sp_tensor p ◯ @FunnyL c c y'))
+    (fun x' : c => ToAFunctor (sp_tensor p ◯ @FunnyR c c x')).
+
+(* The extracted tensor is the object action of the multiplication, on the
+   nose. *)
+Corollary StrictPremonoidal_Binoidal_tensor {c : Category}
+  (p : StrictPremonoidal c) (x y : c) :
+  @tensor c (StrictPremonoidal_Binoidal p) x y = fobj[sp_tensor p] (x, y).
+Proof. reflexivity. Qed.
+
+(* The two partial tensoring functors act on morphisms as the multiplication
+   acts on the generating steps of the funny tensor — definitionally. *)
+Corollary StrictPremonoidal_inj_left_fmap {c : Category}
+  (p : StrictPremonoidal c) {x y : c} (f : x ~{c}~> y) (y' : c) :
+  fmap[@inj_left c (StrictPremonoidal_Binoidal p) y'] f
+    = @fmap (c □ c) c (sp_tensor p) (x, y') (y, y') (lstep f).
+Proof. reflexivity. Qed.
+
+Corollary StrictPremonoidal_inj_right_fmap {c : Category}
+  (p : StrictPremonoidal c) (x' : c) {x y : c} (f : x ~{c}~> y) :
+  fmap[@inj_right c (StrictPremonoidal_Binoidal p) x'] f
+    = @fmap (c □ c) c (sp_tensor p) (x', x) (x', y) (rstep f).
+Proof. reflexivity. Qed.
+
+(** ** The universal-property payoff
+
+    The same multiplication, restricted along the generating steps, is a
+    [SepFunctorial] package for the funny tensor's universal property
+    (Construction/Funny.v): separately functorial data with a shared object
+    map and NO interchange condition. *)
+
+Definition StrictPremonoidal_SepFunctorial {c : Category}
+  (p : StrictPremonoidal c) :
+  @SepFunctorial c c c (fun x y : c => fobj[sp_tensor p] (x, y)) :=
+  toSep (sp_tensor p).
+
+(* Its actions are likewise the images of the generating steps, on the
+   nose. *)
+Corollary StrictPremonoidal_sf_lmap {c : Category}
+  (p : StrictPremonoidal c) {x y : c} (f : x ~{c}~> y) (d : c) :
+  sf_lmap (StrictPremonoidal_SepFunctorial p) f d
+    = @fmap (c □ c) c (sp_tensor p) (x, d) (y, d) (lstep f).
+Proof. reflexivity. Qed.
+
+Corollary StrictPremonoidal_sf_rmap {c : Category}
+  (p : StrictPremonoidal c) (x : c) {d d' : c} (g : d ~{c}~> d') :
+  sf_rmap (StrictPremonoidal_SepFunctorial p) x g
+    = @fmap (c □ c) c (sp_tensor p) (x, d) (x, d') (rstep g).
+Proof. reflexivity. Qed.

--- a/Instance/StrictCat/Premonoid.v
+++ b/Instance/StrictCat/Premonoid.v
@@ -2,24 +2,15 @@ Require Import Category.Lib.
 Require Import Category.Theory.Category.
 Require Import Category.Theory.Isomorphism.
 Require Import Category.Theory.Functor.
-Require Import Category.Theory.Naturality.
-Require Import Category.Construction.Product.
-Require Import Category.Functor.Bifunctor.
 Require Import Category.Instance.One.
 Require Import Category.Instance.StrictCat.
-Require Import Category.Instance.StrictCat.Terminal.
 Require Import Category.Construction.Funny.
 Require Import Category.Construction.Funny.StrictEq.
 Require Import Category.Construction.Funny.Bifunctor.
 Require Import Category.Construction.Funny.Unitors.
-Require Import Category.Construction.Funny.Swap.
 Require Import Category.Construction.Funny.Associator.
 Require Import Category.Instance.StrictCat.Funny.
-Require Import Category.Structure.Terminal.
 Require Import Category.Structure.Monoidal.
-Require Import Category.Structure.Monoidal.Braided.
-Require Import Category.Structure.Monoidal.Symmetric.
-Require Import Category.Structure.Monoidal.Semicartesian.
 Require Import Category.Structure.Monoid.
 Require Import Category.Structure.Binoidal.
 
@@ -69,17 +60,12 @@ Generalizable All Variables.
     Universe scope.  [Funny_Monoidal@{u} : Monoidal@{u Set}] pins
     StrictCat's member categories to [Category@{Set Set Set}].  Re-declaring
     the instance at a rigid universe [v] is blocked: the compiled unitors of
-    Construction/Funny/Unitors.v carry a minimized [Set] level, and
-    [Build_Monoidal] at member level [v] reports the constraint [Set = v] as
-    unsatisfiable (probe ProbeFunnyPoly.v — re-verified this session by
-    recompiling the probe, which reproduces "Cannot enforce Set = v" at the
-    [Build_Monoidal] unitor field; an earlier .vo of the probe was stale).
-    Everything below therefore holds for [Set]-small carrier categories;
-    lifting the restriction requires re-declaring the unitors with explicit
-    universe binders in Construction/Funny/Unitors.v, which is outside this
-    phase's envelope. *)
-
-#[local] Obligation Tactic := idtac.
+    Construction/Funny/Unitors.v carry a minimized [Set] level, so
+    [Build_Monoidal] at member level [v] reports "Cannot enforce Set = v" at
+    the unitor field.  Everything below therefore holds for [Set]-small
+    carrier categories; lifting the restriction requires re-declaring the
+    unitors with explicit universe binders in Construction/Funny/Unitors.v,
+    which is left as future work. *)
 
 (** ** Strict premonoidal structures
 

--- a/Monad/Graded.v
+++ b/Monad/Graded.v
@@ -1,0 +1,375 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Functor.
+Require Import Category.Theory.Monad.
+Require Import Category.Instance.Coq.
+
+Generalizable All Variables.
+
+(** * Graded monads *)
+
+(* nLab: https://ncatlab.org/nlab/show/graded+monad
+
+   Graded monads (also called parametric monads).  Fix an ordinary monoid
+   (E, ε, ·) of "grades" — here a [GradeMonoid], a record over a Coq type with
+   the monoid laws stated in propositional equality [=].  An E-graded monad on
+   a category C is a family of endofunctors  T : E → (C ⟶ C)  together with a
+   unit
+
+     gret : x ~> T ε x
+
+   and a family of graded multiplications
+
+     gjoin : T m (T n x) ~> T (m · n) x
+
+   satisfying the monad laws up to the monoid's associativity and unit
+   equations, which are transported along the family by the cast morphisms
+   [gcast] below.  Grades typically track a quantitative effect discipline:
+   which effects may occur, how many times, at what cost.
+
+   Honest formulation.  The class [GradedMonad] below mirrors Theory/Monad.v
+   field-for-field: [gret] and [gjoin] generalize [ret] and [join], and the
+   five laws [gfmap_ret], [gjoin_fmap_join], [gjoin_fmap_ret], [gjoin_ret],
+   [gjoin_fmap_fmap] generalize the five monad laws, each mediated by a
+   [gcast] along the corresponding grade-monoid equation.  At the trivial
+   one-element grading every [gcast] reduces to [id] and the five laws are
+   literally the five laws of Theory/Monad.v; the bridges [GradedMonad_Monad]
+   and [Monad_GradedMonad_const] below make this degeneracy precise in both
+   directions, with definitional round-trips ([roundtrip_ret],
+   [roundtrip_join]).
+
+   Relation to the monoid picture.  Monad/Monoid.v ([Monoid_Monad]) exhibits
+   an ordinary monad as a monoid object in the endofunctor category [C, C]
+   under composition.  A graded monad likewise has a delooping reading: it is
+   a lax functor from B E — the one-object bicategory whose 1-cells are the
+   elements of E, composed by ·, with only identity 2-cells — to the
+   one-object bicategory delooping the strict monoidal category
+   ([C, C], ◯, Id).  The unique object goes to the unique object, the 1-cell
+   m goes to the endofunctor T m, and the lax coherence 2-cells are exactly
+   [gret] (unit comparison, Id ⟹ T ε) and [gjoin] (composition comparison,
+   T m ◯ T n ⟹ T (m · n)), natural by [gfmap_ret] and [gjoin_fmap_fmap].
+   Equivalently: a lax monoidal functor into ([C, C], ◯, Id) from E read as a
+   discrete strict monoidal category — objects the grades, tensor ·, unit ε —
+   sending the object m to T m.  Bicategories, deloopings and lax monoidal
+   functors are outside the scope of this file, so that equivalent reading is
+   recorded here as prose only; the record below is the elementary spelling
+   of the same data. *)
+
+(* The grade monoid: a plain monoid on a Coq type, with associativity and the
+   two unit laws stated in propositional equality [=].
+
+   NOTE on transparency: concrete instances should supply TRANSPARENT
+   match-term proofs of the three laws (rather than opaque lemmas from the
+   standard library such as [andb_assoc]), so that [gcast] computes to [id]
+   on closed grades by mere reduction.  Alternatively, over a grade type with
+   decidable equality any closed proof can be rewritten to [eq_refl] via
+   [Eqdep_dec.UIP_dec], which by Hedberg's theorem is fully constructive and
+   assumes nothing beyond the core theory; the transparent route taken below
+   ([Trivial_GradeMonoid], [AndGrade]) avoids that extra step. *)
+
+Record GradeMonoid : Type := {
+  grade :> Type;                        (* the underlying type of grades *)
+  gunit : grade;                        (* the neutral grade ε *)
+  gmul : grade → grade → grade;         (* grade composition m · n *)
+
+  gmul_assoc {a b c : grade} : gmul (gmul a b) c = gmul a (gmul b c);
+  gmul_unit_l {a : grade} : gmul gunit a = a;
+  gmul_unit_r {a : grade} : gmul a gunit = a
+}.
+
+Section Graded.
+
+Context {C : Category}.
+Context {E : GradeMonoid}.
+Context {T : E → C ⟶ C}.
+
+(* Transport of a graded carrier along an equality of grades.  This is the
+   only place where the propositional grade equations touch the morphisms:
+   every law of [GradedMonad] is stated up to such a cast.  Defined as a
+   direct match so it computes to [id] whenever the proof reduces to
+   [eq_refl]. *)
+
+Definition gcast {m n : E} (e : m = n) {x : C} : T m x ~> T n x :=
+  match e in _ = k return T m x ~> T k x with
+  | eq_refl => id
+  end.
+
+Lemma gcast_refl {m : E} {x : C} : @gcast m m eq_refl x ≈ id.
+Proof. reflexivity. Qed.
+
+Lemma gcast_trans {m n p : E} (e1 : m = n) (e2 : n = p) {x : C} :
+  gcast e2 ∘ @gcast m n e1 x ≈ gcast (eq_trans e1 e2).
+Proof. destruct e2, e1; simpl; cat. Qed.
+
+(* [gcast] is natural in the object variable: it commutes with the functorial
+   action of the graded carriers. *)
+Lemma gcast_natural {m n : E} (e : m = n) {x y : C} (f : x ~> y) :
+  gcast e ∘ fmap[T m] f ≈ fmap[T n] f ∘ @gcast m n e x.
+Proof. destruct e; simpl; cat. Qed.
+
+(* The E-graded monad, mirroring Theory/Monad.v field-for-field.  [gret] is
+   the unit η at the neutral grade, [gjoin] the grade-multiplying μ, and the
+   five laws are the five laws of [Monad] with every grade equation
+   transported by [gcast].  At the trivial grading every cast is [id] and the
+   laws collapse to the ungraded ones (see [GradedMonad_Monad] below). *)
+
+Class GradedMonad := {
+  gret {x : C} : x ~> T (gunit E) x;                       (* graded unit η *)
+  gjoin {m n : E} {x : C} : T m (T n x) ~> T (gmul E m n) x;   (* graded μ *)
+
+  (* naturality of the unit η: gret ∘ f ≈ fmap f ∘ gret *)
+  gfmap_ret {x y : C} (f : x ~> y) :
+    gret ∘ f ≈ fmap[T (gunit E)] f ∘ gret;
+
+  (* graded associativity: μ ∘ Tμ ≈ μ ∘ μT, up to gmul_assoc *)
+  gjoin_fmap_join {m n p : E} {x : C} :
+    gjoin ∘ fmap[T m] (@gjoin n p x)
+      ≈ gcast (gmul_assoc E) ∘ @gjoin (gmul E m n) p x ∘ @gjoin m n (T p x);
+
+  (* graded left unit law: μ ∘ Tη ≈ id, up to gmul_unit_r *)
+  gjoin_fmap_ret {m : E} {x : C} :
+    gjoin ∘ fmap[T m] (@gret x) ≈ gcast (eq_sym (gmul_unit_r E));
+
+  (* graded right unit law: μ ∘ ηT ≈ id, up to gmul_unit_l *)
+  gjoin_ret {m : E} {x : C} :
+    gjoin ∘ @gret (T m x) ≈ gcast (eq_sym (gmul_unit_l E));
+
+  (* naturality of the multiplication μ *)
+  gjoin_fmap_fmap {m n : E} {x y : C} (f : x ~> y) :
+    gjoin ∘ fmap[T m] (fmap[T n] f) ≈ fmap[T (gmul E m n)] f ∘ gjoin
+}.
+
+End Graded.
+
+Arguments GradedMonad {C} E T.
+
+(* Over a constant family the cast is always the identity, whatever the grade
+   equation was: the transport happens in a family that does not move. *)
+Lemma gcast_const {C : Category} {E : GradeMonoid} {M : C ⟶ C}
+      {m n : E} (e : m = n) {x : C} :
+  @gcast C E (fun _ => M) m n e x ≈ id.
+Proof. destruct e; reflexivity. Qed.
+
+(** ** The degenerate-grading bridge *)
+
+(* The one-element grade monoid.  All three law proofs are transparent
+   match-terms reducing to [eq_refl] on [ttt], so at this grading [gcast]
+   is definitionally [id]. *)
+Definition Trivial_GradeMonoid : GradeMonoid := {|
+  grade := poly_unit;
+  gunit := ttt;
+  gmul := fun _ _ => ttt;
+  gmul_assoc := fun _ _ _ => eq_refl;
+  gmul_unit_l := fun a => match a as u return ttt = u with ttt => eq_refl end;
+  gmul_unit_r := fun a => match a as u return ttt = u with ttt => eq_refl end
+|}.
+
+#[local] Obligation Tactic := idtac.
+
+(* A trivially graded monad is an ordinary monad: every grade proof reduces
+   to [eq_refl] definitionally, so every [gcast] reduces to [id], and the
+   graded laws are the ungraded ones (the unit laws by direct conversion, the
+   associativity law after erasing the identity cast). *)
+Program Definition GradedMonad_Monad {C : Category} {M : C ⟶ C}
+  (G : @GradedMonad C Trivial_GradeMonoid (fun _ => M)) : @Monad C M := {|
+  ret  := fun x => @gret C Trivial_GradeMonoid (fun _ => M) G x;
+  join := fun x => @gjoin C Trivial_GradeMonoid (fun _ => M) G ttt ttt x
+|}.
+Next Obligation. (* fmap_ret *)
+  intros C M G x y f.
+  exact (@gfmap_ret C Trivial_GradeMonoid (fun _ => M) G x y f).
+Qed.
+Next Obligation. (* join_fmap_join *)
+  intros C M G x.
+  etransitivity.
+  - exact (@gjoin_fmap_join C Trivial_GradeMonoid (fun _ => M) G ttt ttt ttt x).
+  - rewrite gcast_const; cat.
+Qed.
+Next Obligation. (* join_fmap_ret: the cast is definitionally [id] here *)
+  intros C M G x.
+  exact (@gjoin_fmap_ret C Trivial_GradeMonoid (fun _ => M) G ttt x).
+Qed.
+Next Obligation. (* join_ret: the cast is definitionally [id] here *)
+  intros C M G x.
+  exact (@gjoin_ret C Trivial_GradeMonoid (fun _ => M) G ttt x).
+Qed.
+Next Obligation. (* join_fmap_fmap *)
+  intros C M G x y f.
+  exact (@gjoin_fmap_fmap C Trivial_GradeMonoid (fun _ => M) G ttt ttt x y f).
+Qed.
+
+(* Conversely, any ordinary monad is E-graded for ANY grade monoid E, as the
+   constant family at its endofunctor: all casts are erased by [gcast_const].
+   Instantiating E with [Trivial_GradeMonoid] gives the inverse direction of
+   the degenerate bridge, so this construction subsumes it. *)
+Program Definition Monad_GradedMonad_const {C : Category} {M : C ⟶ C}
+  (H : @Monad C M) (E : GradeMonoid) : @GradedMonad C E (fun _ => M) := {|
+  gret  := fun x => @ret C M H x;
+  gjoin := fun _ _ x => @join C M H x
+|}.
+Next Obligation. (* gfmap_ret *)
+  intros C M H E x y f.
+  exact (@fmap_ret C M H x y f).
+Qed.
+Next Obligation. (* gjoin_fmap_join *)
+  intros C M H E m n p x.
+  rewrite gcast_const, id_left.
+  exact (@join_fmap_join C M H x).
+Qed.
+Next Obligation. (* gjoin_fmap_ret *)
+  intros C M H E m x.
+  rewrite gcast_const.
+  exact (@join_fmap_ret C M H x).
+Qed.
+Next Obligation. (* gjoin_ret *)
+  intros C M H E m x.
+  rewrite gcast_const.
+  exact (@join_ret C M H x).
+Qed.
+Next Obligation. (* gjoin_fmap_fmap *)
+  intros C M H E m n x y f.
+  exact (@join_fmap_fmap C M H x y f).
+Qed.
+
+(* Round-trips at the trivial grading hold definitionally: passing through
+   either bridge leaves the structure maps unchanged. *)
+
+Corollary roundtrip_ret {C : Category} {M : C ⟶ C} (H : @Monad C M) (x : C) :
+  @gret C Trivial_GradeMonoid (fun _ => M)
+        (Monad_GradedMonad_const H Trivial_GradeMonoid) x ≈ @ret C M H x.
+Proof. reflexivity. Qed.
+
+Corollary roundtrip_join {C : Category} {M : C ⟶ C}
+  (G : @GradedMonad C Trivial_GradeMonoid (fun _ => M)) (x : C) :
+  @join C M (GradedMonad_Monad G) x
+    ≈ @gjoin C Trivial_GradeMonoid (fun _ => M) G ttt ttt x.
+Proof. reflexivity. Qed.
+
+Corollary roundtrip_ret_trivial {C : Category} {M : C ⟶ C}
+  (G : @GradedMonad C Trivial_GradeMonoid (fun _ => M)) (x : C) :
+  @ret C M (GradedMonad_Monad G) x
+    ≈ @gret C Trivial_GradeMonoid (fun _ => M) G x.
+Proof. reflexivity. Qed.
+
+Corollary roundtrip_join_const {C : Category} {M : C ⟶ C}
+  (H : @Monad C M) (x : C) :
+  @gjoin C Trivial_GradeMonoid (fun _ => M)
+         (Monad_GradedMonad_const H Trivial_GradeMonoid) ttt ttt x
+    ≈ @join C M H x.
+Proof. reflexivity. Qed.
+
+(** ** A nontrivial instance: the bool-graded exception monad over Coq *)
+
+(* The grade monoid (bool, true, andb): grade [true] means "pure so far"
+   (no exception can have been raised), grade [false] means an exception may
+   have been raised.  A composite computation is pure exactly when both
+   stages are, whence [andb].  The law proofs are transparent match-terms so
+   that [gcast] reduces on both constructors. *)
+Definition AndGrade : GradeMonoid := {|
+  grade := bool;
+  gunit := true;
+  gmul := andb;
+  gmul_assoc := fun a b c =>
+    match a as a0 return andb (andb a0 b) c = andb a0 (andb b c) with
+    | true  => eq_refl
+    | false => eq_refl
+    end;
+  gmul_unit_l := fun a => eq_refl;
+  gmul_unit_r := fun a =>
+    match a as a0 return andb a0 true = a0 with
+    | true  => eq_refl
+    | false => eq_refl
+    end
+|}.
+
+(* The option endofunctor on Coq, defined locally as a categorical functor
+   (Theory/Coq covers the programming-style classes instead). *)
+Program Definition option_Functor : Coq ⟶ Coq := {|
+  fobj := option;
+  fmap := fun _ _ f o => option_map f o
+|}.
+Next Obligation. (* fmap_respects *)
+  intros x y f g Hfg [a|]; simpl; [rewrite Hfg|]; reflexivity.
+Qed.
+Next Obligation. (* fmap_id *)
+  intros x [a|]; reflexivity.
+Qed.
+Next Obligation. (* fmap_comp *)
+  intros x y z f g [a|]; reflexivity.
+Qed.
+
+(* The graded carrier: at the pure grade the identity functor, at the
+   impure grade [option]. *)
+Definition ExcT (b : bool) : Coq ⟶ Coq :=
+  if b then Id[Coq] else option_Functor.
+
+(* The graded unit lives at grade [true], where the carrier is [Id]. *)
+Definition exc_ret (x : Type) : x → ExcT true x := fun a => a.
+
+(* The graded multiplication.  At (true, _) and (false, true) one of the two
+   layers is the identity functor and the multiplication is the evident
+   reindexing; at (false, false) it is the usual option join. *)
+Definition exc_join (b1 b2 : bool) (x : Type) :
+  ExcT b1 (ExcT b2 x) → ExcT (andb b1 b2) x :=
+  match b1 as a, b2 as b return ExcT a (ExcT b x) → ExcT (andb a b) x with
+  | true, _      => fun o => o
+  | false, true  => fun o => o
+  | false, false => fun o => match o with
+                             | Some v => v
+                             | None   => None
+                             end
+  end.
+
+(* The laws are proven by destructing the grades first — after which every
+   [gcast] reduces to [id], by transparency of the [AndGrade] proofs — and
+   then by pointwise case analysis in Coq's pointwise-equality homsets. *)
+Program Definition Exc_GradedMonad : @GradedMonad Coq AndGrade ExcT := {|
+  gret  := exc_ret;
+  gjoin := exc_join
+|}.
+Next Obligation. (* gfmap_ret *)
+  intros x y f a; reflexivity.
+Qed.
+Next Obligation. (* gjoin_fmap_join *)
+  intros m n p x; destruct m, n, p; simpl; intro o;
+    repeat (destruct o as [o|]); simpl; reflexivity.
+Qed.
+Next Obligation. (* gjoin_fmap_ret *)
+  intros m x; destruct m; simpl; intro o;
+    repeat (destruct o as [o|]); simpl; reflexivity.
+Qed.
+Next Obligation. (* gjoin_ret *)
+  intros m x; destruct m; simpl; intro o;
+    repeat (destruct o as [o|]); simpl; reflexivity.
+Qed.
+Next Obligation. (* gjoin_fmap_fmap *)
+  intros m n x y f; destruct m, n; simpl; intro o;
+    repeat (destruct o as [o|]); simpl; reflexivity.
+Qed.
+
+(** ** The grade-only writer *)
+
+(* Pure grade tracking with trivial data: for ANY grade monoid W, the
+   constant family at the identity functor is W-graded.  All structure maps
+   are identities; every law is a [gcast] transport erased by [gcast_const].
+   This is the "writer into W" whose entire log lives in the grades. *)
+Program Definition GradedWriter (W : GradeMonoid) :
+  @GradedMonad Coq W (fun _ => Id[Coq]) := {|
+  gret  := fun x (a : x) => a;
+  gjoin := fun _ _ x (a : x) => a
+|}.
+Next Obligation. (* gfmap_ret *)
+  intros W x y f; reflexivity.
+Qed.
+Next Obligation. (* gjoin_fmap_join *)
+  intros W m n p x; rewrite gcast_const; reflexivity.
+Qed.
+Next Obligation. (* gjoin_fmap_ret *)
+  intros W m x; rewrite gcast_const; reflexivity.
+Qed.
+Next Obligation. (* gjoin_ret *)
+  intros W m x; rewrite gcast_const; reflexivity.
+Qed.
+Next Obligation. (* gjoin_fmap_fmap *)
+  intros W m n x y f; reflexivity.
+Qed.

--- a/Monad/Kleisli/Commutative.v
+++ b/Monad/Kleisli/Commutative.v
@@ -4,15 +4,11 @@ Require Import Category.Lib.
 Require Import Category.Theory.Category.
 Require Import Category.Theory.Isomorphism.
 Require Import Category.Theory.Functor.
-Require Import Category.Theory.Naturality.
 Require Import Category.Theory.Monad.
 Require Import Category.Functor.Bifunctor.
-Require Import Category.Construction.Product.
 Require Import Category.Structure.Monoidal.
-Require Import Category.Structure.Monoidal.Naturality.
 Require Import Category.Structure.Monoidal.Braided.
 Require Import Category.Structure.Monoidal.Symmetric.
-Require Import Category.Structure.Monoidal.Braided.Proofs.
 Require Import Category.Structure.Monoidal.Hypergraph.
 Require Import Category.Structure.Monoidal.CopyDiscard.
 Require Import Category.Theory.Algebra.Comonoid.
@@ -42,8 +38,8 @@ Set Transparent Obligations.
     premonoidal structure, and characterizes centrality there: a Kleisli
     morphism f is central exactly when the two double strengths [dstr] and
     [dstr'] agree on every tensor with f in either factor
-    ([kleisli_central_iff]).  This file completes deliverable (e) of the
-    effects programme with the commutative case:
+    ([kleisli_central_iff]).  This file treats the commutative case of
+    the Kleisli premonoidal development:
 
     1. The funnel between commutativity and centrality, in both
        directions.  If M is commutative ([commutative_sm], i.e. dstr and
@@ -225,16 +221,7 @@ Proof.
     now rewrite <- bimap_comp. }
   rewrite E; clear E.
   rewrite comp_assoc.
-  assert (E2 : dstr ∘ (ret[M] ⨂ ret[M])
-                 ≈ (ret[M] : b ⨂ d ~{C}~> M (b ⨂ d))).
-  { transitivity (dstr ∘ ((ret[M] ⨂ id[M d]) ∘ (id[b] ⨂ ret[M]))).
-    - apply compose_respects; [reflexivity|].
-      rewrite <- bimap_comp.
-      now rewrite id_left, id_right.
-    - rewrite comp_assoc.
-      rewrite dstr_ret_left.
-      apply strength_ret. }
-  rewrite E2.
+  rewrite dstr_ret_ret.
   unfold kpure.
   reflexivity.
 Qed.

--- a/Monad/Kleisli/Commutative.v
+++ b/Monad/Kleisli/Commutative.v
@@ -1,0 +1,592 @@
+Set Warnings "-notation-overridden".
+
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Theory.Naturality.
+Require Import Category.Theory.Monad.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Construction.Product.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Monoidal.Naturality.
+Require Import Category.Structure.Monoidal.Braided.
+Require Import Category.Structure.Monoidal.Symmetric.
+Require Import Category.Structure.Monoidal.Braided.Proofs.
+Require Import Category.Structure.Monoidal.Hypergraph.
+Require Import Category.Structure.Monoidal.CopyDiscard.
+Require Import Category.Theory.Algebra.Comonoid.
+Require Import Category.Theory.Algebra.CommutativeComonoid.
+Require Import Category.Structure.Binoidal.
+Require Import Category.Structure.Binoidal.Central.
+Require Import Category.Structure.Premonoidal.
+Require Import Category.Structure.Premonoidal.Monoidal.
+Require Import Category.Functor.Strong.
+Require Import Category.Monad.Strong.
+Require Import Category.Monad.Strong.Symmetric.
+Require Import Category.Monad.Kleisli.
+Require Import Category.Monad.Kleisli.Premonoidal.
+
+Generalizable All Variables.
+Set Primitive Projections.
+Set Universe Polymorphism.
+Set Transparent Obligations.
+
+(** * The Kleisli category of a commutative strong monad is monoidal
+
+    nLab: https://ncatlab.org/nlab/show/commutative+monad
+    nLab: https://ncatlab.org/nlab/show/premonoidal+category
+
+    Monad/Kleisli/Premonoidal.v equips the Kleisli category Kl(M) of a
+    strong monad M over a symmetric monoidal base with its Power-Robinson
+    premonoidal structure, and characterizes centrality there: a Kleisli
+    morphism f is central exactly when the two double strengths [dstr] and
+    [dstr'] agree on every tensor with f in either factor
+    ([kleisli_central_iff]).  This file completes deliverable (e) of the
+    effects programme with the commutative case:
+
+    1. The funnel between commutativity and centrality, in both
+       directions.  If M is commutative ([commutative_sm], i.e. dstr and
+       dstr' agree everywhere), then EVERY Kleisli morphism is central
+       ([kleisli_all_central]): both centrality squares are congruence
+       instances of the commutativity equation.  Conversely, if every
+       Kleisli morphism is central, instantiating the centrality of the
+       identity Kleisli maps id[M x] : M x ~{Kl}~> x against id[M y]
+       collapses the centrality square to dstr ≈ dstr' on the nose
+       ([kleisli_all_central_commutative]).  Together: M is commutative
+       iff Kl(M) is monoidal with its canonical tensor.
+
+    2. The monoidal upgrade ([Kleisli_Monoidal]): the all-central engine
+       [Premonoidal_Monoidal] of Structure/Premonoidal/Monoidal.v applied
+       to [Kleisli_Premonoidal] with the centrality witness of point 1.
+       The induced tensor acts on morphism pairs by the double strength:
+       bimap f g ≈ dstr ∘ (f ⨂ g) ([kleisli_bimap_dstr]), and on pure
+       morphisms by the pure image of the base tensor ([kl_pure_tensor]).
+
+    3. The braided and symmetric upgrades ([Kleisli_Braided],
+       [Kleisli_Symmetric]): the braiding of Kl(M) is the pure image of
+       the base braiding.  Its joint naturality square reduces through
+       [kleisli_bimap_dstr] to the conjugation identity
+       dstr' ≈ M(β) ∘ dstr ∘ β ([dstr_braid], a fact of every strong
+       monad over a symmetric base, no commutativity needed); the
+       hexagons and the involution law transfer from the base along the
+       pure functor.
+
+    4. The copy-discard descent ([Kleisli_CopyDiscard]): when the base
+       carries a CopyDiscard structure, Kl(M) does too, with
+       copy := kpure copy and discard := kpure discard.  All comonoid
+       laws and the tensor/unit coherences are pure transfers; the
+       heaviest step is transporting the five-factor middle-interchange
+       word [mid_swap_inv] of Hypergraph.v through the pure functor
+       ([kl_pure_mid_swap_inv]).  Crucially, naturality of copy and
+       discard is not part of the transported structure: in Kl(M) an
+       effectful morphism need not commute with duplication or deletion
+       of its input, and the two Cho-Jacobs squares single out the
+       deterministic morphisms — exactly the substrate
+       Monad/Thunkable.v builds on.
+
+    The comm-gated structures are Definitions, not Instances: they take
+    the commutativity witness as an argument once the section closes, so
+    typeclass resolution can never conjure a monoidal structure on Kl(M)
+    without being handed a proof that M commutes. *)
+
+Section KleisliCommutative.
+
+Context `{@SymmetricMonoidal C}.
+Context {M : C ⟶ C}.
+Context `{@StrongMonad C _ M}.
+
+(* Congruence for [kpure], specialized to the ambient context so that
+   [apply] never has to reconstruct the section instances by
+   unification: the many transfer proofs below invoke it on goals whose
+   endpoint objects are stated through the induced Kleisli tensor. *)
+Lemma kl_pure_eqv {a b : C} {u v : a ~{C}~> b} (E : u ≈ v) :
+  (kpure u : a ~{Kleisli}~> b) ≈ kpure v.
+Proof. now apply kpure_proper. Qed.
+
+(* ------------------------------------------------------------------ *)
+(** ** The braid conjugation identity for the double strengths.        *)
+(* ------------------------------------------------------------------ *)
+
+(* Conjugating [dstr] by the braiding on both sides computes [dstr']:
+   unfolding [rstr] inside [dstr] at the swapped indices exposes a braid
+   pair that the involution law removes, and naturality of join
+   ([join_fmap_fmap]) slides the outer M(β) under the multiplication,
+   reassembling [rstr] inside the fmap argument of [dstr'].  This is a
+   fact of every strong monad over a symmetric base — no commutativity
+   hypothesis enters — and it is what lets the braiding of Kl(M) commute
+   with the double-strength tensor below. *)
+Lemma dstr_braid {x y : C} :
+  (dstr' : M x ⨂ M y ~> M (x ⨂ y))
+    ≈ fmap[M] braid ∘ (dstr : M y ⨂ M x ~> M (y ⨂ x)) ∘ braid.
+Proof.
+  unfold dstr, dstr', rstr.
+  rewrite !fmap_comp.
+  rewrite <- !comp_assoc.
+  rewrite braid_invol.
+  rewrite id_right.
+  rewrite !comp_assoc.
+  rewrite join_fmap_fmap.
+  reflexivity.
+Qed.
+
+(* ------------------------------------------------------------------ *)
+(** ** Commutativity versus centrality: both directions.               *)
+(* ------------------------------------------------------------------ *)
+
+(* If M is commutative, every Kleisli morphism is central: through the
+   characterization [kleisli_central_iff], each of the two centrality
+   squares asks that [dstr] and [dstr'] agree on a tensor with f in one
+   factor, which is a congruence instance of the commutativity
+   equation. *)
+Theorem kleisli_all_central (comm : commutative_sm (M:=M))
+        {x y : C} (f : x ~{Kleisli}~> y) :
+  @central Kleisli Kleisli_Binoidal x y f.
+Proof.
+  apply kleisli_central_iff; intros c d g.
+  split.
+  - now rewrite (comm y d).
+  - now rewrite (comm d y).
+Qed.
+
+(* Conversely, if every Kleisli morphism is central, M is commutative:
+   instantiate the centrality of the Kleisli morphism
+   id[M x] : M x ~{Kl}~> x against id[M y] : M y ~{Kl}~> y.  The square
+   normalizes to dstr ∘ (id ⨂ id) ≈ dstr' ∘ (id ⨂ id), and the identity
+   padding evaporates by [bimap_id_id]. *)
+Theorem kleisli_all_central_commutative
+        (allc : ∀ (x y : C) (f : x ~{Kleisli}~> y),
+                  @central Kleisli Kleisli_Binoidal x y f) :
+  commutative_sm (M:=M).
+Proof.
+  intros x y.
+  destruct (kleisli_central_iff (a:=M x) (b:=x) (@id C (M x))) as [fwd _].
+  destruct (fwd (allc (M x) x (@id C (M x))) (M y) y (@id C (M y)))
+    as [sq _].
+  rewrite bimap_id_id in sq.
+  rewrite !id_right in sq.
+  exact sq.
+Qed.
+
+(* ------------------------------------------------------------------ *)
+(** ** The comm-gated structures.                                      *)
+(* ------------------------------------------------------------------ *)
+
+Section WithComm.
+
+Hypothesis comm : commutative_sm (M:=M).
+
+(** *** The monoidal structure on Kl(M)
+
+    The all-central engine of Structure/Premonoidal/Monoidal.v applied
+    at the Power-Robinson premonoidal structure of Kl(M), with the
+    centrality of all morphisms supplied by [kleisli_all_central]. *)
+
+Definition Kleisli_Monoidal : @Monoidal Kleisli :=
+  @Premonoidal_Monoidal Kleisli Kleisli_Binoidal Kleisli_Premonoidal
+    (fun (x y : Kleisli) (f : x ~{Kleisli}~> y) =>
+       kleisli_all_central comm f).
+
+(* The induced tensor computes the double strength on morphism pairs:
+   [bimap] over [Kleisli_Monoidal] is definitionally the interleaved
+   composite [composite_ff'], whose right-then-left normal form is
+   [kl_square_rl]. *)
+Lemma kleisli_bimap_dstr {a b c d : C}
+      (f : a ~{Kleisli}~> b) (g : c ~{Kleisli}~> d) :
+  (f ⨂[Kleisli_Monoidal] g)
+    ≈ dstr ∘ ((f : a ~{C}~> M b) ⨂ (g : c ~{C}~> M d)).
+Proof. exact (kl_square_rl f g). Qed.
+
+(* Padding one side of the tensor with the Kleisli identity leaves the
+   corresponding one-variable tensoring functor of the binoidal
+   structure; these are [composite_id_right] / [composite_id_left]
+   restated over the monoidal [bimap]. *)
+Lemma kl_bimap_inj_left {a b : C} (w : C) (f : a ~{Kleisli}~> b) :
+  (f ⨂[Kleisli_Monoidal] (@id Kleisli w))
+    ≈ fmap[@inj_left Kleisli Kleisli_Binoidal w] f.
+Proof. exact (@composite_id_right Kleisli Kleisli_Binoidal a b w f). Qed.
+
+Lemma kl_bimap_inj_right (w : C) {a b : C} (f : a ~{Kleisli}~> b) :
+  ((@id Kleisli w) ⨂[Kleisli_Monoidal] f)
+    ≈ fmap[@inj_right Kleisli Kleisli_Binoidal w] f.
+Proof. exact (@composite_id_left Kleisli Kleisli_Binoidal a b w f). Qed.
+
+(* The tensor of two pure morphisms is the pure image of the base
+   tensor: after [kleisli_bimap_dstr], feeding returned values into both
+   factors of [dstr] collapses it through [dstr_ret_left] and
+   [strength_ret] onto a single unit. *)
+Lemma kl_pure_tensor {a b c d : C} (u : a ~{C}~> b) (v : c ~{C}~> d) :
+  ((kpure u) ⨂[Kleisli_Monoidal] (kpure v)) ≈ kpure (u ⨂ v).
+Proof.
+  rewrite kleisli_bimap_dstr.
+  assert (E : ((kpure u : a ~{C}~> M b) ⨂ (kpure v : c ~{C}~> M d))
+                ≈ (ret[M] ⨂ ret[M]) ∘ (u ⨂ v)).
+  { unfold kpure.
+    now rewrite <- bimap_comp. }
+  rewrite E; clear E.
+  rewrite comp_assoc.
+  assert (E2 : dstr ∘ (ret[M] ⨂ ret[M])
+                 ≈ (ret[M] : b ⨂ d ~{C}~> M (b ⨂ d))).
+  { transitivity (dstr ∘ ((ret[M] ⨂ id[M d]) ∘ (id[b] ⨂ ret[M]))).
+    - apply compose_respects; [reflexivity|].
+      rewrite <- bimap_comp.
+      now rewrite id_left, id_right.
+    - rewrite comp_assoc.
+      rewrite dstr_ret_left.
+      apply strength_ret. }
+  rewrite E2.
+  unfold kpure.
+  reflexivity.
+Qed.
+
+(* One-sided pure padding, the workhorse of every transfer proof below:
+   a pure morphism tensored with the Kleisli identity is the pure image
+   of the identity-padded base tensor. *)
+Lemma kl_bimap_pure_l {a b : C} (u : a ~{C}~> b) (w : C) :
+  ((kpure u) ⨂[Kleisli_Monoidal] (@id Kleisli w))
+    ≈ kpure (u ⨂ id[w]).
+Proof.
+  rewrite kl_bimap_inj_left.
+  apply pure_inj_left.
+Qed.
+
+Lemma kl_bimap_pure_r (w : C) {a b : C} (u : a ~{C}~> b) :
+  ((@id Kleisli w) ⨂[Kleisli_Monoidal] (kpure u))
+    ≈ kpure (id[w] ⨂ u).
+Proof.
+  rewrite kl_bimap_inj_right.
+  apply pure_inj_right.
+Qed.
+
+(** *** The pure-transfer kit for the structural isomorphisms
+
+    The unitors and associator of [Kleisli_Monoidal] are the pure images
+    of the base ones BY DEFINITION — the monoidal structure reuses the
+    premonoidal [Kleisli_pure_iso] data — so each transfer equation is
+    closed by reflexivity.  They are recorded as lemmas so downstream
+    proofs can cite the kit uniformly. *)
+
+Lemma kl_pure_unit_left (x : C) :
+  to (@unit_left Kleisli Kleisli_Monoidal x)
+    ≈ kpure (to (@unit_left C _ x)).
+Proof. reflexivity. Qed.
+
+Lemma kl_pure_unit_left_from (x : C) :
+  from (@unit_left Kleisli Kleisli_Monoidal x)
+    ≈ kpure (from (@unit_left C _ x)).
+Proof. reflexivity. Qed.
+
+Lemma kl_pure_unit_right (x : C) :
+  to (@unit_right Kleisli Kleisli_Monoidal x)
+    ≈ kpure (to (@unit_right C _ x)).
+Proof. reflexivity. Qed.
+
+Lemma kl_pure_unit_right_from (x : C) :
+  from (@unit_right Kleisli Kleisli_Monoidal x)
+    ≈ kpure (from (@unit_right C _ x)).
+Proof. reflexivity. Qed.
+
+Lemma kl_pure_assoc (x y z : C) :
+  to (@tensor_assoc Kleisli Kleisli_Monoidal x y z)
+    ≈ kpure (to (@tensor_assoc C _ x y z)).
+Proof. reflexivity. Qed.
+
+Lemma kl_pure_assoc_from (x y z : C) :
+  from (@tensor_assoc Kleisli Kleisli_Monoidal x y z)
+    ≈ kpure (from (@tensor_assoc C _ x y z)).
+Proof. reflexivity. Qed.
+
+(** *** The braided structure on Kl(M)
+
+    The braiding is the pure image of the base braiding.  Its joint
+    naturality square — the Naturality-class predicate consumed by the
+    [braid_natural] field, mirroring how Instance/StrictCat/Funny.v
+    discharges the same obligation — reduces through the two
+    double-strength normal forms [kl_square_lr] / [kl_square_rl] and the
+    pure exchange laws to a C-level equation between [dstr'] and [dstr],
+    which [dstr_braid] closes with one braid involution. *)
+
+Lemma kl_braid_natural {x y z w : C}
+      (g : x ~{Kleisli}~> y) (h : z ~{Kleisli}~> w) :
+  @compose Kleisli _ _ _
+    (@compose Kleisli _ _ _
+       ((h ⨂[Kleisli_Monoidal] (@id Kleisli y)))
+       (((@id Kleisli z) ⨂[Kleisli_Monoidal] g)))
+    (kpure braid)
+  ≈ @compose Kleisli _ _ _
+      (@compose Kleisli _ _ _
+         (kpure braid)
+         (((@id Kleisli y) ⨂[Kleisli_Monoidal] h)))
+      ((g ⨂[Kleisli_Monoidal] (@id Kleisli z))).
+Proof.
+  rewrite !kl_bimap_inj_left, !kl_bimap_inj_right.
+  rewrite <- (comp_assoc (kpure (@braid C _ y w))).
+  rewrite (kl_square_lr h g).
+  rewrite (kl_square_rl g h).
+  rewrite kl_pure_pre.
+  rewrite kl_pure_post.
+  (* C-level: dstr' ∘ (h ⨂ g) ∘ β ≈ M(β) ∘ (dstr ∘ (g ⨂ h)) *)
+  rewrite <- comp_assoc.
+  rewrite bimap_braid.
+  rewrite dstr_braid.
+  rewrite <- !comp_assoc.
+  rewrite (comp_assoc braid braid).
+  rewrite braid_invol.
+  rewrite id_left.
+  reflexivity.
+Qed.
+
+(* The two hexagons transfer from the base along the pure functor: after
+   converting the padded bimaps to pure images, both sides collapse to
+   the pure image of the corresponding base hexagon. *)
+Lemma kl_hexagon {x y z : C} :
+  @compose Kleisli _ _ _
+    (@compose Kleisli _ _ _
+       (kpure (to (@tensor_assoc C _ y z x)))
+       (kpure (@braid C _ x ((y ⨂ z)%object))))
+    (kpure (to (@tensor_assoc C _ x y z)))
+  ≈ @compose Kleisli _ _ _
+      (@compose Kleisli _ _ _
+         (((@id Kleisli y) ⨂[Kleisli_Monoidal] (kpure (@braid C _ x z))))
+         (kpure (to (@tensor_assoc C _ y x z))))
+      (((kpure (@braid C _ x y)) ⨂[Kleisli_Monoidal] (@id Kleisli z))).
+Proof.
+  rewrite kl_bimap_pure_l, kl_bimap_pure_r.
+  rewrite !kl_pure_comp.
+  apply kl_pure_eqv.
+  apply hexagon_identity.
+Qed.
+
+Lemma kl_hexagon_sym {x y z : C} :
+  @compose Kleisli _ _ _
+    (@compose Kleisli _ _ _
+       (kpure (from (@tensor_assoc C _ z x y)))
+       (kpure (@braid C _ ((x ⨂ y)%object) z)))
+    (kpure (from (@tensor_assoc C _ x y z)))
+  ≈ @compose Kleisli _ _ _
+      (@compose Kleisli _ _ _
+         (((kpure (@braid C _ x z)) ⨂[Kleisli_Monoidal] (@id Kleisli y)))
+         (kpure (from (@tensor_assoc C _ x z y))))
+      (((@id Kleisli x) ⨂[Kleisli_Monoidal] (kpure (@braid C _ y z)))).
+Proof.
+  rewrite kl_bimap_pure_l, kl_bimap_pure_r.
+  rewrite !kl_pure_comp.
+  apply kl_pure_eqv.
+  apply hexagon_identity_sym.
+Qed.
+
+Definition Kleisli_Braided : @BraidedMonoidal Kleisli :=
+  @Build_BraidedMonoidal Kleisli
+    Kleisli_Monoidal
+    (fun x y : C => kpure (@braid C _ x y))
+    (fun (x y : C) (g : x ~{Kleisli}~> y)
+         (z w : C) (h : z ~{Kleisli}~> w) => kl_braid_natural g h)
+    (fun x y z : C => @kl_hexagon x y z)
+    (fun x y z : C => @kl_hexagon_sym x y z).
+
+(* The involution law is the pure image of the base one. *)
+Lemma kl_braid_invol {x y : C} :
+  @compose Kleisli _ _ _ (kpure (@braid C _ y x)) (kpure (@braid C _ x y))
+    ≈ @id Kleisli ((x ⨂ y)%object).
+Proof.
+  rewrite kl_pure_comp.
+  transitivity (kpure (@id C ((x ⨂ y)%object))).
+  - apply kl_pure_eqv.
+    apply braid_invol.
+  - apply kpure_id.
+Qed.
+
+Definition Kleisli_Symmetric : @SymmetricMonoidal Kleisli :=
+  @Build_SymmetricMonoidal Kleisli
+    Kleisli_Braided
+    (fun x y : C => @kl_braid_invol x y).
+
+(* The braiding of Kl(M) is the pure image of the base braiding by
+   construction; recorded to complete the pure-transfer kit. *)
+Lemma kl_pure_braid (x y : C) :
+  @braid Kleisli (@symmetric_is_braided Kleisli Kleisli_Symmetric) x y
+    ≈ kpure (@braid C _ x y).
+Proof. reflexivity. Qed.
+
+(* ------------------------------------------------------------------ *)
+(** ** The copy-discard descent to Kl(M).                              *)
+(* ------------------------------------------------------------------ *)
+
+Section WithCD.
+
+Context `{CD : @CopyDiscard C _}.
+
+(* The five-factor middle-interchange word of Hypergraph.v, computed in
+   [Kleisli_Symmetric], is the pure image of the base one: every factor
+   is either a pure structural map on the nose or a pure morphism padded
+   with an identity, and the pure functor preserves the composite. *)
+Lemma kl_pure_mid_swap_inv (X Y : C) :
+  @mid_swap_inv Kleisli Kleisli_Symmetric X Y
+    ≈ kpure (@mid_swap_inv C _ X Y).
+Proof.
+  unfold mid_swap_inv.
+  rewrite !kpure_comp_functor.
+  apply compose_respects.
+  2: reflexivity.
+  apply compose_respects.
+  2: exact (kl_bimap_pure_r X (from (@tensor_assoc C _ X Y Y))).
+  apply compose_respects.
+  2: {
+    etransitivity.
+    - apply bimap_respects; [reflexivity|].
+      exact (kl_bimap_pure_l (@braid C _ X Y) Y).
+    - exact (kl_bimap_pure_r X ((@braid C _ X Y) ⨂ id[Y])).
+  }
+  apply compose_respects.
+  2: exact (kl_bimap_pure_r X (to (@tensor_assoc C _ Y X Y))).
+  reflexivity.
+Qed.
+
+(** *** The per-object commutative comonoid on Kl(M)
+
+    copy := kpure copy and discard := kpure discard; every law is the
+    pure image of the corresponding base law. *)
+
+Lemma kl_delta_coassoc (x : C) :
+  @compose Kleisli _ _ _
+    (((kpure copy[x]) ⨂[Kleisli_Monoidal] (@id Kleisli x)))
+    (kpure copy[x])
+  ≈ @compose Kleisli _ _ _
+      (@compose Kleisli _ _ _
+         (kpure (from (@tensor_assoc C _ x x x)))
+         (((@id Kleisli x) ⨂[Kleisli_Monoidal] (kpure copy[x]))))
+      (kpure copy[x]).
+Proof.
+  rewrite kl_bimap_pure_l, kl_bimap_pure_r.
+  rewrite !kl_pure_comp.
+  apply kl_pure_eqv.
+  exact (@delta_coassoc C _ x (cd_comonoid x)).
+Qed.
+
+Lemma kl_delta_counit_left (x : C) :
+  @compose Kleisli _ _ _
+    (((kpure discard[x]) ⨂[Kleisli_Monoidal] (@id Kleisli x)))
+    (kpure copy[x])
+  ≈ kpure (from (@unit_left C _ x)).
+Proof.
+  rewrite kl_bimap_pure_l.
+  rewrite kl_pure_comp.
+  apply kl_pure_eqv.
+  exact (@delta_counit_left C _ x (cd_comonoid x)).
+Qed.
+
+Lemma kl_delta_counit_right (x : C) :
+  @compose Kleisli _ _ _
+    (((@id Kleisli x) ⨂[Kleisli_Monoidal] (kpure discard[x])))
+    (kpure copy[x])
+  ≈ kpure (from (@unit_right C _ x)).
+Proof.
+  rewrite kl_bimap_pure_r.
+  rewrite kl_pure_comp.
+  apply kl_pure_eqv.
+  exact (@delta_counit_right C _ x (cd_comonoid x)).
+Qed.
+
+Definition Kleisli_cd_comonoid_base (x : C) :
+  @Comonoid Kleisli Kleisli_Monoidal x :=
+  @Build_Comonoid Kleisli Kleisli_Monoidal x
+    (kpure copy[x])
+    (kpure discard[x])
+    (kl_delta_coassoc x)
+    (kl_delta_counit_left x)
+    (kl_delta_counit_right x).
+
+Lemma kl_delta_cocommutative (x : C) :
+  @compose Kleisli _ _ _ (kpure (@braid C _ x x)) (kpure copy[x])
+    ≈ kpure copy[x].
+Proof.
+  rewrite kl_pure_comp.
+  apply kl_pure_eqv.
+  exact (@delta_cocommutative_of_ccomon C _ x (cd_comonoid x)).
+Qed.
+
+Definition Kleisli_cd_comonoid (x : C) :
+  @CommutativeComonoid Kleisli Kleisli_Symmetric x :=
+  @Build_CommutativeComonoid Kleisli Kleisli_Symmetric x
+    (Kleisli_cd_comonoid_base x)
+    (kl_delta_cocommutative x).
+
+(** *** The CopyDiscard coherence fields
+
+    Each side of each coherence is the pure image of the corresponding
+    base composite, so the equations descend along the pure functor.
+    [kl_cd_tensor_delta] is the heaviest: the canonical delta routes
+    through [mid_swap_inv], transported by [kl_pure_mid_swap_inv]. *)
+
+Lemma kl_cd_tensor_delta (X Y : C) :
+  kpure copy[(X ⨂ Y)%object]
+    ≈ @canonical_tensor_delta Kleisli Kleisli_Symmetric X Y
+        (Kleisli_cd_comonoid_base X) (Kleisli_cd_comonoid_base Y).
+Proof.
+  transitivity
+    (kpure (@canonical_tensor_delta C _ X Y
+              (cd_comonoid X) (cd_comonoid Y))).
+  { apply kl_pure_eqv.
+    exact (cd_tensor_delta X Y). }
+  unfold canonical_tensor_delta.
+  rewrite kpure_comp_functor.
+  apply compose_respects.
+  - symmetry.
+    exact (kl_pure_mid_swap_inv X Y).
+  - symmetry.
+    exact (kl_pure_tensor copy[X] copy[Y]).
+Qed.
+
+Lemma kl_cd_tensor_epsilon (X Y : C) :
+  kpure discard[(X ⨂ Y)%object]
+    ≈ @canonical_tensor_epsilon Kleisli Kleisli_Symmetric X Y
+        (Kleisli_cd_comonoid_base X) (Kleisli_cd_comonoid_base Y).
+Proof.
+  transitivity
+    (kpure (@canonical_tensor_epsilon C _ X Y
+              (cd_comonoid X) (cd_comonoid Y))).
+  { apply kl_pure_eqv.
+    exact (cd_tensor_epsilon X Y). }
+  unfold canonical_tensor_epsilon.
+  rewrite kpure_comp_functor.
+  apply compose_respects.
+  - reflexivity.
+  - symmetry.
+    exact (kl_pure_tensor discard[X] discard[Y]).
+Qed.
+
+Lemma kl_cd_unit_delta :
+  kpure copy[@I C _] ≈ kpure (from (@unit_left C _ (@I C _))).
+Proof.
+  apply kl_pure_eqv.
+  exact cd_unit_delta.
+Qed.
+
+Lemma kl_cd_unit_epsilon :
+  kpure discard[@I C _] ≈ @id Kleisli (@I C _).
+Proof.
+  transitivity (kpure (@id C (@I C _))).
+  - apply kl_pure_eqv.
+    exact cd_unit_epsilon.
+  - apply kpure_id.
+Qed.
+
+(* The copy-discard structure of Kl(M).  Note what is NOT transported:
+   naturality of copy and discard, which CopyDiscard deliberately never
+   asks for.  In Kl(M) an effectful morphism need not commute with
+   duplication or deletion of its input; the morphisms that do are the
+   deterministic ones, and Monad/Thunkable.v identifies the thunkable
+   Kleisli morphisms inside them. *)
+Definition Kleisli_CopyDiscard : @CopyDiscard Kleisli Kleisli_Symmetric :=
+  @Build_CopyDiscard Kleisli Kleisli_Symmetric
+    Kleisli_cd_comonoid
+    kl_cd_tensor_delta
+    kl_cd_tensor_epsilon
+    kl_cd_unit_delta
+    kl_cd_unit_epsilon.
+
+End WithCD.
+
+End WithComm.
+
+End KleisliCommutative.

--- a/Monad/Kleisli/Premonoidal.v
+++ b/Monad/Kleisli/Premonoidal.v
@@ -1,0 +1,632 @@
+Set Warnings "-notation-overridden".
+
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Theory.Naturality.
+Require Import Category.Theory.Monad.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Monoidal.Naturality.
+Require Import Category.Structure.Monoidal.Braided.
+Require Import Category.Structure.Monoidal.Symmetric.
+Require Import Category.Structure.Binoidal.
+Require Import Category.Structure.Binoidal.Central.
+Require Import Category.Structure.Premonoidal.
+Require Import Category.Functor.Strong.
+Require Import Category.Monad.Strong.
+Require Import Category.Monad.Strong.Symmetric.
+Require Import Category.Monad.Kleisli.
+
+Generalizable All Variables.
+Set Primitive Projections.
+Set Universe Polymorphism.
+Set Transparent Obligations.
+
+(** * The Kleisli category of a strong monad is premonoidal
+
+    nLab: https://ncatlab.org/nlab/show/premonoidal+category
+    nLab: https://ncatlab.org/nlab/show/strong+monad
+
+    Power–Robinson ("Premonoidal categories and notions of computation",
+    Math. Structures Comput. Sci. 7(5), 1997) observed that for a strong
+    monad M on a symmetric monoidal category C, the Kleisli category Kl(M)
+    carries a canonical premonoidal structure: the tensor of C extends to
+    Kl(M) separately in each variable — through the derived right strength
+    [rstr] on the left and through the left strength [strength] on the
+    right — but not jointly, because the two orders of sequencing a pair of
+    effectful computations in general disagree.  This file constructs that
+    structure over the library's actual [Kleisli] category
+    (Monad/Kleisli.v), in three tiers:
+
+    1. The binoidal structure ([Kleisli_Binoidal]): for each object y' the
+       one-variable tensoring functors
+
+           f ↦ rstr ∘ (f ⨂ id[y'])        ([kl_left_fmap],  - ⊗ y')
+           f ↦ strength ∘ (id[x'] ⨂ f)    ([kl_right_fmap], x' ⊗ -)
+
+       are Kleisli functors: identity preservation is exactly the η-compat
+       laws [rstr_ret] / [strength_ret], and composition preservation is
+       exactly the μ-compat laws [rstr_join] / [strength_join] glued by the
+       single-variable naturality corollaries of Monad/Strong/Symmetric.v.
+       The two composites of a left-tensored f with a right-tensored g
+       normalize to the two double strengths ([kl_square_lr],
+       [kl_square_rl]), giving the concrete characterization of centrality
+       in Kl(M): f is central exactly when [dstr] and [dstr'] agree on
+       every tensor with f in either factor ([kleisli_central_iff]).
+
+    2. The pure functor ([Kleisli_Pure]): postcomposing with the unit
+       embeds C into Kl(M) by f ↦ ret ∘ f ([kpure]), with the exchange
+       laws [kl_pure_post] / [kl_pure_pre] that let pure morphisms slide
+       through Kleisli composites, and the transfer laws [pure_inj_left] /
+       [pure_inj_right] that let them slide through the tensorings.  Every
+       pure morphism is central ([pure_central]): both centrality squares
+       collapse through the four double-strength unit laws
+       [dstr_ret_left], [dstr'_ret_left], [dstr_ret_right],
+       [dstr'_ret_right] of Monad/Strong/Symmetric.v — no commutativity
+       of M is needed.
+
+    3. The premonoidal structure ([Kleisli_Premonoidal]): the unitors and
+       associator of Kl(M) are the images of C's under [Kleisli_Pure]
+       ([Kleisli_pure_iso]), hence central by [pure_central]; their
+       one-variable naturality squares are the strength coherences —
+       [strength_id_left] and [rstr_id_right] for the unitors, and for the
+       associator the three laws [rstr_assoc_to], [strength_rstr_assoc]
+       and [strength_assoc], one per tensor position, glued by the
+       joint naturality of C's associator; triangle and pentagon transfer
+       from C along the pure functor.
+
+    When M is commutative the two tensorings assemble into a genuine
+    monoidal structure on Kl(M); that upgrade lives in
+    Monad/Kleisli/Commutative.v, built on the all-central engine of
+    Structure/Premonoidal/Monoidal.v and on [kleisli_central_iff] below. *)
+
+Section KleisliPremonoidal.
+
+Context `{@SymmetricMonoidal C}.
+Context {M : C ⟶ C}.
+Context `{@StrongMonad C _ M}.
+
+(* ------------------------------------------------------------------ *)
+(** ** Tier 1: the Kleisli binoidal structure.                         *)
+(* ------------------------------------------------------------------ *)
+
+(* The action of - ⊗ y' on a Kleisli morphism f : x ~> M z: tensor with the
+   identity and re-associate the M through the derived right strength.
+   Stated as named C-level definitions so that the [AFunctor] record fields
+   below elaborate without inline Kleisli-hom ascriptions. *)
+Definition kl_left_fmap (y' : C) {x z : C} (f : x ~{C}~> M z) :
+  (x ⨂ y')%object ~{C}~> M ((z ⨂ y')%object) :=
+  rstr ∘ (f ⨂ id[y']).
+
+(* The action of x' ⊗ - on a Kleisli morphism f : y ~> M z, through the
+   left strength. *)
+Definition kl_right_fmap (x' : C) {y z : C} (f : y ~{C}~> M z) :
+  (x' ⨂ y)%object ~{C}~> M ((x' ⨂ z)%object) :=
+  strength[M] ∘ (id[x'] ⨂ f).
+
+Lemma kl_left_respects (y' : C) {x z : C} :
+  Proper (equiv ==> equiv) (fun f : x ~{C}~> M z => kl_left_fmap y' f).
+Proof.
+  repeat intro.
+  unfold kl_left_fmap.
+  apply compose_respects; [reflexivity|].
+  apply bimap_respects; [assumption|reflexivity].
+Qed.
+
+(* Identity preservation is the η-compat law of the derived right
+   strength. *)
+Lemma kl_left_id (y' x : C) :
+  kl_left_fmap y' (ret[M]) ≈ (ret[M] : x ⨂ y' ~> M (x ⨂ y')).
+Proof. apply rstr_ret. Qed.
+
+(* Composition preservation is the μ-compat law [rstr_join], with the
+   naturality corollary [rstr_natural_l] sliding the tensored middle map
+   past the strength. *)
+Lemma kl_left_comp (y' : C) {x y z : C} (f : y ~> M z) (g : x ~> M y) :
+  kl_left_fmap y' (join[M] ∘ fmap[M] f ∘ g)
+    ≈ join[M] ∘ fmap[M] (kl_left_fmap y' f) ∘ kl_left_fmap y' g.
+Proof.
+  unfold kl_left_fmap.
+  transitivity
+    ((rstr ∘ (join[M] ⨂ id[y'])) ∘ ((fmap[M] f ⨂ id[y']) ∘ (g ⨂ id[y']))).
+  { rewrite <- !comp_assoc.
+    apply compose_respects; [reflexivity|].
+    rewrite <- !bimap_comp.
+    rewrite !id_left.
+    now rewrite !comp_assoc. }
+  rewrite rstr_join.
+  rewrite !fmap_comp.
+  rewrite <- !comp_assoc.
+  apply compose_respects; [reflexivity|].
+  apply compose_respects; [reflexivity|].
+  rewrite !comp_assoc.
+  rewrite <- rstr_natural_l.
+  reflexivity.
+Qed.
+
+Definition Kleisli_Tensor_Left (y' : C) :
+  @AFunctor Kleisli Kleisli (fun x : C => (x ⨂ y')%object) :=
+  @Build_AFunctor Kleisli Kleisli (fun x : C => (x ⨂ y')%object)
+    (fun x z (f : x ~{Kleisli}~> z) => kl_left_fmap y' f)
+    (fun x z => kl_left_respects y')
+    (fun x => kl_left_id y' x)
+    (fun x y z f g => kl_left_comp y' f g).
+
+Lemma kl_right_respects (x' : C) {y z : C} :
+  Proper (equiv ==> equiv) (fun f : y ~{C}~> M z => kl_right_fmap x' f).
+Proof.
+  repeat intro.
+  unfold kl_right_fmap.
+  apply compose_respects; [reflexivity|].
+  apply bimap_respects; [reflexivity|assumption].
+Qed.
+
+(* Identity preservation is the η-compat law of the left strength. *)
+Lemma kl_right_id (x' y : C) :
+  kl_right_fmap x' (ret[M]) ≈ (ret[M] : x' ⨂ y ~> M (x' ⨂ y)).
+Proof. apply strength_ret. Qed.
+
+(* Composition preservation is the μ-compat law [strength_join], glued by
+   [strength_natural_r]. *)
+Lemma kl_right_comp (x' : C) {x y z : C} (f : y ~> M z) (g : x ~> M y) :
+  kl_right_fmap x' (join[M] ∘ fmap[M] f ∘ g)
+    ≈ join[M] ∘ fmap[M] (kl_right_fmap x' f) ∘ kl_right_fmap x' g.
+Proof.
+  unfold kl_right_fmap.
+  transitivity
+    ((strength[M] ∘ (id[x'] ⨂ join[M]))
+       ∘ ((id[x'] ⨂ fmap[M] f) ∘ (id[x'] ⨂ g))).
+  { rewrite <- !comp_assoc.
+    apply compose_respects; [reflexivity|].
+    rewrite <- !bimap_comp.
+    rewrite !id_left.
+    now rewrite !comp_assoc. }
+  rewrite strength_join.
+  rewrite !fmap_comp.
+  rewrite <- !comp_assoc.
+  apply compose_respects; [reflexivity|].
+  apply compose_respects; [reflexivity|].
+  rewrite !comp_assoc.
+  rewrite <- strength_natural_r.
+  reflexivity.
+Qed.
+
+Definition Kleisli_Tensor_Right (x' : C) :
+  @AFunctor Kleisli Kleisli (fun y : C => (x' ⨂ y)%object) :=
+  @Build_AFunctor Kleisli Kleisli (fun y : C => (x' ⨂ y)%object)
+    (fun y z (f : y ~{Kleisli}~> z) => kl_right_fmap x' f)
+    (fun y z => kl_right_respects x')
+    (fun y => kl_right_id x' y)
+    (fun x y z f g => kl_right_comp x' f g).
+
+(* The Power–Robinson binoidal structure on Kl(M): the object tensor is
+   inherited from C, and the two one-variable tensoring functors are the
+   strength-mediated actions above. *)
+#[export] Instance Kleisli_Binoidal : @Binoidal Kleisli :=
+  @Build_Binoidal Kleisli
+    (fun x y : C => (x ⨂ y)%object)
+    Kleisli_Tensor_Left
+    Kleisli_Tensor_Right.
+
+(* The tensoring actions in rewrite form: both equations are definitional,
+   so downstream proofs can move between the Kleisli-functor view and the
+   C-level strength view without unfolding by hand. *)
+Lemma kl_inj_left_fmap {y' x z : C} (f : x ~{C}~> M z) :
+  fmap[@inj_left Kleisli Kleisli_Binoidal y'] f ≈ rstr ∘ (f ⨂ id[y']).
+Proof. reflexivity. Qed.
+
+Lemma kl_inj_right_fmap {x' y z : C} (f : y ~{C}~> M z) :
+  fmap[@inj_right Kleisli Kleisli_Binoidal x'] f ≈ strength[M] ∘ (id[x'] ⨂ f).
+Proof. reflexivity. Qed.
+
+(* ------------------------------------------------------------------ *)
+(** ** Normal forms for the two centrality squares.                    *)
+(* ------------------------------------------------------------------ *)
+
+(* The composite fmap[inj_left] f ∘ fmap[inj_right] g in Kl(M) — in
+   execution order: Kleisli composition runs the precomposed factor
+   first, so g's computation on the right factor runs before f's on the
+   left — computes the double strength [dstr'] (right computation
+   sequenced first). *)
+Lemma kl_square_lr {a b c d} (f : a ~> M b) (g : c ~> M d) :
+  @compose Kleisli _ _ _
+    (fmap[@inj_left _ Kleisli_Binoidal d] f)
+    (fmap[@inj_right _ Kleisli_Binoidal a] g)
+    ≈ dstr' ∘ (f ⨂ g).
+Proof.
+  simpl.
+  unfold kl_left_fmap, kl_right_fmap, dstr'.
+  rewrite fmap_comp.
+  rewrite <- !comp_assoc.
+  apply compose_respects; [reflexivity|].
+  apply compose_respects; [reflexivity|].
+  (* fmap (f ⨂ id) ∘ (strength ∘ (id ⨂ g)) ≈ strength ∘ (f ⨂ g) *)
+  rewrite comp_assoc.
+  rewrite strength_natural_l.
+  rewrite <- comp_assoc.
+  rewrite <- bimap_comp.
+  now rewrite id_left, id_right.
+Qed.
+
+(* The mirror composite fmap[inj_right] g ∘ fmap[inj_left] f — in
+   execution order, f's computation on the left factor runs before g's
+   on the right — computes the double strength [dstr] (left computation
+   sequenced first). *)
+Lemma kl_square_rl {a b c d} (f : a ~> M b) (g : c ~> M d) :
+  @compose Kleisli _ _ _
+    (fmap[@inj_right _ Kleisli_Binoidal b] g)
+    (fmap[@inj_left _ Kleisli_Binoidal c] f)
+    ≈ dstr ∘ (f ⨂ g).
+Proof.
+  simpl.
+  unfold kl_left_fmap, kl_right_fmap, dstr.
+  rewrite fmap_comp.
+  rewrite <- !comp_assoc.
+  apply compose_respects; [reflexivity|].
+  apply compose_respects; [reflexivity|].
+  (* fmap (id ⨂ g) ∘ (rstr ∘ (f ⨂ id)) ≈ rstr ∘ (f ⨂ g) *)
+  rewrite comp_assoc.
+  rewrite rstr_natural_r.
+  rewrite <- comp_assoc.
+  rewrite <- bimap_comp.
+  now rewrite id_left, id_right.
+Qed.
+
+(* The concrete characterization of centrality in Kl(M): a Kleisli morphism
+   f is central (Structure/Binoidal.v) exactly when the two double
+   strengths agree on every tensor with f in either factor.  Commutative
+   monads are precisely those all of whose Kleisli morphisms are central. *)
+Lemma kleisli_central_iff {a b} (f : a ~> M b) :
+  @central Kleisli Kleisli_Binoidal a b f
+    ↔ ∀ c d (g : c ~> M d),
+        (dstr ∘ (f ⨂ g) ≈ dstr' ∘ (f ⨂ g))
+      ∧ (dstr ∘ (g ⨂ f) ≈ dstr' ∘ (g ⨂ f)).
+Proof.
+  split.
+  - intros central_f c d g.
+    destruct (central_f c d g) as [sq1 sq2].
+    split.
+    + rewrite <- kl_square_lr, <- kl_square_rl.
+      now symmetry.
+    + rewrite <- kl_square_lr, <- kl_square_rl.
+      now symmetry.
+  - intros commutes c d g.
+    split.
+    + rewrite kl_square_lr, kl_square_rl.
+      symmetry; apply commutes.
+    + rewrite kl_square_lr, kl_square_rl.
+      symmetry; apply commutes.
+Qed.
+
+(* ------------------------------------------------------------------ *)
+(** ** Tier 2: the pure functor C ⟶ Kl(M).                             *)
+(* ------------------------------------------------------------------ *)
+
+(* A pure Kleisli morphism: an ordinary C-morphism followed by the unit. *)
+Definition kpure {x y : C} (f : x ~{C}~> y) : x ~{Kleisli}~> y :=
+  ret[M] ∘ f.
+
+(* Postcomposing a Kleisli morphism with a pure map is functorial action:
+   the unit collapses through [join_fmap_ret]. *)
+Lemma kl_pure_post {x y z : C} (u : y ~{C}~> z) (h : x ~{Kleisli}~> y) :
+  @compose Kleisli _ _ _ (kpure u) h ≈ fmap[M] u ∘ h.
+Proof.
+  simpl.
+  unfold kpure.
+  apply compose_respects; [|reflexivity].
+  rewrite fmap_comp.
+  rewrite comp_assoc.
+  rewrite join_fmap_ret.
+  now rewrite id_left.
+Qed.
+
+(* Precomposing a Kleisli morphism with a pure map is plain C-level
+   precomposition: the unit collapses through [fmap_ret] and [join_ret]. *)
+Lemma kl_pure_pre {x y z : C} (h : y ~{C}~> M z) (u : x ~{C}~> y) :
+  @compose Kleisli _ _ _ h (kpure u) ≈ h ∘ u.
+Proof.
+  simpl.
+  unfold kpure.
+  rewrite comp_assoc.
+  apply compose_respects; [|reflexivity].
+  rewrite <- comp_assoc.
+  rewrite <- fmap_ret.
+  rewrite comp_assoc.
+  rewrite join_ret.
+  now rewrite id_left.
+Qed.
+
+(* Kleisli composition of pure maps is pure composition. *)
+Lemma kl_pure_comp {x y z : C} (u : y ~{C}~> z) (v : x ~{C}~> y) :
+  @compose Kleisli _ _ _ (kpure u) (kpure v) ≈ kpure (u ∘ v).
+Proof.
+  rewrite kl_pure_pre.
+  unfold kpure.
+  now rewrite comp_assoc.
+Qed.
+
+Lemma kpure_respects {x y : C} :
+  Proper (equiv ==> equiv) (fun f : x ~{C}~> y => (kpure f : x ~{C}~> M y)).
+Proof.
+  repeat intro.
+  unfold kpure.
+  apply compose_respects; [reflexivity|assumption].
+Qed.
+
+(* Congruence for [kpure] in apply-friendly form, stated over the C-level
+   homset so that no Kleisli unification is required of the caller. *)
+Lemma kpure_proper {x y : C} {f g : x ~{C}~> y} (E : f ≈ g) :
+  (kpure f : x ~{C}~> M y) ≈ kpure g.
+Proof.
+  unfold kpure.
+  now rewrite E.
+Qed.
+
+Lemma kpure_id {x : C} : kpure (@id C x) ≈ @id Kleisli x.
+Proof.
+  unfold kpure; simpl.
+  now rewrite id_right.
+Qed.
+
+Lemma kpure_comp_functor {x y z : C} (u : y ~{C}~> z) (v : x ~{C}~> y) :
+  kpure (u ∘ v) ≈ @compose Kleisli _ _ _ (kpure u) (kpure v).
+Proof. symmetry; apply kl_pure_comp. Qed.
+
+(* The pure functor: the identity on objects, f ↦ ret ∘ f on morphisms.
+   This is the left adjoint of the Kleisli adjunction, viewed here purely
+   as the medium through which the structural isomorphisms of C transfer
+   to Kl(M). *)
+Definition Kleisli_Pure : C ⟶ Kleisli := {|
+  fobj := fun x : C => (x : Kleisli);
+  fmap := fun (x y : C) (f : x ~{C}~> y) => kpure f;
+  fmap_respects := fun x y : C => @kpure_respects x y;
+  fmap_id := fun x : C => @kpure_id x;
+  fmap_comp := fun (x y z : C) f g => kpure_comp_functor f g
+|}.
+
+(* Pure maps slide through the left tensoring: the unit exits through the
+   η-compat law [rstr_ret] of the derived right strength. *)
+Lemma pure_inj_left {x y : C} (f : x ~{C}~> y) (z : C) :
+  fmap[@inj_left Kleisli Kleisli_Binoidal z] (kpure f) ≈ kpure (f ⨂ id[z]).
+Proof.
+  rewrite kl_inj_left_fmap.
+  unfold kpure.
+  rewrite bimap_comp_id_right.
+  rewrite comp_assoc.
+  rewrite rstr_ret.
+  reflexivity.
+Qed.
+
+(* Pure maps slide through the right tensoring, through [strength_ret]. *)
+Lemma pure_inj_right {x y : C} (f : x ~{C}~> y) (z : C) :
+  fmap[@inj_right Kleisli Kleisli_Binoidal z] (kpure f) ≈ kpure (id[z] ⨂ f).
+Proof.
+  rewrite kl_inj_right_fmap.
+  unfold kpure.
+  rewrite bimap_comp_id_left.
+  rewrite comp_assoc.
+  rewrite strength_ret.
+  reflexivity.
+Qed.
+
+(* Every pure morphism is central in Kl(M).  Through the characterization
+   [kleisli_central_iff], each of the two squares reduces to one of the
+   four double-strength unit laws of Monad/Strong/Symmetric.v: feeding a
+   returned value into either factor collapses [dstr] and [dstr'] onto the
+   SAME single strength ([strength] on the left factor, [rstr] on the
+   right), so the two sequencing orders agree.  The proof is direct — no
+   thunkability and no commutativity hypothesis enters. *)
+Theorem pure_central {x y : C} (f : x ~{C}~> y) :
+  @central Kleisli Kleisli_Binoidal x y (kpure f).
+Proof.
+  apply kleisli_central_iff; intros c d g.
+  split.
+  - assert (E : ((kpure f : x ~{C}~> M y) ⨂ g) ≈ (ret[M] ⨂ id[M d]) ∘ (f ⨂ g)).
+    { unfold kpure.
+      rewrite <- bimap_comp.
+      now rewrite id_left. }
+    rewrite E.
+    rewrite !comp_assoc.
+    now rewrite dstr_ret_left, dstr'_ret_left.
+  - assert (E : (g ⨂ (kpure f : x ~{C}~> M y)) ≈ (id[M d] ⨂ ret[M]) ∘ (g ⨂ f)).
+    { unfold kpure.
+      rewrite <- bimap_comp.
+      now rewrite id_left. }
+    rewrite E.
+    rewrite !comp_assoc.
+    now rewrite dstr_ret_right, dstr'_ret_right.
+Qed.
+
+(* ------------------------------------------------------------------ *)
+(** ** Tier 3: the premonoidal structure on Kl(M).                     *)
+(* ------------------------------------------------------------------ *)
+
+(* An isomorphism of C becomes an isomorphism of Kl(M) through the pure
+   functor: both inverse laws are the C-level laws under [kl_pure_comp]. *)
+Lemma kl_pure_iso_law {x y : C} (u : x ~{C}~> y) (v : y ~{C}~> x) :
+  u ∘ v ≈ id[y] →
+  @compose Kleisli _ _ _ (kpure u) (kpure v) ≈ @id Kleisli y.
+Proof.
+  intros E.
+  rewrite kl_pure_comp.
+  unfold kpure.
+  rewrite E.
+  simpl.
+  now rewrite id_right.
+Qed.
+
+Definition Kleisli_pure_iso {x y : C} (i : x ≅ y) : @Isomorphism Kleisli x y := {|
+  to := kpure (to i);
+  from := kpure (from i);
+  iso_to_from := kl_pure_iso_law (to i) (from i) (iso_to_from i);
+  iso_from_to := kl_pure_iso_law (from i) (to i) (iso_from_to i)
+|}.
+
+(* Naturality of the left unitor in Kl(M): after the pure-map exchange
+   laws, this is Kock's unit coherence [strength_id_left] composed with
+   naturality of λ in C. *)
+Lemma kl_unit_left_natural {x y : C} (g : x ~{Kleisli}~> y) :
+  @compose Kleisli _ _ _ g (kpure (to (@unit_left C _ x)))
+    ≈ @compose Kleisli _ _ _ (kpure (to (@unit_left C _ y)))
+        (fmap[@inj_right Kleisli Kleisli_Binoidal (@I C _)] g).
+Proof.
+  rewrite kl_pure_pre, kl_pure_post.
+  rewrite kl_inj_right_fmap.
+  rewrite comp_assoc.
+  rewrite strength_id_left.
+  apply (@to_unit_left_natural C _ x (M y) g).
+Qed.
+
+(* Naturality of the right unitor: the mirror argument through the derived
+   right strength's ρ-coherence [rstr_id_right]. *)
+Lemma kl_unit_right_natural {x y : C} (g : x ~{Kleisli}~> y) :
+  @compose Kleisli _ _ _ g (kpure (to (@unit_right C _ x)))
+    ≈ @compose Kleisli _ _ _ (kpure (to (@unit_right C _ y)))
+        (fmap[@inj_left Kleisli Kleisli_Binoidal (@I C _)] g).
+Proof.
+  rewrite kl_pure_pre, kl_pure_post.
+  rewrite kl_inj_left_fmap.
+  rewrite comp_assoc.
+  rewrite rstr_id_right.
+  apply (@to_unit_right_natural C _ x (M y) g).
+Qed.
+
+(* Naturality of the associator in the LEFT tensor position: the α-law of
+   the derived right strength ([rstr_assoc_to]) absorbs the two stacked
+   left tensorings, and joint naturality of C's associator (with
+   identities in the other two positions) closes the square. *)
+Lemma kl_assoc_natural_left {x y z w : C} (g : x ~{Kleisli}~> y) :
+  @compose Kleisli _ _ _
+    (fmap[@inj_left Kleisli Kleisli_Binoidal (z ⨂ w)%object] g)
+    (kpure (to (@tensor_assoc C _ x z w)))
+  ≈ @compose Kleisli _ _ _
+      (kpure (to (@tensor_assoc C _ y z w)))
+      (fmap[@inj_left Kleisli Kleisli_Binoidal w]
+         (fmap[@inj_left Kleisli Kleisli_Binoidal z] g)).
+Proof.
+  rewrite kl_pure_pre, kl_pure_post.
+  rewrite !kl_inj_left_fmap.
+  rewrite bimap_comp_id_right.
+  rewrite !comp_assoc.
+  rewrite rstr_assoc_to.
+  pose proof (@to_tensor_assoc_natural
+                C _ x (M y) z z w w g (id[z]) (id[w])) as AN.
+  rewrite bimap_id_id in AN.
+  rewrite <- !comp_assoc.
+  rewrite <- AN.
+  reflexivity.
+Qed.
+
+(* Naturality of the associator in the MIDDLE tensor position: the sole
+   consumer of the mixed coherence [strength_rstr_assoc] of
+   Monad/Strong/Symmetric.v, which relates the left strength inside a left
+   tensoring to the right strength inside a right tensoring across α. *)
+Lemma kl_assoc_natural_middle {x z w y : C} (h : z ~{Kleisli}~> w) :
+  @compose Kleisli _ _ _
+    (fmap[@inj_right Kleisli Kleisli_Binoidal x]
+       (fmap[@inj_left Kleisli Kleisli_Binoidal y] h))
+    (kpure (to (@tensor_assoc C _ x z y)))
+  ≈ @compose Kleisli _ _ _
+      (kpure (to (@tensor_assoc C _ x w y)))
+      (fmap[@inj_left Kleisli Kleisli_Binoidal y]
+         (fmap[@inj_right Kleisli Kleisli_Binoidal x] h)).
+Proof.
+  rewrite kl_pure_pre, kl_pure_post.
+  rewrite !kl_inj_right_fmap.
+  rewrite !kl_inj_left_fmap.
+  rewrite bimap_comp_id_left.
+  rewrite bimap_comp_id_right.
+  rewrite !comp_assoc.
+  rewrite strength_rstr_assoc.
+  pose proof (@to_tensor_assoc_natural
+                C _ x x z (M w) y y (id[x]) h (id[y])) as AN.
+  rewrite <- !comp_assoc.
+  rewrite <- AN.
+  reflexivity.
+Qed.
+
+(* Naturality of the associator in the RIGHT tensor position: Kock's
+   associativity coherence [strength_assoc] absorbs the two stacked right
+   tensorings. *)
+Lemma kl_assoc_natural_right {x y z w : C} (i : z ~{Kleisli}~> w) :
+  @compose Kleisli _ _ _
+    (fmap[@inj_right Kleisli Kleisli_Binoidal x]
+       (fmap[@inj_right Kleisli Kleisli_Binoidal y] i))
+    (kpure (to (@tensor_assoc C _ x y z)))
+  ≈ @compose Kleisli _ _ _
+      (kpure (to (@tensor_assoc C _ x y w)))
+      (fmap[@inj_right Kleisli Kleisli_Binoidal (x ⨂ y)%object] i).
+Proof.
+  rewrite kl_pure_pre, kl_pure_post.
+  rewrite !kl_inj_right_fmap.
+  rewrite bimap_comp_id_left.
+  rewrite !comp_assoc.
+  rewrite strength_assoc.
+  pose proof (@to_tensor_assoc_natural
+                C _ x x y y z (M w) (id[x]) (id[y]) i) as AN.
+  rewrite bimap_id_id in AN.
+  rewrite <- !comp_assoc.
+  rewrite <- AN.
+  reflexivity.
+Qed.
+
+(* The triangle coherence transfers from C: all three structural maps are
+   pure, so the equation is the image of C's triangle under [kpure]. *)
+Lemma kl_triangle {x y : C} :
+  fmap[@inj_left Kleisli Kleisli_Binoidal y] (kpure (to (@unit_right C _ x)))
+  ≈ @compose Kleisli _ _ _
+      (fmap[@inj_right Kleisli Kleisli_Binoidal x]
+         (kpure (to (@unit_left C _ y))))
+      (kpure (to (@tensor_assoc C _ x (@I C _) y))).
+Proof.
+  rewrite pure_inj_left, pure_inj_right.
+  rewrite kl_pure_comp.
+  apply kpure_proper.
+  apply triangle_identity.
+Qed.
+
+(* The pentagon coherence transfers from C the same way. *)
+Lemma kl_pentagon {x y z w : C} :
+  @compose Kleisli _ _ _
+    (@compose Kleisli _ _ _
+       (fmap[@inj_right Kleisli Kleisli_Binoidal x]
+          (kpure (to (@tensor_assoc C _ y z w))))
+       (kpure (to (@tensor_assoc C _ x (y ⨂ z)%object w))))
+    (fmap[@inj_left Kleisli Kleisli_Binoidal w]
+       (kpure (to (@tensor_assoc C _ x y z))))
+  ≈ @compose Kleisli _ _ _
+      (kpure (to (@tensor_assoc C _ x y (z ⨂ w)%object)))
+      (kpure (to (@tensor_assoc C _ (x ⨂ y)%object z w))).
+Proof.
+  rewrite pure_inj_right, pure_inj_left.
+  rewrite !kl_pure_comp.
+  apply kpure_proper.
+  apply pentagon_identity.
+Qed.
+
+(* The Power–Robinson premonoidal structure on the Kleisli category of a
+   strong monad over a symmetric monoidal base: unit and structural
+   isomorphisms are the pure images of C's, centrality of the structural
+   maps is [pure_central], the three one-variable associator squares are
+   the three strength coherences, and the coherence laws transfer along
+   the pure functor. *)
+#[export] Instance Kleisli_Premonoidal : @Premonoidal Kleisli Kleisli_Binoidal :=
+  @Build_Premonoidal Kleisli Kleisli_Binoidal
+    (@I C _)
+    (fun x : C => Kleisli_pure_iso (@unit_left C _ x))
+    (fun x : C => Kleisli_pure_iso (@unit_right C _ x))
+    (fun x y z : C => Kleisli_pure_iso (@tensor_assoc C _ x y z))
+    (fun x : C => pure_central (to (@unit_left C _ x)))
+    (fun x : C => pure_central (to (@unit_right C _ x)))
+    (fun x y z : C => pure_central (to (@tensor_assoc C _ x y z)))
+    (fun (x y : C) (g : x ~{Kleisli}~> y) => kl_unit_left_natural g)
+    (fun (x y : C) (g : x ~{Kleisli}~> y) => kl_unit_right_natural g)
+    (fun (x y z w : C) (g : x ~{Kleisli}~> y) => kl_assoc_natural_left g)
+    (fun (x z w y : C) (h : z ~{Kleisli}~> w) => kl_assoc_natural_middle h)
+    (fun (x y z w : C) (i : z ~{Kleisli}~> w) => kl_assoc_natural_right i)
+    (fun x y : C => @kl_triangle x y)
+    (fun x y z w : C => @kl_pentagon x y z w).
+
+End KleisliPremonoidal.

--- a/Monad/Kleisli/Premonoidal.v
+++ b/Monad/Kleisli/Premonoidal.v
@@ -4,15 +4,12 @@ Require Import Category.Lib.
 Require Import Category.Theory.Category.
 Require Import Category.Theory.Isomorphism.
 Require Import Category.Theory.Functor.
-Require Import Category.Theory.Naturality.
 Require Import Category.Theory.Monad.
 Require Import Category.Functor.Bifunctor.
 Require Import Category.Structure.Monoidal.
-Require Import Category.Structure.Monoidal.Naturality.
 Require Import Category.Structure.Monoidal.Braided.
 Require Import Category.Structure.Monoidal.Symmetric.
 Require Import Category.Structure.Binoidal.
-Require Import Category.Structure.Binoidal.Central.
 Require Import Category.Structure.Premonoidal.
 Require Import Category.Functor.Strong.
 Require Import Category.Monad.Strong.

--- a/Monad/Strong.v
+++ b/Monad/Strong.v
@@ -284,8 +284,8 @@ Arguments RightStrongMonad {C} _ M.
    computations.  Out of the left strength t and the right strength t' one
    builds two "double strengths" M x ⨂ M y ~> M (x ⨂ y):
 
-     dstr  = μ ∘ M t  ∘ t'   (sequence the right computation first)
-     dstr' = μ ∘ M t' ∘ t    (sequence the left  computation first)
+     dstr  = μ ∘ M t  ∘ t'   (sequence the left  computation first)
+     dstr' = μ ∘ M t' ∘ t    (sequence the right computation first)
 
    and the monad is commutative when dstr ≈ dstr' — running the two effects in
    either order yields the same result.  This double strength is precisely the

--- a/Monad/Strong.v
+++ b/Monad/Strong.v
@@ -240,7 +240,9 @@ End StrongMonadValidation.
                                       ≈ join ∘ fmap rstrength ∘ rstrength
 
    This dual is provided for completeness and symmetry with [StrongMonad]; no
-   instance is built here.  [CommutativeStrongMonad] below deliberately inlines
+   instance is built here.  (A derived instance over any symmetric base is
+   built in Monad/Strong/Symmetric.v as [rstr_RightStrongMonad].)
+   [CommutativeStrongMonad] below deliberately inlines
    a [RightStrongFunctor] plus its two compatibility laws (rather than bundling
    a [RightStrongMonad]) so that the left and right strengths share the *same*
    underlying monad, keeping [join] unambiguous in the commutativity law. *)
@@ -341,13 +343,15 @@ Arguments CommutativeStrongMonad {C} _ M.
    two monad-compatibility laws — so every strong monad over a symmetric base is
    right-strong in the monad-relevant sense.
 
-   We deliver this as a derived morphism family with its laws rather than as a
-   full [RightStrongMonad] instance: the two [RightStrongFunctor] *coherence*
-   laws (unit-object [rrstrength_id_right] and associator [rstrength_assoc])
-   require braided-coherence lemmas relating the unitors and associator to the
-   braiding (e.g. ρ ≈ λ ∘ β) that are not available from the library's bare
-   [BraidedMonoidal]/[SymmetricMonoidal] axiomatization, so we omit them rather
-   than assume any axiom. *)
+   This file delivers the derived morphism family with its naturality and
+   monad-compatibility laws; the two [RightStrongFunctor] *coherence* laws
+   (unit-object [rrstrength_id_right] and associator [rstrength_assoc]) are
+   now derivable as well: the braid-unitor coherences (ρ ≈ λ ∘ β and its
+   mirrors) are proven from the bare axioms in
+   Structure/Monoidal/Braided/Proofs.v ([braid_unit_left],
+   [braid_unit_right], [braid_I_I]), and Monad/Strong/Symmetric.v packages
+   [rstr] as a full [RightStrongFunctor] and [RightStrongMonad]
+   ([rstr_RightStrongFunctor], [rstr_RightStrongMonad]). *)
 
 Section SymmetricRightStrength.
 
@@ -438,11 +442,12 @@ Definition dstr' {x y} : M x ⨂ M y ~> M (x ⨂ y) :=
    This is the symmetric-base specialization, phrased with the *derived* right
    strength [rstr]; it is distinct from the abstract
    [CommutativeStrongMonad.commutativity] field (stated over an arbitrary
-   bundled right strength).  The two are not formally bridged here: packaging
-   [rstr] as a full [RightStrongFunctor] — and so obtaining a
-   [CommutativeStrongMonad] over the symmetric base — would need the
-   braid/unitor coherence ρ ≈ λ ∘ β, which the bare [SymmetricMonoidal]
-   axiomatization used here does not provide. *)
+   bundled right strength).  The bridge is provided in
+   Monad/Strong/Symmetric.v: [commutative_CommutativeStrongMonad] turns a
+   [commutative_sm] witness into a [CommutativeStrongMonad] over the derived
+   right strength, and [CSM_commutative_sm] gives the converse whenever the
+   bundled right strength agrees with [rstr]; the required braid/unitor
+   coherence is [braid_unit_left] in Structure/Monoidal/Braided/Proofs.v. *)
 Definition commutative_sm : Type := ∀ x y, @dstr x y ≈ @dstr' x y.
 
 End SymmetricRightStrength.

--- a/Monad/Strong/Symmetric.v
+++ b/Monad/Strong/Symmetric.v
@@ -4,17 +4,14 @@ Require Import Category.Lib.
 Require Import Category.Theory.Category.
 Require Import Category.Theory.Isomorphism.
 Require Import Category.Theory.Functor.
-Require Import Category.Theory.Naturality.
 Require Import Category.Theory.Natural.Transformation.
 Require Import Category.Theory.Monad.
 Require Import Category.Functor.Bifunctor.
 Require Import Category.Structure.Monoidal.
-Require Import Category.Structure.Monoidal.Naturality.
 Require Import Category.Structure.Monoidal.Braided.
 Require Import Category.Structure.Monoidal.Symmetric.
 Require Import Category.Structure.Monoidal.Braided.Proofs.
 Require Import Category.Functor.Strong.
-Require Import Category.Natural.Transformation.Strong.
 Require Import Category.Construction.Product.
 Require Import Category.Functor.Construction.Product.
 Require Import Category.Monad.Strong.
@@ -195,6 +192,21 @@ Proof.
   rewrite comp_assoc.
   rewrite join_fmap_ret.
   now rewrite id_left.
+Qed.
+
+(* Both factors pure at once: the double strength collapses to the unit.
+   Shared by [kl_pure_tensor] (Monad/Kleisli/Commutative.v) and the
+   thunkability development (Monad/Thunkable.v). *)
+Lemma dstr_ret_ret {x y} :
+  dstr ∘ (ret[M] ⨂ ret[M]) ≈ (ret[M] : x ⨂ y ~{C}~> M (x ⨂ y)).
+Proof.
+  transitivity (dstr ∘ ((ret[M] ⨂ id[M y]) ∘ (id[x] ⨂ ret[M]))).
+  - apply compose_respects; [reflexivity|].
+    rewrite <- bimap_comp.
+    now rewrite id_left, id_right.
+  - rewrite comp_assoc.
+    rewrite dstr_ret_left.
+    apply strength_ret.
 Qed.
 
 Lemma dstr_natural {x y z w} (u : x ~> z) (v : y ~> w) :

--- a/Monad/Strong/Symmetric.v
+++ b/Monad/Strong/Symmetric.v
@@ -1,0 +1,616 @@
+Set Warnings "-notation-overridden".
+
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Theory.Naturality.
+Require Import Category.Theory.Natural.Transformation.
+Require Import Category.Theory.Monad.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Monoidal.Naturality.
+Require Import Category.Structure.Monoidal.Braided.
+Require Import Category.Structure.Monoidal.Symmetric.
+Require Import Category.Structure.Monoidal.Braided.Proofs.
+Require Import Category.Functor.Strong.
+Require Import Category.Natural.Transformation.Strong.
+Require Import Category.Construction.Product.
+Require Import Category.Functor.Construction.Product.
+Require Import Category.Monad.Strong.
+
+Generalizable All Variables.
+
+(** Strong monads over a symmetric monoidal base: the full right strength. *)
+
+(* nLab: https://ncatlab.org/nlab/show/strong+monad
+   nLab: https://ncatlab.org/nlab/show/commutative+monad
+
+   Monad/Strong.v derives, for a strong monad M over a symmetric monoidal
+   base, the braid-conjugated right strength
+
+       rstr = M(β) ∘ t ∘ β  :  M x ⨂ y ~> M (x ⨂ y)
+
+   together with its naturality ([rstr_natural]) and its two
+   monad-compatibility laws ([rstr_ret], [rstr_join]) — but stops short of
+   packaging it as a [RightStrongFunctor]: the two functor-level coherences
+   (the ρ-law [rrstrength_id_right] and the α-law [rstrength_assoc]) need the
+   braid/unitor coherence ρ ≈ λ ∘ β of Joyal & Street ("Braided tensor
+   categories", Adv. Math. 102, 1993, Prop. 2.1), which the bare
+   [SymmetricMonoidal] axiomatization does not hand out directly.  That
+   coherence is now proved from the hexagons in
+   Structure/Monoidal/Braided/Proofs.v ([braid_unit_left],
+   [braid_unit_right]), and this file completes the programme:
+
+   1. the naturality corollaries of the left and right strengths in
+      single-variable rewrite form ([strength_natural_l/r],
+      [rstr_natural_l/r]), the workhorses of every proof below and of the
+      Kleisli premonoidal development (Monad/Kleisli/Premonoidal.v);
+
+   2. the double-strength toolkit: unit laws for [dstr] and [dstr'] against
+      ret in either factor ([dstr_ret_left], [dstr_ret_right],
+      [dstr'_ret_left], [dstr'_ret_right]), joint naturality
+      ([dstr_natural], [dstr'_natural]), and Führmann-style reassociation
+      lemmas ([dstr_reassoc_left], [dstr_reassoc_left'],
+      [dstr'_reassoc_right], [dstr'_reassoc_right']) that rebracket a double
+      strength through an extra M-layer (Führmann, "Direct models of the
+      computational lambda-calculus", MFPS 1999);
+
+   3. the two missing coherences [rstr_id_right] and [rstr_assoc], plus the
+      mixed associativity coherence [strength_rstr_assoc] relating the left
+      and the derived right strength across the associator — the key lemma
+      behind associativity of the premonoidal tensor on Kl(M);
+
+   4. the packaging: [rstr_nat] (the right strength as a natural
+      transformation (⨂) ◯ M ∏⟶ Id ⟹ M ◯ (⨂)), the instances
+      [rstr_RightStrongFunctor] and [rstr_RightStrongMonad], and the bridge
+      between the concrete commutativity predicate [commutative_sm] and the
+      abstract [CommutativeStrongMonad] class, in both directions
+      ([commutative_CommutativeStrongMonad], [CSM_commutative_sm]) with the
+      round trip [commutative_sm_round_trip].
+
+   The bridge's converse direction is honest: an abstract
+   [CommutativeStrongMonad] bundles its own right strength, which need not
+   be the braid-derived one, so the converse takes the agreement of the two
+   right strengths as an explicit hypothesis.  At the instance produced by
+   the forward direction that hypothesis holds by reflexivity, which is
+   exactly the round-trip corollary. *)
+
+Section StrongSymmetric.
+
+Context {C : Category}.
+Context `{SM : @SymmetricMonoidal C}.
+Context {M : C ⟶ C}.
+Context `{SMon : @StrongMonad C _ M}.
+
+(* ------------------------------------------------------------------ *)
+(** ** Naturality corollaries in single-variable rewrite form.          *)
+(* ------------------------------------------------------------------ *)
+
+(* Clean the identity components out of a joint naturality square. *)
+Local Ltac cleanup_nat SN :=
+  repeat (rewrite ?bimap_id_id in SN; rewrite ?fmap_id in SN);
+  rewrite ?id_left, ?id_right in SN.
+
+(* Massage a joint (factored) naturality square into single-bimap form. *)
+Local Ltac fuse_nat SN :=
+  rewrite <- ?fmap_comp in SN;
+  rewrite <- ?comp_assoc in SN;
+  rewrite ?bimap_id_left_right in SN.
+
+Lemma strength_natural_l {x y z} (g : x ~> y) :
+  fmap[M] (g ⨂ id[z]) ∘ strength[M] ≈ strength[M] ∘ (g ⨂ id[M z]).
+Proof.
+  pose proof (@strength_natural _ _ M _ x y g z z (id[z])) as SN.
+  simpl in SN.
+  cleanup_nat SN.
+  exact SN.
+Qed.
+
+Lemma strength_natural_r {x z w} (h : z ~> w) :
+  fmap[M] (id[x] ⨂ h) ∘ strength[M] ≈ strength[M] ∘ (id[x] ⨂ fmap[M] h).
+Proof.
+  pose proof (@strength_natural _ _ M _ x x (id[x]) z w h) as SN.
+  simpl in SN.
+  cleanup_nat SN.
+  exact SN.
+Qed.
+
+Lemma rstr_natural_l {x z y} (f : x ~> z) :
+  fmap[M] (f ⨂ id[y]) ∘ rstr ≈ rstr ∘ (fmap[M] f ⨂ id[y]).
+Proof.
+  pose proof (@rstr_natural _ _ M _ x z y y f (id[y])) as RN.
+  rewrite ?fmap_id in RN.
+  exact RN.
+Qed.
+
+Lemma rstr_natural_r {x y w} (g : y ~> w) :
+  fmap[M] (id[x] ⨂ g) ∘ rstr ≈ rstr ∘ (id[M x] ⨂ g).
+Proof.
+  pose proof (@rstr_natural _ _ M _ x x y w (id[x]) g) as RN.
+  rewrite ?fmap_id in RN.
+  exact RN.
+Qed.
+
+(* ------------------------------------------------------------------ *)
+(** ** The double-strength toolkit: unit laws and naturality.           *)
+(* ------------------------------------------------------------------ *)
+
+(* Feeding a returned value into the left factor of [dstr] leaves just the
+   left strength: the rstr leg collapses by [rstr_ret] and [join_ret]. *)
+Lemma dstr_ret_left {x y} :
+  dstr ∘ (ret[M] ⨂ id[M y]) ≈ (strength[M] : x ⨂ M y ~> M (x ⨂ y)).
+Proof.
+  unfold dstr.
+  rewrite <- !comp_assoc.
+  rewrite rstr_ret.
+  rewrite <- fmap_ret.
+  rewrite comp_assoc.
+  rewrite join_ret.
+  now rewrite id_left.
+Qed.
+
+(* Mirror: feeding a returned value into the right factor of [dstr'] leaves
+   just the derived right strength. *)
+Lemma dstr'_ret_right {x y} :
+  dstr' ∘ (id[M x] ⨂ ret[M]) ≈ (rstr : M x ⨂ y ~> M (x ⨂ y)).
+Proof.
+  unfold dstr'.
+  rewrite <- !comp_assoc.
+  rewrite strength_ret.
+  rewrite <- fmap_ret.
+  rewrite comp_assoc.
+  rewrite join_ret.
+  now rewrite id_left.
+Qed.
+
+(* The two cross unit laws: [dstr'] against ret on the left and [dstr]
+   against ret on the right.  Here the returned value enters the *outer*
+   strength of the composite, so the collapse goes through naturality
+   (pushing ret across the strength), the opposite compatibility law under
+   fmap, and [join_fmap_ret]. *)
+Lemma dstr'_ret_left {x y} :
+  dstr' ∘ (ret[M] ⨂ id[M y]) ≈ (strength[M] : x ⨂ M y ~> M (x ⨂ y)).
+Proof.
+  unfold dstr'.
+  rewrite <- !comp_assoc.
+  rewrite <- strength_natural_l.
+  rewrite (comp_assoc (fmap[M] rstr)).
+  rewrite <- fmap_comp.
+  rewrite rstr_ret.
+  rewrite comp_assoc.
+  rewrite join_fmap_ret.
+  now rewrite id_left.
+Qed.
+
+Lemma dstr_ret_right {x y} :
+  dstr ∘ (id[M x] ⨂ ret[M]) ≈ (rstr : M x ⨂ y ~> M (x ⨂ y)).
+Proof.
+  unfold dstr.
+  rewrite <- !comp_assoc.
+  rewrite <- rstr_natural_r.
+  rewrite (comp_assoc (fmap[M] strength[M])).
+  rewrite <- fmap_comp.
+  rewrite strength_ret.
+  rewrite comp_assoc.
+  rewrite join_fmap_ret.
+  now rewrite id_left.
+Qed.
+
+Lemma dstr_natural {x y z w} (u : x ~> z) (v : y ~> w) :
+  fmap[M] (u ⨂ v) ∘ dstr ≈ dstr ∘ (fmap[M] u ⨂ fmap[M] v).
+Proof.
+  unfold dstr.
+  rewrite !comp_assoc.
+  rewrite <- join_fmap_fmap.
+  rewrite <- !comp_assoc.
+  apply compose_respects; [reflexivity|].
+  rewrite comp_assoc.
+  rewrite <- fmap_comp.
+  pose proof (@strength_natural _ _ M _ x z u y w v) as SN.
+  simpl in SN.
+  fuse_nat SN.
+  rewrite <- (@rstr_natural _ _ M _ x z (fobj[M] y) (fobj[M] w) u (fmap[M] v)).
+  rewrite comp_assoc.
+  rewrite <- fmap_comp.
+  apply compose_respects; [|reflexivity].
+  apply fmap_respects.
+  rewrite SN.
+  reflexivity.
+Qed.
+
+Lemma dstr'_natural {x y z w} (u : x ~> z) (v : y ~> w) :
+  fmap[M] (u ⨂ v) ∘ dstr' ≈ dstr' ∘ (fmap[M] u ⨂ fmap[M] v).
+Proof.
+  unfold dstr'.
+  rewrite !comp_assoc.
+  rewrite <- join_fmap_fmap.
+  rewrite <- !comp_assoc.
+  apply compose_respects; [reflexivity|].
+  rewrite comp_assoc.
+  rewrite <- fmap_comp.
+  pose proof (@strength_natural _ _ M _ (fobj[M] x) (fobj[M] z) (fmap[M] u) y w v) as SN.
+  simpl in SN.
+  fuse_nat SN.
+  rewrite <- SN.
+  rewrite comp_assoc.
+  rewrite <- fmap_comp.
+  apply compose_respects; [|reflexivity].
+  apply fmap_respects.
+  rewrite (@rstr_natural _ _ M _ x z y w u v).
+  reflexivity.
+Qed.
+
+(* ------------------------------------------------------------------ *)
+(** ** Führmann's reassociation lemmas.                                 *)
+(* ------------------------------------------------------------------ *)
+
+(* Rebracketing [dstr] through an extra M-layer on the left factor: for ANY
+   f, applying [fmap ret] to the left component and then collapsing with
+   join ∘ fmap rstr computes [dstr] again. *)
+Lemma dstr_reassoc_left {a b c d} (f : a ~> M b) (g : c ~> M d) :
+  join[M] ∘ fmap[M] rstr ∘ dstr ∘ ((fmap[M] ret[M] ∘ f) ⨂ g)
+    ≈ dstr ∘ (f ⨂ g).
+Proof.
+  assert (E : (fmap[M] ret[M] ∘ f) ⨂ g ≈ (fmap[M] ret[M] ⨂ id) ∘ (f ⨂ g)).
+  { rewrite <- bimap_comp.
+    now rewrite id_left. }
+  rewrite E; clear E.
+  rewrite <- (@fmap_id _ _ M d).
+  rewrite !comp_assoc.
+  rewrite <- (comp_assoc _ dstr).
+  rewrite <- dstr_natural.
+  rewrite <- !comp_assoc.
+  rewrite (comp_assoc (fmap[M] rstr)).
+  rewrite <- fmap_comp.
+  rewrite rstr_ret.
+  rewrite (comp_assoc join[M]).
+  rewrite join_fmap_ret.
+  now rewrite id_left.
+Qed.
+
+(* The same expression with a bare ret in place of fmap ret instead
+   computes the sibling double strength [dstr']. *)
+Lemma dstr_reassoc_left' {a b c d} (f : a ~> M b) (g : c ~> M d) :
+  join[M] ∘ fmap[M] rstr ∘ dstr ∘ ((ret[M] ∘ f) ⨂ g)
+    ≈ dstr' ∘ (f ⨂ g).
+Proof.
+  assert (E : (ret[M] ∘ f) ⨂ g ≈ (ret[M] ⨂ id[M d]) ∘ (f ⨂ g)).
+  { rewrite <- bimap_comp.
+    now rewrite id_left. }
+  rewrite E; clear E.
+  rewrite !comp_assoc.
+  rewrite <- (comp_assoc _ dstr).
+  rewrite dstr_ret_left.
+  unfold dstr'.
+  reflexivity.
+Qed.
+
+(* Mirror reassociation on the right factor of [dstr']. *)
+Lemma dstr'_reassoc_right {a b c d} (g : c ~> M d) (f : a ~> M b) :
+  join[M] ∘ fmap[M] strength[M] ∘ dstr' ∘ (g ⨂ (fmap[M] ret[M] ∘ f))
+    ≈ dstr' ∘ (g ⨂ f).
+Proof.
+  assert (E : g ⨂ (fmap[M] ret[M] ∘ f) ≈ (id ⨂ fmap[M] ret[M]) ∘ (g ⨂ f)).
+  { rewrite <- bimap_comp.
+    now rewrite id_left. }
+  rewrite E; clear E.
+  rewrite <- (@fmap_id _ _ M d).
+  rewrite !comp_assoc.
+  rewrite <- (comp_assoc _ dstr').
+  rewrite <- dstr'_natural.
+  rewrite <- !comp_assoc.
+  rewrite (comp_assoc (fmap[M] strength[M])).
+  rewrite <- fmap_comp.
+  rewrite strength_ret.
+  rewrite (comp_assoc join[M]).
+  rewrite join_fmap_ret.
+  now rewrite id_left.
+Qed.
+
+(* Mirror: the bare-ret variant computes [dstr]. *)
+Lemma dstr'_reassoc_right' {a b c d} (g : c ~> M d) (f : a ~> M b) :
+  join[M] ∘ fmap[M] strength[M] ∘ dstr' ∘ (g ⨂ (ret[M] ∘ f))
+    ≈ dstr ∘ (g ⨂ f).
+Proof.
+  assert (E : g ⨂ (ret[M] ∘ f) ≈ (id[M d] ⨂ ret[M]) ∘ (g ⨂ f)).
+  { rewrite <- bimap_comp.
+    now rewrite id_left. }
+  rewrite E; clear E.
+  rewrite !comp_assoc.
+  rewrite <- (comp_assoc _ dstr').
+  rewrite dstr'_ret_right.
+  unfold dstr.
+  reflexivity.
+Qed.
+
+(* ------------------------------------------------------------------ *)
+(** ** The two right-strength coherences.                               *)
+(* ------------------------------------------------------------------ *)
+
+(* Kock's associativity law for the left strength, solved for the composite
+   strength ∘ (id ⨂ strength): every proof below uses it in this
+   orientation, which requires no bracket surgery at the rewrite site. *)
+Lemma strength_assoc_solved {a b c} :
+  strength[M] ∘ (id[a] ⨂ strength[M])
+    ≈ fmap[M] (to (@tensor_assoc _ _ a b c)) ∘ strength[M]
+        ∘ from (@tensor_assoc _ _ a b (M c)).
+Proof.
+  rewrite strength_assoc.
+  rewrite <- !comp_assoc.
+  rewrite iso_to_from.
+  now rewrite id_right.
+Qed.
+
+(* The braid-word coherence at the heart of both associativity proofs: the
+   two ways of moving the outer factor a of (c ⨂ b) ⨂ a to the front — braid
+   the inner pair first and then braid a across the tensor, or braid a
+   across in one step on either side of the associator — agree.  It is the
+   hexagon [hexagon_b] composed against the solved hexagon
+   [hexagon_a_solved], glued by naturality of the braiding. *)
+Lemma braid_swap_assoc {a b c} :
+  from (@tensor_assoc _ _ a b c) ∘ (braid ∘ (braid ⨂ id[a]))
+    ≈ (braid ∘ ((id[c] ⨂ braid) ∘ to (@tensor_assoc _ _ c b a))
+         : (c ⨂ b) ⨂ a ~> (a ⨂ b) ⨂ c).
+Proof.
+  rewrite <- bimap_braid.
+  rewrite hexagon_b.
+  rewrite hexagon_a_solved.
+  rewrite <- !comp_assoc.
+  reflexivity.
+Qed.
+
+(* The same coherence solved against the associator: precomposing the braid
+   word with to tensor_assoc on the left cancels the inverse associator. *)
+Lemma braid_swap_assoc_solved {a b c} :
+  to (@tensor_assoc _ _ a b c) ∘ braid ∘ (id[c] ⨂ braid)
+    ∘ to (@tensor_assoc _ _ c b a)
+    ≈ (braid ∘ (braid ⨂ id[a]) : (c ⨂ b) ⨂ a ~> a ⨂ (b ⨂ c)).
+Proof.
+  rewrite <- !comp_assoc.
+  rewrite <- braid_swap_assoc.
+  rewrite (cancel_to_from_cons tensor_assoc).
+  reflexivity.
+Qed.
+
+(* The ρ-coherence of the derived right strength: M(ρ) ∘ rstr ≈ ρ.  The
+   braid/unitor exchange of Joyal & Street ([braid_unit_right]) turns the
+   fused fmap argument ρ ∘ β into λ, the left strength's own unit coherence
+   [strength_id_left] absorbs it, and [braid_unit_left] at M x closes the
+   remaining λ ∘ β. *)
+Lemma rstr_id_right {x} :
+  fmap[M] (to unit_right) ∘ rstr ≈ to (@unit_right _ _ (M x)).
+Proof.
+  unfold rstr.
+  rewrite !comp_assoc.
+  rewrite <- fmap_comp.
+  rewrite braid_unit_right.
+  rewrite strength_id_left.
+  apply braid_unit_left.
+Qed.
+
+(* The α-coherence of the derived right strength, in the to-oriented form
+   from which the class field's from-oriented form follows by iso
+   cancellation.  The chase: unfold rstr, slide the braids outward by
+   naturality of the braiding and of the strength, absorb the two stacked
+   strengths with [strength_assoc_solved], convert the residual braid word
+   with [braid_swap_assoc], and finish with [braid_swap_assoc_solved] inside
+   the fmap argument. *)
+Lemma rstr_assoc_to {x y z} :
+  fmap[M] (to (@tensor_assoc _ _ x y z)) ∘ rstr ∘ bimap rstr id
+    ≈ rstr ∘ to (@tensor_assoc _ _ (M x) y z).
+Proof.
+  unfold rstr.
+  rewrite <- !comp_assoc.
+  rewrite <- bimap_braid.
+  rewrite !bimap_comp_id_left.
+  rewrite <- !comp_assoc.
+  rewrite (comp_assoc strength[M] (id[z] ⨂ fmap[M] braid)).
+  rewrite <- strength_natural_r.
+  rewrite <- !comp_assoc.
+  rewrite (comp_assoc strength[M] (id[z] ⨂ strength[M])).
+  rewrite strength_assoc_solved.
+  rewrite <- !comp_assoc.
+  rewrite bimap_braid.
+  rewrite braid_swap_assoc.
+  rewrite (comp_assoc braid (id[M x] ⨂ braid)).
+  rewrite <- bimap_braid.
+  rewrite <- !comp_assoc.
+  rewrite (comp_assoc strength[M] (braid ⨂ id[M x])).
+  rewrite <- strength_natural_l.
+  rewrite !comp_assoc.
+  rewrite <- !fmap_comp.
+  apply compose_respects; [|reflexivity].
+  apply compose_respects; [|reflexivity].
+  apply compose_respects; [|reflexivity].
+  apply fmap_respects.
+  rewrite braid_swap_assoc_solved.
+  rewrite <- comp_assoc.
+  rewrite <- bimap_comp.
+  rewrite braid_invol.
+  rewrite id_left.
+  rewrite bimap_id_id.
+  now rewrite id_right.
+Qed.
+
+(* The α-coherence in the [RightStrongFunctor] field orientation. *)
+Lemma rstr_assoc {x y z} :
+  rstr ∘ bimap rstr id ∘ from (@tensor_assoc _ _ (M x) y z)
+    ≈ fmap[M] (from (@tensor_assoc _ _ x y z)) ∘ rstr.
+Proof.
+  apply (iso_to_epic tensor_assoc).
+  rewrite <- !comp_assoc.
+  rewrite iso_from_to.
+  rewrite id_right.
+  rewrite <- rstr_assoc_to.
+  rewrite !comp_assoc.
+  rewrite <- fmap_comp.
+  rewrite iso_from_to.
+  rewrite fmap_id.
+  now rewrite id_left.
+Qed.
+
+(* ------------------------------------------------------------------ *)
+(** ** The mixed associativity coherence.                               *)
+(* ------------------------------------------------------------------ *)
+
+(* The coherence that mixes the left strength and the derived right
+   strength across the associator:
+
+       M(α) ∘ rstr ∘ (t ⨂ id) ≈ t ∘ (id ⨂ rstr) ∘ α
+
+   on (x ⨂ M y) ⨂ z.  This is the hardest single equation of the
+   development; its sole consumer is the middle-associativity naturality
+   square of the Kleisli premonoidal tensor
+   (kl_assoc_natural_middle in Monad/Kleisli/Premonoidal.v).
+
+   The proof is staged: first the symmetric hexagon in solved "cons" form
+   (assert S1), which rewrites the inverse-associator-after-braid tail of
+   the unfolded left side; then naturality of the strength slides the
+   remaining braid under fmap; both sides collapse onto a common
+   strength-spine, and the residual fmap argument is the first hexagon plus
+   [braid_invol].
+
+   A fallback route, recorded for maintainers: the same equation can
+   instead be established at its point of use, by inlining the statement
+   into the proof of [kl_assoc_natural_middle] and staging further
+   intermediate asserts there against the unfolded Kleisli composite; the
+   ingredients — the hexagon lemmas, the strength coherences and
+   [braid_invol] — are unchanged, only the staging site moves. *)
+Lemma strength_rstr_assoc {x y z} :
+  fmap[M] (to (@tensor_assoc _ _ x y z)) ∘ rstr ∘ bimap strength[M] id
+    ≈ strength[M] ∘ bimap id rstr ∘ to (@tensor_assoc _ _ x (M y) z).
+Proof.
+  (* Stage 1: the symmetric hexagon, solved for α⁻¹ ∘ β. *)
+  assert (S1 : from (@tensor_assoc _ _ z x (M y))
+                 ∘ @braid C _ (x ⨂ M y)%object z
+                 ≈ (braid ⨂ id[M y])
+                     ∘ (from (@tensor_assoc _ _ x z (M y))
+                          ∘ ((id[x] ⨂ braid)
+                               ∘ to (@tensor_assoc _ _ x (M y) z)))).
+  { apply (iso_to_epic (iso_sym tensor_assoc)).
+    rewrite <- !comp_assoc.
+    rewrite iso_to_from.
+    rewrite id_right.
+    rewrite !comp_assoc.
+    apply hexagon_identity_sym. }
+  unfold rstr.
+  rewrite <- !comp_assoc.
+  (* Stage 2: normalize both sides onto the common strength-spine. *)
+  rewrite <- bimap_braid.
+  rewrite !bimap_comp_id_left.
+  rewrite <- !comp_assoc.
+  rewrite (comp_assoc strength[M] (id[x] ⨂ fmap[M] braid)).
+  rewrite <- strength_natural_r.
+  rewrite <- !comp_assoc.
+  rewrite (comp_assoc strength[M] (id[z] ⨂ strength[M])).
+  rewrite (comp_assoc strength[M] (id[x] ⨂ strength[M])).
+  rewrite !strength_assoc_solved.
+  rewrite <- !comp_assoc.
+  rewrite S1.
+  rewrite (comp_assoc strength[M] (braid ⨂ id[M y])).
+  rewrite <- strength_natural_l.
+  rewrite !comp_assoc.
+  rewrite <- !fmap_comp.
+  apply compose_respects; [|reflexivity].
+  apply compose_respects; [|reflexivity].
+  apply compose_respects; [|reflexivity].
+  apply compose_respects; [|reflexivity].
+  apply fmap_respects.
+  (* Stage 3: the residual braid word is the first hexagon plus invol. *)
+  rewrite hexagon_identity.
+  rewrite <- comp_assoc.
+  rewrite <- bimap_comp.
+  rewrite braid_invol.
+  rewrite id_left.
+  rewrite bimap_id_id.
+  now rewrite id_right.
+Qed.
+
+(* ------------------------------------------------------------------ *)
+(** ** Packaging: the right strong functor and right strong monad.      *)
+(* ------------------------------------------------------------------ *)
+
+(* The derived right strength as a natural transformation
+   (⨂) ◯ M ∏⟶ Id ⟹ M ◯ (⨂): the shape demanded by the
+   [RightStrongFunctor] field.  The component at (x, y) is definitionally
+   [rstr], so the coherence laws transfer on the nose. *)
+Definition rstr_nat : (⨂) ◯ M ∏⟶ Id ⟹ M ◯ (⨂).
+Proof using C M SM SMon.
+  refine (@Build_Transform' (C ∏ C) C ((⨂) ◯ M ∏⟶ Id) (M ◯ (⨂))
+            (fun p => match p with (x, y) => @rstr C SM M SMon x y end) _).
+  intros [x1 x2] [y1 y2] [f g]; simpl.
+  exact (@rstr_natural C SM M SMon x1 y1 x2 y2 f g).
+Defined.
+
+(* The packaging that Monad/Strong.v deferred: rstr, with the ρ- and
+   α-coherences proved above, is a [RightStrongFunctor] structure on M. *)
+#[export] Instance rstr_RightStrongFunctor : @RightStrongFunctor C _ M :=
+  @Build_RightStrongFunctor C _ M
+    rstr_nat
+    (fun x => @rstr_id_right x)
+    (fun x y z => @rstr_assoc x y z).
+
+(* Sanity check: the packaged right strength is definitionally [rstr]. *)
+Corollary rstrength_is_rstr {x y} :
+  @rstrength C _ M rstr_RightStrongFunctor x y ≈ rstr.
+Proof. reflexivity. Qed.
+
+(* Together with the monad-compatibility laws [rstr_ret] and [rstr_join]
+   from Monad/Strong.v, every strong monad over a symmetric base is a right
+   strong monad. *)
+#[export] Instance rstr_RightStrongMonad : @RightStrongMonad C _ M :=
+  @Build_RightStrongMonad C _ M
+    strongmonad_is_monad
+    rstr_RightStrongFunctor
+    (fun x y => @rstr_ret C SM M SMon x y)
+    (fun x y => @rstr_join C SM M SMon x y).
+
+(* ------------------------------------------------------------------ *)
+(** ** The bridge to [CommutativeStrongMonad].                          *)
+(* ------------------------------------------------------------------ *)
+
+(* Forward direction: the concrete commutativity predicate over the derived
+   right strength yields the abstract class.  Both sides of the
+   [commutativity] field are definitionally [dstr] and [dstr'] once the
+   packaged rstrength unfolds to [rstr]. *)
+Definition commutative_CommutativeStrongMonad
+  (comm : @commutative_sm C SM M SMon) : @CommutativeStrongMonad C _ M :=
+  @Build_CommutativeStrongMonad C _ M
+    SMon
+    rstr_RightStrongFunctor
+    (fun x y => @rstr_ret C SM M SMon x y)
+    (fun x y => @rstr_join C SM M SMon x y)
+    (fun x y => comm x y).
+
+(* Converse direction.  An abstract [CommutativeStrongMonad] carries its own
+   bundled right strength, which need not be the braid-derived one, so the
+   honest converse takes the agreement E of the two right strengths — over
+   the strong monad bundled in H' itself — as an explicit hypothesis and
+   produces the concrete predicate for that strong monad. *)
+Definition CSM_commutative_sm
+  (H' : @CommutativeStrongMonad C _ M)
+  (E : ∀ x y, @rstrength C _ M (@comm_is_rstrong C _ M H') x y
+                ≈ @rstr C SM M (@comm_is_strong C _ M H') x y) :
+  @commutative_sm C SM M (@comm_is_strong C _ M H').
+Proof.
+  intros x y.
+  unfold dstr, dstr'.
+  rewrite <- !E.
+  exact (@commutativity C _ M H' x y).
+Qed.
+
+(* Round trip: at the instance produced by the forward direction, the
+   agreement hypothesis holds by reflexivity — the packaged right strength
+   IS rstr — and the underlying strong monad is definitionally the ambient
+   one, so the composite of the two bridges reproduces a commutativity
+   witness for the ambient strong monad. *)
+Corollary commutative_sm_round_trip
+  (comm : @commutative_sm C SM M SMon) : @commutative_sm C SM M SMon.
+Proof.
+  apply (CSM_commutative_sm (commutative_CommutativeStrongMonad comm)).
+  intros x y.
+  reflexivity.
+Qed.
+
+End StrongSymmetric.

--- a/Monad/Thunkable.v
+++ b/Monad/Thunkable.v
@@ -1,0 +1,531 @@
+Set Warnings "-notation-overridden".
+
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Theory.Monad.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Monoidal.Braided.
+Require Import Category.Structure.Monoidal.Symmetric.
+Require Import Category.Structure.Monoidal.CopyDiscard.
+Require Import Category.Structure.Monoidal.CopyDiscard.Deterministic.
+Require Import Category.Structure.Monoidal.Markov.
+Require Import Category.Theory.Algebra.Comonoid.
+Require Import Category.Theory.Algebra.CommutativeComonoid.
+Require Import Category.Theory.Algebra.Comonoid.Hom.
+Require Import Category.Structure.Binoidal.
+Require Import Category.Structure.Binoidal.Central.
+Require Import Category.Functor.Strong.
+Require Import Category.Monad.Strong.
+Require Import Category.Monad.Strong.Symmetric.
+Require Import Category.Monad.Kleisli.
+Require Import Category.Monad.Kleisli.Premonoidal.
+Require Import Category.Monad.Kleisli.Commutative.
+Require Import Category.Construction.Subcategory.
+
+Generalizable All Variables.
+Set Primitive Projections.
+Set Universe Polymorphism.
+Set Transparent Obligations.
+
+(** * Thunkable Kleisli morphisms: Führmann's hierarchy over a strong monad
+
+    nLab: https://ncatlab.org/nlab/show/premonoidal+category
+    nLab: https://ncatlab.org/nlab/show/strong+monad
+    Reference: Führmann, "Direct models of the computational
+               lambda-calculus", MFPS XV, ENTCS 20, 1999
+    Reference: Cho & Jacobs, "Disintegration and Bayesian inversion via
+               string diagrams", MSCS 29(7):938-971, 2019 (arXiv:1709.00322)
+
+    A Kleisli morphism f : x ~> M y of a strong monad M is THUNKABLE
+    (Führmann) when freezing its result into a returned computation is the
+    same as returning the frozen computation:
+
+        fmap[M] ret[M] ∘ f ≈ ret[M] ∘ f        (at x ~> M (M y))
+
+    Operationally: running f and then wrapping the value is the same as
+    wrapping the entire computation f unrun — f can be turned into a thunk
+    without changing its meaning, so f carries no observable effect
+    ordering of its own.  This file develops Führmann's hierarchy over the
+    library's actual Kleisli premonoidal structure
+    (Monad/Kleisli/Premonoidal.v), in three tiers:
+
+    1. Over a bare strong monad on a symmetric monoidal base, the
+       unconditional part of the hierarchy:
+
+           pure  ⇒  thunkable  ⇒  central
+
+       [pure_thunkable] is a two-line naturality computation, and
+       [thunkable_central] runs both centrality squares of
+       [kleisli_central_iff] through Führmann's reassociation lemmas
+       ([dstr_reassoc_left] / [dstr_reassoc_left'] and their mirrors,
+       Monad/Strong/Symmetric.v): rebracketing a double strength through
+       an extra M-layer computes [dstr] when the layer is fmap ret and
+       [dstr'] when it is a bare ret, and thunkability equates the two
+       layers.  Thunkable morphisms contain the identities
+       ([thunkable_id]) and are closed under Kleisli composition
+       ([thunkable_comp]) and under postcomposition with pure maps
+       ([thunkable_fmap_post]), so they form a wide subcategory [Thunk]
+       of Kl(M) through Construction/Subcategory.v — sitting inside the
+       centre Z(Kl(M)) (the [CentralSub] of Structure/Binoidal/Central.v
+       at [Kleisli_Binoidal]) by [thunkable_central].
+
+    2. Over a copy-discard base, the bridge into categorical probability:
+       a thunkable morphism is copyable and discardable — the two
+       Cho-Jacobs squares stated against the double strength — PROVIDED
+       the base copy and discard are natural ([copy_nat], [discard_nat]).
+       The engine is the slide lemma [thunkable_slide]: any G that is an
+       algebra-map-on-returns (G ∘ ret ≈ ret ∘ g) slides across a
+       thunkable f as the pure map g.  The two naturality hypotheses are
+       genuinely needed and genuinely available: they hold automatically
+       in cartesian bases ([CD_of_Cartesian] in
+       Structure/Monoidal/CopyDiscard/Proofs.v, where copy is the natural
+       diagonal), and the discard half holds in any Markov category
+       ([discard_natural] in Structure/Monoidal/Markov.v).  They are NOT
+       derivable in a bare [CopyDiscard] base: taking M := Id makes every
+       morphism thunkable, so an unconditional implication would force
+       every morphism of every copy-discard category to be a comonoid
+       homomorphism — exactly the naturality that [CopyDiscard]
+       deliberately never asks for (its negative space is what carves out
+       the deterministic morphisms in the first place).
+
+    3. Over a commutative strong monad on a copy-discard base, the honest
+       form of the master plan's thunkable-determinism statement:
+       [thunkable_deterministic] lands every thunkable Kleisli morphism in
+       the Cho-Jacobs deterministic class of the descended copy-discard
+       structure [Kleisli_CopyDiscard] (Monad/Kleisli/Commutative.v) —
+       i.e. inside the wide subcategory [Det] of Kl(M) — and
+       [pure_deterministic] transports base-deterministic morphisms along
+       the pure functor.  The bridging lemmas [kl_copyable_eq] and
+       [kl_discardable_eq] identify the two comonoid-homomorphism squares
+       of Kl(M) with [copyable] and [discardable] on the nose.
+
+    Strictness of the hierarchy (recorded as prose, not formalized):
+    both inclusions of the thunkable class — inside the centre (tier 1)
+    and inside the deterministic class (tier 3) — are strict in general.
+    Central but not thunkable: for the writer monad M x = x × W over a
+    nontrivial commutative monoid W (in Sets), M is commutative, so
+    EVERY Kleisli morphism is central ([kleisli_all_central],
+    Monad/Kleisli/Commutative.v), yet the map x ↦ (x, w) with w ≠ e is
+    not thunkable, because thunkability forces the written w to equal e;
+    Führmann (1999) draws the same separation for continuation monads.
+    Deterministic but not thunkable: for the read-only state monad
+    M x = x × x (reader along a two-element environment, in Sets), every
+    Kleisli morphism is copyable and discardable, but only the morphisms
+    that ignore the read value are thunkable (Moss & Perrone,
+    "Probability monads with submonads of deterministic states",
+    LICS 2022, Theorem 3.14).  The converse of
+    [thunkable_deterministic] is therefore not provable, and the
+    deterministic class is in general strictly larger than the thunkable
+    one. *)
+
+Section Thunkable.
+
+Context {C : Category}.
+Context `{SM : @SymmetricMonoidal C}.
+Context {M : C ⟶ C}.
+Context `{SMon : @StrongMonad C _ M}.
+
+(* ------------------------------------------------------------------ *)
+(** ** Tier 1: thunkability over a bare strong monad.                  *)
+(* ------------------------------------------------------------------ *)
+
+(* Führmann's definition: f can be frozen into a thunk.  The equation
+   lives at x ~> M (M y): on the left the computation runs and its value
+   is returned; on the right the whole computation is returned unrun. *)
+Definition thunkable {x y : C} (f : x ~> M y) : Type :=
+  fmap[M] ret[M] ∘ f ≈ ret[M] ∘ f.
+
+(* Thunkability is a property of the ≈-class of a morphism. *)
+Lemma thunkable_respects {x y : C} {f g : x ~> M y} :
+  f ≈ g → thunkable f → thunkable g.
+Proof.
+  unfold thunkable.
+  intros E tf.
+  now rewrite <- E.
+Qed.
+
+(* The Kleisli identity is thunkable: both sides are the unit naturality
+   square [fmap_ret] instantiated at the unit itself. *)
+Lemma thunkable_id {x : C} : thunkable (ret[M] : x ~{C}~> M x).
+Proof.
+  unfold thunkable.
+  symmetry.
+  apply fmap_ret.
+Qed.
+
+(* Every pure morphism is thunkable: push the outer unit across f with
+   [fmap_ret]. *)
+Lemma pure_thunkable {x y : C} (f : x ~{C}~> y) : thunkable (kpure f).
+Proof.
+  unfold thunkable, kpure.
+  rewrite comp_assoc.
+  rewrite <- fmap_ret.
+  now rewrite comp_assoc.
+Qed.
+
+(* Thunkable morphisms are closed under Kleisli composition
+   join ∘ fmap f ∘ g.  Both sides normalize to fmap f ∘ g: the left via
+   naturality of join and [tf] under the doubled functor, collapsing with
+   [join_fmap_ret]; the right by walking the unit leftwards across join
+   and fmap f with [fmap_ret], meeting [tg], and cancelling with
+   [join_ret] inside the fused fmap argument. *)
+Lemma thunkable_comp {x y z : C} {f : y ~> M z} {g : x ~> M y} :
+  thunkable f → thunkable g → thunkable (join[M] ∘ fmap[M] f ∘ g).
+Proof.
+  intros tf tg.
+  unfold thunkable in *.
+  transitivity (fmap[M] f ∘ g).
+  - (* fmap ret ∘ (join ∘ fmap f ∘ g) ≈ fmap f ∘ g *)
+    rewrite !comp_assoc.
+    rewrite <- join_fmap_fmap.
+    rewrite <- (comp_assoc join[M]).
+    rewrite <- fmap_comp.
+    rewrite tf.
+    rewrite fmap_comp.
+    rewrite comp_assoc.
+    rewrite join_fmap_ret.
+    now rewrite id_left.
+  - (* fmap f ∘ g ≈ ret ∘ (join ∘ fmap f ∘ g) *)
+    symmetry.
+    rewrite !comp_assoc.
+    rewrite fmap_ret.
+    rewrite <- (comp_assoc (fmap[M] join[M])).
+    rewrite fmap_ret.
+    rewrite <- !comp_assoc.
+    rewrite <- tg.
+    rewrite (comp_assoc (fmap[M] (fmap[M] f))).
+    rewrite <- fmap_comp.
+    rewrite comp_assoc.
+    rewrite <- fmap_comp.
+    rewrite <- fmap_ret.
+    rewrite comp_assoc.
+    rewrite join_ret.
+    now rewrite id_left.
+Qed.
+
+(* Thunkable morphisms absorb pure postcomposition: fmap u ∘ f is again
+   thunkable.  The unit walks across u by [fmap_ret], meets [tf], and
+   walks back out across fmap u. *)
+Lemma thunkable_fmap_post {x y z : C} (u : y ~{C}~> z) {f : x ~> M y} :
+  thunkable f → thunkable (fmap[M] u ∘ f).
+Proof.
+  intro tf.
+  unfold thunkable in *.
+  rewrite comp_assoc.
+  rewrite <- fmap_comp.
+  rewrite fmap_ret.
+  rewrite fmap_comp.
+  rewrite <- comp_assoc.
+  rewrite tf.
+  rewrite comp_assoc.
+  rewrite <- fmap_ret.
+  now rewrite <- comp_assoc.
+Qed.
+
+(* Führmann's theorem: every thunkable morphism is central in Kl(M).
+   Through [kleisli_central_iff] each centrality square asks that [dstr]
+   and [dstr'] agree on a tensor with f in one factor; the reassociation
+   lemmas of Monad/Strong/Symmetric.v rewrite [dstr ∘ (f ⨂ g)] as the
+   rebracketed word at (fmap ret ∘ f) ⨂ g and [dstr' ∘ (f ⨂ g)] as the
+   same word at (ret ∘ f) ⨂ g, and thunkability of f equates the two
+   insertions.  No commutativity of M enters. *)
+Theorem thunkable_central {x y : C} (f : x ~> M y) :
+  thunkable f → @central Kleisli Kleisli_Binoidal x y f.
+Proof.
+  intros tf.
+  apply kleisli_central_iff; intros c d g.
+  split.
+  - rewrite <- (dstr_reassoc_left f g).
+    rewrite <- (dstr_reassoc_left' f g).
+    now rewrite tf.
+  - rewrite <- (dstr'_reassoc_right g f).
+    rewrite <- (dstr'_reassoc_right' g f).
+    now rewrite tf.
+Qed.
+
+(* Feeding returned values into BOTH factors of the double strength
+   leaves a single unit: split ret ⨂ ret at the middle, collapse the
+   left insertion with [dstr_ret_left] and the remaining strength with
+   [strength_ret].  This is the unit law of the lax monoidal structure
+   that [dstr] puts on M, needed below for the copyability of thunkable
+   morphisms. *)
+Lemma dstr_ret_ret {b d : C} :
+  dstr ∘ (ret[M] ⨂ ret[M]) ≈ (ret[M] : b ⨂ d ~{C}~> M (b ⨂ d)).
+Proof.
+  transitivity (dstr ∘ ((ret[M] ⨂ id[M d]) ∘ (id[b] ⨂ ret[M]))).
+  - apply compose_respects; [reflexivity|].
+    rewrite <- bimap_comp.
+    now rewrite id_left, id_right.
+  - rewrite comp_assoc.
+    rewrite dstr_ret_left.
+    apply strength_ret.
+Qed.
+
+(* ------------------------------------------------------------------ *)
+(** ** The wide subcategory Thunk of thunkable morphisms.              *)
+(* ------------------------------------------------------------------ *)
+
+(* [thunkable_id] and [thunkable_comp] are exactly the closure conditions
+   of Construction/Subcategory.v, read at the definitional Kleisli
+   composite (@compose Kleisli is join ∘ fmap f ∘ g on the nose), so the
+   thunkable morphisms over ALL objects form a wide subcategory of Kl(M),
+   Führmann's category of thunkable maps.  The packaging mirrors
+   [DeterministicSub]/[Det] of CopyDiscard/Deterministic.v and
+   [CentralSub]/[Centre] of Structure/Binoidal/Central.v.
+
+   Hierarchy note: the shom-collection of [ThunkableSub] includes into
+   that of [CentralSub] at [Kleisli_Binoidal] — that inclusion IS
+   [thunkable_central] — so Thunk sits inside the centre Z(Kl(M)) as wide
+   subcategories of Kl(M); and every pure morphism [kpure f] lands in
+   Thunk by [pure_thunkable]. *)
+
+Program Definition ThunkableSub : Subcategory Kleisli := {|
+  sobj  := fun _ => poly_unit;
+  shom  := fun x y _ _ f => thunkable f;
+  scomp := fun _ _ _ _ _ _ _ _ tf tg => thunkable_comp tf tg;
+  sid   := fun _ _ => thunkable_id
+|}.
+
+Definition Thunk : Category := Sub Kleisli ThunkableSub.
+
+Lemma Thunk_wide : Wide Kleisli ThunkableSub.
+Proof. intro x; exact ttt. Qed.
+
+(* The inclusion Thunk ⟶ Kl(M) is the generic faithful
+   [Incl Kleisli ThunkableSub] from Construction/Subcategory.v. *)
+
+(* ------------------------------------------------------------------ *)
+(** ** Tier 2: copyability and discardability over a CD base.          *)
+(* ------------------------------------------------------------------ *)
+
+Section ThunkableCD.
+
+Context `{CD : @CopyDiscard C _}.
+
+(* The two naturality hypotheses.  [CopyDiscard] itself deliberately
+   never demands them — their absence for general morphisms is what
+   makes the deterministic subclass meaningful — but tier 2 genuinely
+   needs them: with M := Id every morphism is thunkable, so deriving
+   copyable/discardable from thunkable over a bare CD base would force
+   every morphism of every copy-discard category into a comonoid
+   homomorphism, which bare CD does not grant.  Both hypotheses hold in
+   cartesian bases ([CD_of_Cartesian] in CopyDiscard/Proofs.v: copy is
+   the natural diagonal, discard the eliminate of the terminal unit),
+   and [discard_nat] alone holds in every Markov category
+   ([discard_natural], Structure/Monoidal/Markov.v). *)
+
+Hypothesis copy_nat : ∀ (x y : C) (u : x ~{C}~> y),
+  copy[y] ∘ u ≈ (u ⨂ u) ∘ copy[x].
+
+Hypothesis discard_nat : ∀ (x y : C) (u : x ~{C}~> y),
+  discard[y] ∘ u ≈ discard[x].
+
+(* The slide lemma, the engine of tier 2: if G agrees with the pure map
+   g on returned values (G ∘ ret ≈ ret ∘ g), then G slides across any
+   thunkable f as fmap g.  Proof: conjugate [tf] with fmap G, exchange
+   G against g inside the fused functor argument with [algG], convert
+   the surviving head fmap ret into a bare ret with
+   [thunkable_fmap_post], and cancel the resulting unit under join with
+   [join_ret]. *)
+Lemma thunkable_slide {a b c : C} (f : a ~> M b) (tf : thunkable f)
+      (G : M b ~{C}~> M c) (g : b ~{C}~> c)
+      (algG : G ∘ ret[M] ≈ ret[M] ∘ g) :
+  G ∘ f ≈ fmap[M] g ∘ f.
+Proof.
+  assert (E : ret[M] ∘ (fmap[M] g ∘ f) ≈ ret[M] ∘ (G ∘ f)).
+  { transitivity (fmap[M] G ∘ (fmap[M] ret[M] ∘ f)).
+    - rewrite <- (thunkable_fmap_post g tf).
+      rewrite !comp_assoc.
+      rewrite <- !fmap_comp.
+      rewrite algG.
+      reflexivity.
+    - rewrite tf.
+      rewrite comp_assoc.
+      rewrite <- fmap_ret.
+      now rewrite <- comp_assoc. }
+  rewrite <- (id_left (G ∘ f)).
+  rewrite <- (@join_ret C M _ c).
+  rewrite <- comp_assoc.
+  rewrite <- E.
+  rewrite comp_assoc.
+  rewrite join_ret.
+  now rewrite id_left.
+Qed.
+
+(* The Cho-Jacobs squares for a Kleisli morphism, stated at the double
+   strength: copying the output of f agrees with running f twice on a
+   copied input (combined by [dstr]), and discarding the output of f
+   agrees with discarding its input outright. *)
+Definition copyable {x y : C} (f : x ~> M y) : Type :=
+  dstr ∘ (f ⨂ f) ∘ copy[x] ≈ fmap[M] copy[y] ∘ f.
+
+Definition discardable {x y : C} (f : x ~> M y) : Type :=
+  fmap[M] discard[y] ∘ f ≈ ret[M] ∘ discard[x].
+
+(* Thunkable morphisms are copyable: naturality of copy at f turns the
+   copied-input side into (dstr ∘ copy[M y]) ∘ f, and that G slides
+   across f as fmap copy[y] — its algebra-map equation is naturality of
+   copy at ret followed by the double-strength unit law
+   [dstr_ret_ret]. *)
+Theorem thunkable_copyable {x y : C} (f : x ~> M y) :
+  thunkable f → copyable f.
+Proof using C CD M SM SMon copy_nat.
+  intro tf.
+  unfold copyable.
+  rewrite <- comp_assoc.
+  rewrite <- (copy_nat x (M y) f).
+  rewrite comp_assoc.
+  apply (thunkable_slide f tf (dstr ∘ copy[M y]) copy[y]).
+  rewrite <- comp_assoc.
+  rewrite (copy_nat y (M y) ret[M]).
+  rewrite comp_assoc.
+  rewrite dstr_ret_ret.
+  reflexivity.
+Qed.
+
+(* Thunkable morphisms are discardable: the mirror argument, sliding
+   G := ret ∘ discard[M y] across f as fmap discard[y]; both the
+   algebra-map equation and the final collapse are [discard_nat]. *)
+Theorem thunkable_discardable {x y : C} (f : x ~> M y) :
+  thunkable f → discardable f.
+Proof using C CD M SM SMon discard_nat.
+  intro tf.
+  unfold discardable.
+  assert (algG : (ret[M] ∘ discard[M y]) ∘ ret[M] ≈ ret[M] ∘ discard[y]).
+  { rewrite <- comp_assoc.
+    now rewrite (discard_nat y (M y) ret[M]). }
+  rewrite <- (thunkable_slide f tf (ret[M] ∘ discard[M y]) discard[y] algG).
+  rewrite <- comp_assoc.
+  now rewrite (discard_nat x (M y) f).
+Qed.
+
+(* Pure morphisms are copyable and discardable, through
+   [pure_thunkable]. *)
+Corollary pure_copyable {x y : C} (f : x ~{C}~> y) : copyable (kpure f).
+Proof using C CD M SM SMon copy_nat.
+  apply thunkable_copyable, pure_thunkable.
+Qed.
+
+Corollary pure_discardable {x y : C} (f : x ~{C}~> y) :
+  discardable (kpure f).
+Proof using C CD M SM SMon discard_nat.
+  apply thunkable_discardable, pure_thunkable.
+Qed.
+
+(* ------------------------------------------------------------------ *)
+(** ** Tier 3: the bridge to the deterministic class of Kl(M).         *)
+(* ------------------------------------------------------------------ *)
+
+Section ThunkableDeterministic.
+
+(* When M is commutative, Kl(M) is itself a copy-discard category
+   ([Kleisli_CopyDiscard], Monad/Kleisli/Commutative.v: copy and discard
+   are the pure images of the base generators), and the Cho-Jacobs
+   deterministic predicate of CopyDiscard/Deterministic.v applies to
+   Kleisli morphisms.  This section identifies its two comonoid-
+   homomorphism squares with [copyable] and [discardable], lands every
+   thunkable morphism in the deterministic class — the honest form of
+   the thunkable-determinism bridge; see the header for why the M := Id
+   reading rules out an unconditional converse-free statement over bare
+   CD — and transports base-deterministic morphisms along the pure
+   functor. *)
+
+Hypothesis comm : commutative_sm (M:=M).
+
+(* The δ-square of the descended comonoid at f is exactly [copyable] f:
+   the pure exchange laws strip the units, and the induced tensor
+   computes the double strength ([kleisli_bimap_dstr]). *)
+Lemma kl_copyable_eq {x y : C} (f : x ~{Kleisli}~> y) :
+  (@compose Kleisli _ _ _ (kpure copy[y]) f
+     ≈ @compose Kleisli _ _ _
+         (f ⨂[Kleisli_Monoidal comm] f) (kpure copy[x]))
+  ↔ copyable f.
+Proof.
+  split; intro E.
+  - unfold copyable.
+    rewrite kl_pure_post in E.
+    rewrite kl_pure_pre in E.
+    rewrite (kleisli_bimap_dstr comm f f) in E.
+    symmetry; exact E.
+  - rewrite kl_pure_post.
+    rewrite kl_pure_pre.
+    rewrite (kleisli_bimap_dstr comm f f).
+    symmetry; exact E.
+Qed.
+
+(* The ε-square of the descended comonoid at f is exactly
+   [discardable] f. *)
+Lemma kl_discardable_eq {x y : C} (f : x ~{Kleisli}~> y) :
+  (@compose Kleisli _ _ _ (kpure discard[y]) f ≈ kpure discard[x])
+  ↔ discardable f.
+Proof.
+  split; intro E.
+  - unfold discardable.
+    rewrite kl_pure_post in E.
+    exact E.
+  - rewrite kl_pure_post.
+    exact E.
+Qed.
+
+(* The bridge: every thunkable Kleisli morphism is deterministic in the
+   Cho-Jacobs sense for the descended copy-discard structure on Kl(M) —
+   i.e. it lies in the wide subcategory [Det] of Kl(M) built by
+   CopyDiscard/Deterministic.v at [Kleisli_CopyDiscard].  Both comonoid-
+   homomorphism squares are tier 2 through the [kl_*_eq]
+   identifications. *)
+Theorem thunkable_deterministic {x y : C} (f : x ~{Kleisli}~> y) :
+  thunkable f →
+  @deterministic Kleisli (Kleisli_Symmetric comm)
+    (Kleisli_CopyDiscard comm (CD:=CD)) x y f.
+Proof using C CD M SM SMon comm copy_nat discard_nat.
+  intro tf.
+  split.
+  - exact (snd (kl_copyable_eq f) (thunkable_copyable f tf)).
+  - exact (snd (kl_discardable_eq f) (thunkable_discardable f tf)).
+Qed.
+
+(* The two squares of a pure image, as standalone transfers: the pure
+   functor carries the base squares to Kl(M) through [kl_pure_comp] and
+   [kl_pure_tensor]. *)
+Lemma pure_hom_delta {x y : C} (f : x ~{C}~> y)
+      (Fd : copy[y] ∘ f ≈ (f ⨂ f) ∘ copy[x]) :
+  @compose Kleisli _ _ _ (kpure copy[y]) (kpure f)
+    ≈ @compose Kleisli _ _ _
+        ((kpure f) ⨂[Kleisli_Monoidal comm] (kpure f)) (kpure copy[x]).
+Proof.
+  rewrite (kl_pure_tensor comm f f).
+  rewrite !kl_pure_comp.
+  apply kl_pure_eqv.
+  exact Fd.
+Qed.
+
+Lemma pure_hom_epsilon {x y : C} (f : x ~{C}~> y)
+      (Fe : discard[y] ∘ f ≈ discard[x]) :
+  @compose Kleisli _ _ _ (kpure discard[y]) (kpure f) ≈ kpure discard[x].
+Proof.
+  rewrite kl_pure_comp.
+  apply kl_pure_eqv.
+  exact Fe.
+Qed.
+
+(* Determinism transports along the pure functor: a base-deterministic
+   morphism has a deterministic pure image in Kl(M). *)
+Theorem pure_deterministic {x y : C} (f : x ~{C}~> y) :
+  @deterministic C SM CD x y f →
+  @deterministic Kleisli (Kleisli_Symmetric comm)
+    (Kleisli_CopyDiscard comm (CD:=CD)) x y (kpure f).
+Proof.
+  intros [Fd Fe].
+  split.
+  - exact (pure_hom_delta f Fd).
+  - exact (pure_hom_epsilon f Fe).
+Qed.
+
+End ThunkableDeterministic.
+
+End ThunkableCD.
+
+End Thunkable.

--- a/Monad/Thunkable.v
+++ b/Monad/Thunkable.v
@@ -2,22 +2,15 @@ Set Warnings "-notation-overridden".
 
 Require Import Category.Lib.
 Require Import Category.Theory.Category.
-Require Import Category.Theory.Isomorphism.
 Require Import Category.Theory.Functor.
 Require Import Category.Theory.Monad.
 Require Import Category.Functor.Bifunctor.
 Require Import Category.Structure.Monoidal.
-Require Import Category.Structure.Monoidal.Braided.
 Require Import Category.Structure.Monoidal.Symmetric.
 Require Import Category.Structure.Monoidal.CopyDiscard.
 Require Import Category.Structure.Monoidal.CopyDiscard.Deterministic.
-Require Import Category.Structure.Monoidal.Markov.
 Require Import Category.Theory.Algebra.Comonoid.
-Require Import Category.Theory.Algebra.CommutativeComonoid.
-Require Import Category.Theory.Algebra.Comonoid.Hom.
 Require Import Category.Structure.Binoidal.
-Require Import Category.Structure.Binoidal.Central.
-Require Import Category.Functor.Strong.
 Require Import Category.Monad.Strong.
 Require Import Category.Monad.Strong.Symmetric.
 Require Import Category.Monad.Kleisli.
@@ -92,7 +85,7 @@ Set Transparent Obligations.
        the deterministic morphisms in the first place).
 
     3. Over a commutative strong monad on a copy-discard base, the honest
-       form of the master plan's thunkable-determinism statement:
+       form of the thunkable-determinism statement:
        [thunkable_deterministic] lands every thunkable Kleisli morphism in
        the Cho-Jacobs deterministic class of the descended copy-discard
        structure [Kleisli_CopyDiscard] (Monad/Kleisli/Commutative.v) —
@@ -116,7 +109,7 @@ Set Transparent Obligations.
     Kleisli morphism is copyable and discardable, but only the morphisms
     that ignore the read value are thunkable (Moss & Perrone,
     "Probability monads with submonads of deterministic states",
-    LICS 2022, Theorem 3.14).  The converse of
+    LICS 2022, Theorem 3.14 and Example 3.16).  The converse of
     [thunkable_deterministic] is therefore not provable, and the
     deterministic class is in general strictly larger than the thunkable
     one. *)
@@ -247,22 +240,9 @@ Proof.
 Qed.
 
 (* Feeding returned values into BOTH factors of the double strength
-   leaves a single unit: split ret ⨂ ret at the middle, collapse the
-   left insertion with [dstr_ret_left] and the remaining strength with
-   [strength_ret].  This is the unit law of the lax monoidal structure
-   that [dstr] puts on M, needed below for the copyability of thunkable
-   morphisms. *)
-Lemma dstr_ret_ret {b d : C} :
-  dstr ∘ (ret[M] ⨂ ret[M]) ≈ (ret[M] : b ⨂ d ~{C}~> M (b ⨂ d)).
-Proof.
-  transitivity (dstr ∘ ((ret[M] ⨂ id[M d]) ∘ (id[b] ⨂ ret[M]))).
-  - apply compose_respects; [reflexivity|].
-    rewrite <- bimap_comp.
-    now rewrite id_left, id_right.
-  - rewrite comp_assoc.
-    rewrite dstr_ret_left.
-    apply strength_ret.
-Qed.
+   leaves a single unit — [dstr_ret_ret] (Monad/Strong/Symmetric.v), the
+   unit law of the lax monoidal structure that [dstr] puts on M, needed
+   below for the copyability of thunkable morphisms. *)
 
 (* ------------------------------------------------------------------ *)
 (** ** The wide subcategory Thunk of thunkable morphisms.              *)

--- a/Structure/Binoidal.v
+++ b/Structure/Binoidal.v
@@ -34,9 +34,11 @@ Reserved Infix "⊗" (at level 30, right associativity).
    and f' : a' ~> b' on the right may be applied in two orders, giving in
    general distinct composites a ⊗ a' ~> b ⊗ b'. This is the "premagmoidal"
    precursor to a premonoidal category, which adds a unit and central
-   coherence isomorphisms. The naming here follows the rest of the library;
-   the symbols ⋉ / ⋊ match the nLab convention for the right/left tensoring
-   functors. *)
+   coherence isomorphisms. The premonoidal successor is
+   Structure/Premonoidal.v; the funny-tensor characterization of
+   separately-functorial tensors is Instance/StrictCat/Premonoid.v. The
+   naming here follows the rest of the library; the symbols ⋉ / ⋊ match the
+   nLab convention for the right/left tensoring functors. *)
 Class Binoidal := {
   tensor (x y : C) : C where "x ⊗ y" := (tensor x y);
 
@@ -66,7 +68,10 @@ Proof. reflexivity. Qed.
    first conjunct is the square on x ⊗ x' ~~> y ⊗ y' (f on the left, f' on the
    right); the second is the mirror square on x' ⊗ x ~~> y' ⊗ y. When f is
    central these common composites are the f ⊗ f' and f' ⊗ f below. The
-   central morphisms form the centre, a monoidal subcategory of C. *)
+   central morphisms form the centre, a monoidal subcategory of C: it is
+   constructed as a wide subcategory in Structure/Binoidal/Central.v
+   ([Centre]), and shown monoidal for premonoidal C in
+   Structure/Premonoidal/Centre.v ([Centre_Monoidal]). *)
 
 Definition central `(f : x ~> y) : Type :=
   ∀ x' y' (f' : x' ~> y'),

--- a/Structure/Binoidal/Central.v
+++ b/Structure/Binoidal/Central.v
@@ -1,0 +1,259 @@
+Set Warnings "-notation-overridden".
+
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Structure.Binoidal.
+Require Import Category.Construction.Subcategory.
+
+Generalizable All Variables.
+Set Primitive Projections.
+Set Universe Polymorphism.
+Set Transparent Obligations.
+
+(** * The centrality closure kit for binoidal categories
+
+    nLab: https://ncatlab.org/nlab/show/premonoidal+category
+    (centrality and the centre are discussed there; bare binoidal
+    categories have no dedicated nLab page and are covered under
+    premonoidal categories)
+
+    Structure/Binoidal.v defines when a morphism [f : x ~> y] of a
+    binoidal category is [central]: tensoring [f] with any morphism [f']
+    in either order gives the same composite, on both the [x ⊗ x'] and
+    the [x' ⊗ x] side.  This file develops the closure properties of that
+    predicate that are available in a BARE binoidal category — no unit,
+    no associator:
+
+      - [central_id]        : identities are central;
+      - [central_respects]  : centrality respects ≈;
+      - [central_comp]      : central morphisms compose;
+      - [central_iso_from]  : the inverse of a central isomorphism is
+                              central;
+
+    together with the interaction of [composite_ff'] with identities
+    ([composite_id_left] / [composite_id_right]) and with composition
+    under a single centrality hypothesis ([composite_ff'_comp_l] /
+    [composite_ff'_comp_r]).  The last two isolate the exact "middle
+    interchange" that one-sided functoriality of the tensor needs; both
+    reduce to the same square, read off one conjunct of the centrality of
+    [f] or of [g'].
+
+    The closure properties package the central morphisms as the centre
+    Z(C) — here [Centre] — a wide subcategory of [C] built through
+    Construction/Subcategory.v, mirroring the deterministic subcategory
+    [Det] of Structure/Monoidal/CopyDiscard/Deterministic.v.
+
+    What is deliberately NOT here: closure of centrality under the tensor
+    [composite_ff'] itself.  For central [f] and [f'], commuting
+    [composite_ff' f f'] past a right-tensored morphism is a square at
+    the nested tensor [(x ⊗ x') ⊗ a], and a bare binoidal category
+    carries no morphism relating the two nesting levels, so that square
+    is unreachable from the single-level centrality data.  Once an
+    associator is present the chase goes through; the closure lemma
+    [composite_ff'_central] therefore lives in
+    Structure/Premonoidal/Centre.v, where Z(C) is also shown to be
+    monoidal ([Centre_Monoidal]), discharging the promise recorded in the
+    comment above [central] in Structure/Binoidal.v. *)
+
+Section CentralKit.
+
+Context {C : Category}.
+Context `{@Binoidal C}.
+
+(** ** Closure properties of centrality *)
+
+(* Identities are central: both defining squares reduce by [fmap_id] and
+   the unit laws to a triviality. *)
+Lemma central_id {x : C} : central (@id C x).
+Proof.
+  intros x' y' f'; split.
+  - rewrite !fmap_id; cat.
+  - rewrite !fmap_id; cat.
+Qed.
+
+(* Centrality is a property of the ≈-class of a morphism: both defining
+   squares mention [f] only through [fmap], which respects ≈. *)
+Lemma central_respects {x y : C} {f g : x ~> y} :
+  f ≈ g → central f → central g.
+Proof.
+  intros E cf x' y' f'.
+  destruct (cf x' y' f') as [sq1 sq2].
+  split.
+  - rewrite <- E; exact sq1.
+  - rewrite <- E; exact sq2.
+Qed.
+
+(* Central morphisms compose: expand [fmap] over the composite with
+   [fmap_comp], then paste [g]'s square followed by [f]'s square.  Each
+   conjunct is a single-level pasting of two commuting squares. *)
+Lemma central_comp {x y z : C} {f : y ~> z} {g : x ~> y} :
+  central f → central g → central (f ∘ g).
+Proof.
+  intros cf cg x' y' f'.
+  destruct (cf x' y' f') as [f1 f2].
+  destruct (cg x' y' f') as [g1 g2].
+  split.
+  - rewrite !fmap_comp.
+    rewrite !comp_assoc_sym.
+    rewrite g1.
+    rewrite !comp_assoc.
+    now rewrite f1.
+  - rewrite !fmap_comp.
+    rewrite !comp_assoc.
+    rewrite f2.
+    rewrite !comp_assoc_sym.
+    now rewrite g2.
+Qed.
+
+(* The inverse of a central isomorphism is central: conjugate each
+   to-square by the tensored inverse on both sides and cancel via
+   [fmap_comp], the isomorphism laws, and [fmap_id].  The auxiliary
+   equation [E] expresses the tensored [f'] as the to-square composite
+   flanked by one inverse; substituting it into the goal leaves only the
+   other cancellation. *)
+Lemma central_iso_from {x y : C} (i : x ≅ y) :
+  central (to i) → central (from i).
+Proof.
+  intros ci x' y' f'.
+  destruct (ci x' y' f') as [sq1 sq2].
+  split.
+  - assert (E : fmap[inj_right y] f'
+                  ≈ fmap[inj_left y'] (to i)
+                      ∘ (fmap[inj_right x] f' ∘ fmap[inj_left x'] (from i))).
+    { rewrite !comp_assoc.
+      rewrite sq1.
+      rewrite !comp_assoc_sym.
+      rewrite <- (fmap_comp (to i) (from i)).
+      rewrite iso_to_from.
+      rewrite fmap_id.
+      now rewrite id_right. }
+    rewrite E.
+    rewrite !comp_assoc.
+    rewrite <- (fmap_comp (from i) (to i)).
+    rewrite iso_from_to.
+    rewrite fmap_id.
+    now rewrite id_left.
+  - assert (E : fmap[inj_left y] f'
+                  ≈ fmap[inj_right y'] (to i)
+                      ∘ (fmap[inj_left x] f' ∘ fmap[inj_right x'] (from i))).
+    { rewrite !comp_assoc.
+      rewrite <- sq2.
+      rewrite !comp_assoc_sym.
+      rewrite <- (fmap_comp (to i) (from i)).
+      rewrite iso_to_from.
+      rewrite fmap_id.
+      now rewrite id_right. }
+    rewrite E.
+    rewrite !comp_assoc.
+    rewrite <- (fmap_comp (from i) (to i)).
+    rewrite iso_from_to.
+    rewrite fmap_id.
+    now rewrite id_left.
+Qed.
+
+(** ** [composite_ff'] against identities *)
+
+(* Tensoring the identity on the left leaves the right tensoring of [g]. *)
+Lemma composite_id_left {x y : C} (w : C) (g : x ~> y) :
+  composite_ff' (id[w]) g ≈ fmap[inj_right w] g.
+Proof.
+  unfold composite_ff'.
+  rewrite fmap_id.
+  now rewrite id_right.
+Qed.
+
+(* Tensoring the identity on the right leaves the left tensoring of [f]. *)
+Lemma composite_id_right {x y : C} (w : C) (f : x ~> y) :
+  composite_ff' f (id[w]) ≈ fmap[inj_left w] f.
+Proof.
+  unfold composite_ff'.
+  rewrite fmap_id.
+  now rewrite id_left.
+Qed.
+
+(** ** One-sided bifunctoriality
+
+    In a monoidal category [bimap] is functorial in both variables
+    jointly.  For the binoidal [composite_ff'] the analogous interchange
+
+      composite_ff' (f ∘ g) (f' ∘ g') ≈ composite_ff' f f' ∘ composite_ff' g g'
+
+    needs exactly one middle swap,
+
+      fmap[inj_right z] g' ∘ fmap[inj_left x'] f
+        ≈ fmap[inj_left y'] f ∘ fmap[inj_right y] g',
+
+    and a SINGLE centrality hypothesis supplies it: this square is
+    conjunct 1 of [central f] instantiated at [g'], and equally conjunct 2
+    of [central g'] instantiated at [f].  Hence the two variants below,
+    one keyed on each hypothesis; the shared proof pastes the swap between
+    the [fmap_comp] expansions. *)
+
+Lemma composite_ff'_comp_l {x y z x' y' z' : C} {f : y ~> z} {g : x ~> y}
+      {f' : y' ~> z'} {g' : x' ~> y'} :
+  central f →
+  composite_ff' (f ∘ g) (f' ∘ g') ≈ composite_ff' f f' ∘ composite_ff' g g'.
+Proof.
+  intros cf.
+  destruct (cf x' y' g') as [sq _].
+  unfold composite_ff'.
+  rewrite !fmap_comp.
+  rewrite !comp_assoc_sym.
+  rewrite (comp_assoc (fmap[inj_right z] g')).
+  rewrite <- sq.
+  now rewrite !comp_assoc_sym.
+Qed.
+
+Lemma composite_ff'_comp_r {x y z x' y' z' : C} {f : y ~> z} {g : x ~> y}
+      {f' : y' ~> z'} {g' : x' ~> y'} :
+  central g' →
+  composite_ff' (f ∘ g) (f' ∘ g') ≈ composite_ff' f f' ∘ composite_ff' g g'.
+Proof.
+  intros cg'.
+  destruct (cg' y z f) as [_ sq].
+  unfold composite_ff'.
+  rewrite !fmap_comp.
+  rewrite !comp_assoc_sym.
+  rewrite (comp_assoc (fmap[inj_right z] g')).
+  rewrite <- sq.
+  now rewrite !comp_assoc_sym.
+Qed.
+
+(** ** The centre Z(C) as a wide subcategory
+
+    [central_id] and [central_comp] are exactly the closure conditions
+    Construction/Subcategory.v asks of a subcollection of morphisms, so
+    the central morphisms over ALL objects form a wide subcategory, the
+    centre of the binoidal category (Power–Robinson, "Premonoidal
+    categories and notions of computation", 1997).  The packaging
+    mirrors [DeterministicSub]/[Det] of
+    Structure/Monoidal/CopyDiscard/Deterministic.v. *)
+
+Program Definition CentralSub : Subcategory C := {|
+  sobj  := fun _ => poly_unit;
+  shom  := fun x y _ _ f => central f;
+  scomp := fun _ _ _ _ _ _ _ _ cf cg => central_comp cf cg;
+  sid   := fun _ _ => central_id
+|}.
+
+Lemma Centre_wide : Wide C CentralSub.
+Proof. intro x; exact ttt. Qed.
+
+(* The inclusion Z(C) ⟶ C is the generic faithful [Incl C CentralSub]
+   from Construction/Subcategory.v.  Note that [Sub]'s homset compares
+   first projections — [fun f g => `1 f ≈ `1 g] — so every equation
+   between morphisms of the centre is literally an equation between the
+   underlying morphisms of [C]; Structure/Premonoidal/Centre.v relies on
+   this when it transports the coherence laws of a premonoidal [C] to
+   its (monoidal) centre. *)
+
+End CentralKit.
+
+(* The centre as a category, with the base category explicit so that
+   downstream files can write [Centre C] for the centre of [C].  Its
+   objects are those of [C] tagged with the trivial [poly_unit] witness,
+   and its morphisms are the central morphisms. *)
+Definition Centre (C : Category) `{H : @Binoidal C} : Category :=
+  Sub C (@CentralSub C H).

--- a/Structure/Premonoidal.v
+++ b/Structure/Premonoidal.v
@@ -1,0 +1,355 @@
+Set Warnings "-notation-overridden".
+
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Structure.Binoidal.
+Require Import Category.Structure.Binoidal.Central.
+
+Generalizable All Variables.
+Set Primitive Projections.
+Set Universe Polymorphism.
+Set Transparent Obligations.
+
+(** * Premonoidal categories
+
+    nLab: https://ncatlab.org/nlab/show/premonoidal+category
+    Wikipedia: https://en.wikipedia.org/wiki/Premonoidal_category
+
+    A premonoidal category (Power–Robinson, "Premonoidal categories and
+    notions of computation", Math. Structures Comput. Sci. 7(5), 1997) is a
+    binoidal category — Structure/Binoidal.v — together with
+
+      - a unit object [premon_I];
+      - unitor isomorphisms  lambda : I ⊗ x ≅ x   ([premon_unit_left])
+                             rho    : x ⊗ I ≅ x   ([premon_unit_right]);
+      - an associator alpha : (x ⊗ y) ⊗ z ≅ x ⊗ (y ⊗ z)  ([premon_assoc]);
+
+    such that the forward components of lambda, rho and alpha are CENTRAL
+    (Structure/Binoidal.v, [central]), each family is natural in every
+    variable SEPARATELY, and the triangle and pentagon coherence laws hold.
+    The iso orientations and the naturality-square orientations mirror
+    Structure/Monoidal.v exactly, so that a monoidal category yields a
+    premonoidal one field-for-field (Structure/Premonoidal/Monoidal.v).
+
+    Design of the field set:
+
+      - Naturality is one variable at a time.  In a binoidal category the
+        tensor is only separately functorial, so a jointly-natural square in
+        the style of Monoidal.v's [to_tensor_assoc_natural] is not the
+        primitive notion; the three one-variable associator squares
+        ([premon_assoc_natural_left]/[_middle]/[_right]) are.  Remarkably,
+        the JOINT square for the interleaved composite [composite_ff'] is
+        still derivable from them with no centrality hypothesis at all
+        ([premon_joint_assoc_natural] below).
+
+      - Only the forward (to) directions are data.  The from-direction
+        centralities follow by [central_iso_from], and the from-direction
+        naturality squares follow by conjugating the to-squares with the
+        isomorphisms ([premon_square_from]).  Keeping the class minimal
+        means fewer obligations for instance builders; the derived lemmas
+        below restore the full Monoidal.v-style surface.
+
+      - Centrality of the structural isomorphisms is what separates a
+        premonoidal category from a mere "binoidal category with coherent
+        isos": it makes the unitors and associator morphisms of the centre
+        Z(C), so that Z(C) becomes a genuine monoidal category
+        (Structure/Premonoidal/Centre.v), and it is exactly what the
+        one-sided interchange lemmas [composite_ff'_comp_l]/[_r] of
+        Structure/Binoidal/Central.v consume.
+
+    The [composite_ff']-phrased translation lemmas at the end of this file
+    ([premon_unit_left_natural_ff'], [premon_unit_right_natural_ff'],
+    [premon_triangle_ff'], [premon_pentagon_ff'], and the unitor from-forms)
+    restate the class fields with identity padding, which is the exact shape
+    [Build_Monoidal] needs when every morphism is central
+    (Structure/Premonoidal/Monoidal.v) and when the tensor is restricted to
+    the centre (Structure/Premonoidal/Centre.v). *)
+
+Section Premonoidal.
+
+Context {C : Category}.
+Context `{@Binoidal C}.
+
+(* Section-local object-level tensor, mirroring the section notation of
+   Structure/Binoidal.v.  The global ⊗ lives in two scopes (objects and,
+   via [composite_ff'], morphisms); since morphism_scope is opened on top
+   of object_scope, an unscoped section notation is needed for ⊗ to mean
+   the OBJECT tensor inside the field types below.  Morphism-level
+   interleaved tensoring is always written [composite_ff'] in this file. *)
+Local Notation "x ⊗ y" := (tensor x y)
+  (at level 30, right associativity).
+
+(* Conjugating a commuting square by isomorphisms on both vertical edges:
+   from   g ∘ to i ≈ to j ∘ f   we get   f ∘ from i ≈ from j ∘ g.
+   Instantiated below with the unitors and the associator, this converts
+   every to-direction naturality field into its from-direction form, so the
+   inverse squares need not be part of the class data. *)
+Lemma premon_square_from {a b c d : C} (i : a ≅ b) (j : c ≅ d)
+      (f : a ~> c) (g : b ~> d) :
+  g ∘ to i ≈ to j ∘ f →
+  f ∘ from i ≈ from j ∘ g.
+Proof.
+  intros sq.
+  symmetry.
+  rewrite <- (id_right g).
+  rewrite <- (iso_to_from i).
+  rewrite !comp_assoc.
+  rewrite <- (comp_assoc (from j) g (to i)).
+  rewrite sq.
+  rewrite (comp_assoc (from j) (to j) f).
+  rewrite (iso_from_to j).
+  now rewrite id_left.
+Qed.
+
+(* The premonoidal structure proper.  Field orientations follow
+   Structure/Monoidal.v L48-94: the isos point I ⊗ x → x, x ⊗ I → x and
+   (x ⊗ y) ⊗ z → x ⊗ (y ⊗ z); the naturality squares put the tensored
+   morphism after the structural map on the right-hand side; triangle and
+   pentagon are verbatim transcriptions with the joint bimap replaced by
+   the separate tensorings ⋉ / ⋊ of Structure/Binoidal.v. *)
+Class Premonoidal := {
+  premon_I : C;
+
+  premon_unit_left  {x} : premon_I ⊗ x ≅ x;                 (* lambda *)
+  premon_unit_right {x} : x ⊗ premon_I ≅ x;                 (* rho *)
+  premon_assoc {x y z} : (x ⊗ y) ⊗ z ≅ x ⊗ (y ⊗ z);         (* alpha *)
+
+  (* The forward structural maps are central; the from-directions are
+     derived below via [central_iso_from]. *)
+  premon_unit_left_central  {x} : central (to (@premon_unit_left x));
+  premon_unit_right_central {x} : central (to (@premon_unit_right x));
+  premon_assoc_central {x y z} : central (to (@premon_assoc x y z));
+
+  (* Naturality, one variable at a time.  For the unitors there is a single
+     variable; for the associator there are three squares, one for each
+     tensor position. *)
+  premon_unit_left_natural {x y} (g : x ~> y) :
+    g ∘ to premon_unit_left
+      << premon_I ⊗ x ~~> y >>
+    to premon_unit_left ∘ (premon_I ⋊ g);
+
+  premon_unit_right_natural {x y} (g : x ~> y) :
+    g ∘ to premon_unit_right
+      << x ⊗ premon_I ~~> y >>
+    to premon_unit_right ∘ (g ⋉ premon_I);
+
+  premon_assoc_natural_left {x y z w} (g : x ~> y) :
+    (g ⋉ (z ⊗ w)) ∘ to premon_assoc
+      << (x ⊗ z) ⊗ w ~~> y ⊗ (z ⊗ w) >>
+    to premon_assoc ∘ ((g ⋉ z) ⋉ w);
+
+  premon_assoc_natural_middle {x z w y} (h : z ~> w) :
+    (x ⋊ (h ⋉ y)) ∘ to premon_assoc
+      << (x ⊗ z) ⊗ y ~~> x ⊗ (w ⊗ y) >>
+    to premon_assoc ∘ ((x ⋊ h) ⋉ y);
+
+  premon_assoc_natural_right {x y z w} (i : z ~> w) :
+    (x ⋊ (y ⋊ i)) ∘ to premon_assoc
+      << (x ⊗ y) ⊗ z ~~> x ⊗ (y ⊗ w) >>
+    to premon_assoc ∘ ((x ⊗ y) ⋊ i);
+
+  (* Coherence: triangle (unitors against the associator, across the unit)
+     and pentagon (the two reassociations of a fourfold tensor agree). *)
+  premon_triangle {x y} :
+    to premon_unit_right ⋉ y
+      << (x ⊗ premon_I) ⊗ y ~~> x ⊗ y >>
+    (x ⋊ to premon_unit_left) ∘ to premon_assoc;
+
+  premon_pentagon {x y z w} :
+    (x ⋊ to premon_assoc) ∘ to premon_assoc ∘ (to premon_assoc ⋉ w)
+      << ((x ⊗ y) ⊗ z) ⊗ w ~~> x ⊗ (y ⊗ (z ⊗ w)) >>
+    to premon_assoc ∘ to premon_assoc
+}.
+
+Context `{Premonoidal}.
+
+(** ** From-direction centrality
+
+    The inverse of a central isomorphism is central
+    (Structure/Binoidal/Central.v, [central_iso_from]), so the inverse
+    structural maps are central as well. *)
+
+Lemma premon_unit_left_central_from {x} :
+  central (from (@premon_unit_left _ x)).
+Proof. apply central_iso_from, premon_unit_left_central. Qed.
+
+Lemma premon_unit_right_central_from {x} :
+  central (from (@premon_unit_right _ x)).
+Proof. apply central_iso_from, premon_unit_right_central. Qed.
+
+Lemma premon_assoc_central_from {x y z} :
+  central (from (@premon_assoc _ x y z)).
+Proof. apply central_iso_from, premon_assoc_central. Qed.
+
+(** ** From-direction naturality
+
+    Each to-square conjugates to the corresponding from-square via
+    [premon_square_from]; the orientations mirror Monoidal.v's
+    [from_unit_left_natural] etc. *)
+
+Lemma premon_unit_left_natural_from {x y} (g : x ~> y) :
+  (premon_I ⋊ g) ∘ from premon_unit_left
+    << x ~~> premon_I ⊗ y >>
+  from premon_unit_left ∘ g.
+Proof. apply premon_square_from, premon_unit_left_natural. Qed.
+
+Lemma premon_unit_right_natural_from {x y} (g : x ~> y) :
+  (g ⋉ premon_I) ∘ from premon_unit_right
+    << x ~~> y ⊗ premon_I >>
+  from premon_unit_right ∘ g.
+Proof. apply premon_square_from, premon_unit_right_natural. Qed.
+
+Lemma premon_assoc_natural_left_from {x y z w} (g : x ~> y) :
+  ((g ⋉ z) ⋉ w) ∘ from premon_assoc
+    << x ⊗ (z ⊗ w) ~~> (y ⊗ z) ⊗ w >>
+  from premon_assoc ∘ (g ⋉ (z ⊗ w)).
+Proof. apply premon_square_from, premon_assoc_natural_left. Qed.
+
+Lemma premon_assoc_natural_middle_from {x z w y} (h : z ~> w) :
+  ((x ⋊ h) ⋉ y) ∘ from premon_assoc
+    << x ⊗ (z ⊗ y) ~~> (x ⊗ w) ⊗ y >>
+  from premon_assoc ∘ (x ⋊ (h ⋉ y)).
+Proof. apply premon_square_from, premon_assoc_natural_middle. Qed.
+
+Lemma premon_assoc_natural_right_from {x y z w} (i : z ~> w) :
+  ((x ⊗ y) ⋊ i) ∘ from premon_assoc
+    << x ⊗ (y ⊗ z) ~~> (x ⊗ y) ⊗ w >>
+  from premon_assoc ∘ (x ⋊ (y ⋊ i)).
+Proof. apply premon_square_from, premon_assoc_natural_right. Qed.
+
+(** ** Joint naturality of the associator, without centrality
+
+    In a binoidal category the interleaved tensor [composite_ff' f f']
+    (written f ⊗ g in the global morphism scope) is in general functorial
+    only up to a centrality hypothesis, and the two interleavings of a
+    pair of morphisms in general disagree.  Nevertheless, the associator
+    is natural against [composite_ff'] JOINTLY in all three variables,
+    with NO centrality hypothesis: decompose each [composite_ff'] into
+    its ⋊-then-⋉ factors, expand the outer tensorings of composites by
+    functoriality, and push alpha through the three one-variable squares;
+    both sides land on the same fully right-associated word
+
+        alpha ∘ ((y ⊗ w) ⋊ i) ∘ ((y ⋊ h) ⋉ u) ∘ ((g ⋉ z) ⋉ u).
+
+    The reason no interchange is needed: in [composite_ff' g (composite_ff'
+    h i) ∘ alpha] the three factors are already stacked in the order
+    right-position, middle-position, left-position, which is exactly the
+    order in which the three one-variable squares consume them, and each
+    square permutes a factor past alpha without ever swapping two
+    non-structural factors.
+
+    This lemma is the engine behind Structure/Premonoidal/Monoidal.v's
+    [Premonoidal_Monoidal] (where it discharges [to_tensor_assoc_natural]
+    once every morphism is central) and, at `1-projections, behind the
+    monoidal structure of the centre in Structure/Premonoidal/Centre.v. *)
+
+Lemma premon_joint_assoc_natural {x y z w u v}
+      (g : x ~> y) (h : z ~> w) (i : u ~> v) :
+  composite_ff' g (composite_ff' h i) ∘ to premon_assoc
+    << (x ⊗ z) ⊗ u ~~> y ⊗ (w ⊗ v) >>
+  to premon_assoc ∘ composite_ff' (composite_ff' g h) i.
+Proof.
+  unfold composite_ff'.
+  rewrite !fmap_comp.
+  rewrite <- !comp_assoc.
+  (* left-position square: (g ⋉ (z ⊗ u)) ∘ alpha ≈ alpha ∘ ((g ⋉ z) ⋉ u) *)
+  transitivity
+    ((y ⋊ (w ⋊ i))
+       ∘ ((y ⋊ (h ⋉ u)) ∘ (to premon_assoc ∘ ((g ⋉ z) ⋉ u)))).
+  { apply compose_respects; [reflexivity|].
+    apply compose_respects; [reflexivity|].
+    apply premon_assoc_natural_left. }
+  (* middle-position square: (y ⋊ (h ⋉ u)) ∘ alpha ≈ alpha ∘ ((y ⋊ h) ⋉ u) *)
+  transitivity
+    ((y ⋊ (w ⋊ i))
+       ∘ (to premon_assoc ∘ (((y ⋊ h) ⋉ u) ∘ ((g ⋉ z) ⋉ u)))).
+  { apply compose_respects; [reflexivity|].
+    rewrite !comp_assoc.
+    apply compose_respects; [|reflexivity].
+    apply premon_assoc_natural_middle. }
+  (* right-position square: (y ⋊ (w ⋊ i)) ∘ alpha ≈ alpha ∘ ((y ⊗ w) ⋊ i) *)
+  rewrite comp_assoc.
+  transitivity
+    ((to premon_assoc ∘ ((y ⊗ w) ⋊ i))
+       ∘ (((y ⋊ h) ⋉ u) ∘ ((g ⋉ z) ⋉ u))).
+  { apply compose_respects; [|reflexivity].
+    apply premon_assoc_natural_right. }
+  rewrite <- !comp_assoc.
+  reflexivity.
+Qed.
+
+Lemma premon_joint_assoc_natural_from {x y z w u v}
+      (g : x ~> y) (h : z ~> w) (i : u ~> v) :
+  composite_ff' (composite_ff' g h) i ∘ from premon_assoc
+    << x ⊗ (z ⊗ u) ~~> (y ⊗ w) ⊗ v >>
+  from premon_assoc ∘ composite_ff' g (composite_ff' h i).
+Proof. apply premon_square_from, premon_joint_assoc_natural. Qed.
+
+(** ** Translation to [composite_ff'] form
+
+    The unitor naturality squares and the coherence laws, restated with
+    identity padding through [composite_ff'] (via [composite_id_left] /
+    [composite_id_right] of Structure/Binoidal/Central.v).  With the
+    tensor bifunctor of an all-central or centre-restricted premonoidal
+    category defined by [fmap := composite_ff'], these are literally the
+    [Build_Monoidal] fields of Structure/Monoidal.v. *)
+
+Lemma premon_unit_left_natural_ff' {x y} (g : x ~> y) :
+  g ∘ to premon_unit_left
+    << premon_I ⊗ x ~~> y >>
+  to premon_unit_left ∘ composite_ff' (id[premon_I]) g.
+Proof.
+  rewrite composite_id_left.
+  apply premon_unit_left_natural.
+Qed.
+
+Lemma premon_unit_right_natural_ff' {x y} (g : x ~> y) :
+  g ∘ to premon_unit_right
+    << x ⊗ premon_I ~~> y >>
+  to premon_unit_right ∘ composite_ff' g (id[premon_I]).
+Proof.
+  rewrite composite_id_right.
+  apply premon_unit_right_natural.
+Qed.
+
+Lemma premon_unit_left_natural_from_ff' {x y} (g : x ~> y) :
+  composite_ff' (id[premon_I]) g ∘ from premon_unit_left
+    << x ~~> premon_I ⊗ y >>
+  from premon_unit_left ∘ g.
+Proof.
+  rewrite composite_id_left.
+  apply premon_unit_left_natural_from.
+Qed.
+
+Lemma premon_unit_right_natural_from_ff' {x y} (g : x ~> y) :
+  composite_ff' g (id[premon_I]) ∘ from premon_unit_right
+    << x ~~> y ⊗ premon_I >>
+  from premon_unit_right ∘ g.
+Proof.
+  rewrite composite_id_right.
+  apply premon_unit_right_natural_from.
+Qed.
+
+Lemma premon_triangle_ff' {x y} :
+  composite_ff' (to premon_unit_right) (id[y])
+    << (x ⊗ premon_I) ⊗ y ~~> x ⊗ y >>
+  composite_ff' (id[x]) (to premon_unit_left) ∘ to premon_assoc.
+Proof.
+  rewrite composite_id_left, composite_id_right.
+  apply premon_triangle.
+Qed.
+
+Lemma premon_pentagon_ff' {x y z w} :
+  composite_ff' (id[x]) (to premon_assoc)
+      ∘ to premon_assoc
+      ∘ composite_ff' (to premon_assoc) (id[w])
+    << ((x ⊗ y) ⊗ z) ⊗ w ~~> x ⊗ (y ⊗ (z ⊗ w)) >>
+  to premon_assoc ∘ to premon_assoc.
+Proof.
+  rewrite composite_id_left, composite_id_right.
+  apply premon_pentagon.
+Qed.
+
+End Premonoidal.

--- a/Structure/Premonoidal/Centre.v
+++ b/Structure/Premonoidal/Centre.v
@@ -1,0 +1,333 @@
+Set Warnings "-notation-overridden".
+
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Construction.Product.
+Require Import Category.Construction.Subcategory.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Binoidal.
+Require Import Category.Structure.Binoidal.Central.
+Require Import Category.Structure.Premonoidal.
+
+Generalizable All Variables.
+Set Primitive Projections.
+Set Universe Polymorphism.
+Set Transparent Obligations.
+
+(** * The centre of a premonoidal category is monoidal
+
+    nLab: https://ncatlab.org/nlab/show/premonoidal+category
+    (the centre Z(C) and its monoidal structure are discussed there)
+
+    Structure/Binoidal/Central.v packages the central morphisms of a
+    binoidal category as a wide subcategory Z(C) = [Centre C], and records
+    why closure of centrality under the interleaved tensor [composite_ff']
+    is out of reach in a bare binoidal category: the required commuting
+    square lives at the nested tensor (x ⊗ x') ⊗ a, and without structural
+    morphisms there is nothing connecting the two nesting levels.  A
+    premonoidal category (Structure/Premonoidal.v) supplies exactly the
+    missing ingredient — a central associator, natural in each variable
+    separately — and this file completes the development:
+
+      - [composite_ff'_central]: if f and f' are central, so is
+        [composite_ff' f f'].  Each defining square of the composite is
+        conjugated by the associator, trading the single unreachable
+        square at the nested tensor for three one-variable naturality
+        squares plus two single-level centrality squares (Power–Robinson,
+        "Premonoidal categories and notions of computation", 1997).
+
+      - [Centre_Tensor]: the tensor restricts to a genuine bifunctor
+        Z(C) ∏ Z(C) ⟶ Z(C).  On the centre, [composite_ff'] is jointly
+        functorial because the one-sided interchange lemma
+        [composite_ff'_comp_l] of Structure/Binoidal/Central.v receives
+        its centrality hypothesis from the hom witnesses, and the tensor
+        of two central morphisms is again central by the closure theorem.
+
+      - [Centre_Monoidal]: Z(C) is a monoidal category.  Unit, unitors
+        and associator are inherited from the premonoidal structure (the
+        forward components are central by the class fields, the inverses
+        by [central_iso_from]); every coherence field is an equation
+        between underlying morphisms of C because [Sub]-homsets compare
+        first projections, so the [composite_ff']-phrased translation
+        lemmas of Structure/Premonoidal.v discharge them verbatim.
+
+    Together these discharge the promise recorded above [central] in
+    Structure/Binoidal.v: the central morphisms form the centre, a
+    monoidal subcategory of C. *)
+
+Section PremonoidalCentre.
+
+Context {C : Category}.
+Context `{B : @Binoidal C}.
+Context `{P : @Premonoidal C B}.
+
+(* Section-local object-level tensor, exactly as in
+   Structure/Premonoidal.v: the unscoped notation makes ⊗ mean the OBJECT
+   tensor everywhere inside this section, while morphism-level interleaved
+   tensoring is always written [composite_ff']. *)
+Local Notation "x ⊗ y" := (tensor x y)
+  (at level 30, right associativity).
+
+(** ** Closure of centrality under the tensor
+
+    For central f : x ~> y and f' : x' ~> y', the interleaved tensor
+    [composite_ff' f f'] is central.  Writing α for [to premon_assoc],
+    the first defining square (against an arbitrary h : a ~> b) is
+    conjugated by α : ((y ⊗ y') ⊗ b) ≅ (y ⊗ (y' ⊗ b)); expanding
+    [fmap[inj_left _]] over the two factors of the composite and pushing
+    α through each factor with the three one-variable naturality squares
+    ([premon_assoc_natural_middle], [_left], [_right]) brings both sides
+    to a word in which the two centrality squares — [central f] against
+    (x' ⋊ h) and [central f'] against h — apply at a SINGLE tensor level;
+    both sides land on the common normal form
+
+        (y ⋊ (y' ⋊ h)) ∘ (y ⋊ (f' ⋉ a)) ∘ (f ⋉ (x' ⊗ a)) ∘ α.
+
+    The second square mirrors the first with the from-direction
+    naturality squares (conjugating by [from premon_assoc]) and the
+    second conjuncts of the two centrality hypotheses.  Each square is
+    established after composing with the conjugating isomorphism on the
+    left, which is sufficient because the [to] and [from] components of
+    an isomorphism are monic ([iso_to_monic] and [iso_from_monic],
+    Theory/Isomorphism.v).  Note that
+    [composite_f'f f' f] is definitionally [composite_ff' f' f], so no
+    mirror closure lemma is needed. *)
+
+Theorem composite_ff'_central {x x' y y'} {f : x ~> y} {f' : x' ~> y'} :
+  central f → central f' → central (composite_ff' f f').
+Proof using B C P.
+  intros cf cf' a b h.
+  split.
+  - (* Square 1, on (x ⊗ x') ⊗ a ~~> (y ⊗ y') ⊗ b. *)
+    destruct (cf (x' ⊗ a) (x' ⊗ b) (fmap[inj_right x'] h)) as [cfh _].
+    destruct (cf' a b h) as [cf'h _].
+    apply (iso_to_monic (@premon_assoc C B P y y' b)).
+    unfold composite_ff'.
+    rewrite !fmap_comp.
+    rewrite !comp_assoc.
+    transitivity
+      ((((y ⋊ (y' ⋊ h)) ∘ (y ⋊ (f' ⋉ a))) ∘ (f ⋉ (x' ⊗ a)))
+         ∘ to (@premon_assoc C B P x x' a)).
+    { (* Left side: push α through the middle, left and right factors,
+         then swap with the two centralities. *)
+      transitivity
+        ((((y ⋊ (f' ⋉ b)) ∘ to (@premon_assoc C B P y x' b))
+            ∘ ((f ⋉ x') ⋉ b)) ∘ ((x ⊗ x') ⋊ h)).
+      { do 2 (apply compose_respects; [|reflexivity]).
+        symmetry; apply premon_assoc_natural_middle. }
+      transitivity
+        ((((y ⋊ (f' ⋉ b)) ∘ (f ⋉ (x' ⊗ b)))
+            ∘ to (@premon_assoc C B P x x' b)) ∘ ((x ⊗ x') ⋊ h)).
+      { apply compose_respects; [|reflexivity].
+        rewrite <- !comp_assoc.
+        apply compose_respects; [reflexivity|].
+        symmetry; apply premon_assoc_natural_left. }
+      transitivity
+        ((((y ⋊ (f' ⋉ b)) ∘ (f ⋉ (x' ⊗ b))) ∘ (x ⋊ (x' ⋊ h)))
+           ∘ to (@premon_assoc C B P x x' a)).
+      { rewrite <- !comp_assoc.
+        do 2 (apply compose_respects; [reflexivity|]).
+        symmetry; apply premon_assoc_natural_right. }
+      transitivity
+        ((((y ⋊ (f' ⋉ b)) ∘ (y ⋊ (x' ⋊ h))) ∘ (f ⋉ (x' ⊗ a)))
+           ∘ to (@premon_assoc C B P x x' a)).
+      { apply compose_respects; [|reflexivity].
+        rewrite <- !comp_assoc.
+        apply compose_respects; [reflexivity|].
+        apply cfh. }
+      do 2 (apply compose_respects; [|reflexivity]).
+      rewrite <- !fmap_comp.
+      now rewrite cf'h. }
+    { (* Right side: the same three naturality squares, no swaps. *)
+      symmetry.
+      transitivity
+        ((((y ⋊ (y' ⋊ h)) ∘ to (@premon_assoc C B P y y' a))
+            ∘ ((y ⋊ f') ⋉ a)) ∘ ((f ⋉ x') ⋉ a)).
+      { do 2 (apply compose_respects; [|reflexivity]).
+        symmetry; apply premon_assoc_natural_right. }
+      transitivity
+        ((((y ⋊ (y' ⋊ h)) ∘ (y ⋊ (f' ⋉ a)))
+            ∘ to (@premon_assoc C B P y x' a)) ∘ ((f ⋉ x') ⋉ a)).
+      { apply compose_respects; [|reflexivity].
+        rewrite <- !comp_assoc.
+        apply compose_respects; [reflexivity|].
+        symmetry; apply premon_assoc_natural_middle. }
+      rewrite <- !comp_assoc.
+      do 2 (apply compose_respects; [reflexivity|]).
+      symmetry; apply premon_assoc_natural_left. }
+  - (* Square 2, on a ⊗ (x ⊗ x') ~~> b ⊗ (y ⊗ y'). *)
+    destruct (cf a b h) as [_ cf2].
+    destruct (cf' (a ⊗ y) (b ⊗ y) (fmap[inj_left y] h)) as [_ cf'2].
+    apply (iso_from_monic (@premon_assoc C B P b y y')).
+    unfold composite_ff'.
+    rewrite !fmap_comp.
+    rewrite !comp_assoc.
+    transitivity
+      (((((b ⊗ y) ⋊ f') ∘ ((b ⋊ f) ⋉ x')) ∘ ((h ⋉ x) ⋉ x'))
+         ∘ from (@premon_assoc C B P a x x')).
+    { (* Left side: push α⁻¹ through, then swap with the two
+         centralities' second conjuncts. *)
+      transitivity
+        (((((h ⋉ y) ⋉ y') ∘ from (@premon_assoc C B P a y y'))
+            ∘ (a ⋊ (y ⋊ f'))) ∘ (a ⋊ (f ⋉ x'))).
+      { do 2 (apply compose_respects; [|reflexivity]).
+        symmetry; apply premon_assoc_natural_left_from. }
+      transitivity
+        (((((h ⋉ y) ⋉ y') ∘ ((a ⊗ y) ⋊ f'))
+            ∘ from (@premon_assoc C B P a y x')) ∘ (a ⋊ (f ⋉ x'))).
+      { apply compose_respects; [|reflexivity].
+        rewrite <- !comp_assoc.
+        apply compose_respects; [reflexivity|].
+        symmetry; apply premon_assoc_natural_right_from. }
+      transitivity
+        (((((h ⋉ y) ⋉ y') ∘ ((a ⊗ y) ⋊ f')) ∘ ((a ⋊ f) ⋉ x'))
+           ∘ from (@premon_assoc C B P a x x')).
+      { rewrite <- !comp_assoc.
+        do 2 (apply compose_respects; [reflexivity|]).
+        symmetry; apply premon_assoc_natural_middle_from. }
+      transitivity
+        (((((b ⊗ y) ⋊ f') ∘ ((h ⋉ y) ⋉ x')) ∘ ((a ⋊ f) ⋉ x'))
+           ∘ from (@premon_assoc C B P a x x')).
+      { do 2 (apply compose_respects; [|reflexivity]).
+        apply cf'2. }
+      apply compose_respects; [|reflexivity].
+      rewrite <- !comp_assoc.
+      apply compose_respects; [reflexivity|].
+      transitivity (((h ⋉ y) ∘ (a ⋊ f)) ⋉ x').
+      { symmetry.
+        exact (@fmap_comp C C (@inj_left C B x') (a ⊗ x) (a ⊗ y) (b ⊗ y)
+                 (fmap[@inj_left C B y] h) (fmap[@inj_right C B a] f)). }
+      transitivity (((b ⋊ f) ∘ (h ⋉ x)) ⋉ x').
+      { now rewrite cf2. }
+      exact (@fmap_comp C C (@inj_left C B x') (a ⊗ x) (b ⊗ x) (b ⊗ y)
+               (fmap[@inj_right C B b] f) (fmap[@inj_left C B x] h)). }
+    { (* Right side: the same three from-direction squares, no swaps. *)
+      symmetry.
+      transitivity
+        (((((b ⊗ y) ⋊ f') ∘ from (@premon_assoc C B P b y x'))
+            ∘ (b ⋊ (f ⋉ x'))) ∘ (h ⋉ (x ⊗ x'))).
+      { do 2 (apply compose_respects; [|reflexivity]).
+        symmetry; apply premon_assoc_natural_right_from. }
+      transitivity
+        (((((b ⊗ y) ⋊ f') ∘ ((b ⋊ f) ⋉ x'))
+            ∘ from (@premon_assoc C B P b x x')) ∘ (h ⋉ (x ⊗ x'))).
+      { apply compose_respects; [|reflexivity].
+        rewrite <- !comp_assoc.
+        apply compose_respects; [reflexivity|].
+        symmetry; apply premon_assoc_natural_middle_from. }
+      rewrite <- !comp_assoc.
+      do 2 (apply compose_respects; [reflexivity|]).
+      symmetry; apply premon_assoc_natural_left_from. }
+Qed.
+
+(** ** Lifting central isomorphisms to the centre
+
+    A C-isomorphism whose forward component is central lifts to an
+    isomorphism in Z(C): the inverse is central by [central_iso_from],
+    and both inverse laws are the underlying C-equations because
+    [Sub]-homsets compare first projections.  The objects are arbitrary
+    objects of the centre (their [poly_unit] witnesses need not be
+    [ttt]), which is exactly the generality [Build_Monoidal] requires
+    below. *)
+
+Definition Centre_lift_iso {p q : @Centre C B} (i : `1 p ≅[C] `1 q)
+           (ci : central (to i)) : p ≅[@Centre C B] q :=
+  @Build_Isomorphism (@Centre C B) p q
+    (to i; ci)
+    (from i; central_iso_from i ci)
+    (iso_to_from i)
+    (iso_from_to i).
+
+(** ** The tensor bifunctor on the centre *)
+
+Definition Centre_Tensor_obj (p : @Centre C B ∏ @Centre C B) :
+  @Centre C B := (`1 (fst p) ⊗ `1 (snd p); ttt).
+
+Definition Centre_Tensor_fmap (p q : @Centre C B ∏ @Centre C B)
+           (fg : p ~{@Centre C B ∏ @Centre C B}~> q) :
+  Centre_Tensor_obj p ~{@Centre C B}~> Centre_Tensor_obj q :=
+  (composite_ff' (`1 (fst fg)) (`1 (snd fg));
+   composite_ff'_central (`2 (fst fg)) (`2 (snd fg))).
+
+Lemma Centre_Tensor_respects (p q : @Centre C B ∏ @Centre C B) :
+  Proper (equiv ==> equiv) (Centre_Tensor_fmap p q).
+Proof.
+  intros fg hk [e1 e2]; simpl.
+  apply composite_ff'_respects; assumption.
+Qed.
+
+Lemma Centre_Tensor_id (p : @Centre C B ∏ @Centre C B) :
+  Centre_Tensor_fmap p p (@id (@Centre C B ∏ @Centre C B) p) ≈ id.
+Proof.
+  simpl.
+  rewrite composite_id_left.
+  exact (@fmap_id C C (@inj_right C B (`1 (fst p))) (`1 (snd p))).
+Qed.
+
+(* Joint functoriality: on the centre the one-sided interchange
+   [composite_ff'_comp_l] receives its centrality hypothesis from the
+   hom witness of the first component. *)
+Lemma Centre_Tensor_comp (p q r : @Centre C B ∏ @Centre C B)
+      (fg : q ~{@Centre C B ∏ @Centre C B}~> r)
+      (hk : p ~{@Centre C B ∏ @Centre C B}~> q) :
+  Centre_Tensor_fmap p r (fg ∘ hk)
+    ≈ Centre_Tensor_fmap q r fg ∘ Centre_Tensor_fmap p q hk.
+Proof.
+  simpl.
+  apply composite_ff'_comp_l.
+  exact (`2 (fst fg)).
+Qed.
+
+Definition Centre_Tensor : (@Centre C B ∏ @Centre C B) ⟶ @Centre C B := {|
+  fobj := Centre_Tensor_obj;
+  fmap := Centre_Tensor_fmap;
+  fmap_respects := Centre_Tensor_respects;
+  fmap_id := Centre_Tensor_id;
+  fmap_comp := Centre_Tensor_comp
+|}.
+
+(** ** Z(C) is a monoidal category (Power–Robinson)
+
+    Every equational field of [Monoidal] at the centre is, by the
+    [Sub]-homset convention, an equation between underlying morphisms of
+    C, and those equations are precisely the [composite_ff']-phrased
+    translation lemmas of Structure/Premonoidal.v: the unitor squares and
+    the triangle/pentagon via identity padding, and the associator
+    squares via the joint naturality lemma (which needs no centrality at
+    all).  This discharges the promise recorded above [central] in
+    Structure/Binoidal.v. *)
+
+Definition Centre_Monoidal : @Monoidal (@Centre C B) :=
+  @Build_Monoidal (@Centre C B)
+    (@premon_I C B P; ttt)
+    Centre_Tensor
+    (fun p =>
+       @Centre_lift_iso (Centre_Tensor_obj ((@premon_I C B P; ttt), p)) p
+         (@premon_unit_left C B P (`1 p))
+         (@premon_unit_left_central C B P (`1 p)))
+    (fun p =>
+       @Centre_lift_iso (Centre_Tensor_obj (p, (@premon_I C B P; ttt))) p
+         (@premon_unit_right C B P (`1 p))
+         (@premon_unit_right_central C B P (`1 p)))
+    (fun p q r =>
+       @Centre_lift_iso
+         (Centre_Tensor_obj (Centre_Tensor_obj (p, q), r))
+         (Centre_Tensor_obj (p, Centre_Tensor_obj (q, r)))
+         (@premon_assoc C B P (`1 p) (`1 q) (`1 r))
+         (@premon_assoc_central C B P (`1 p) (`1 q) (`1 r)))
+    (fun p q g => premon_unit_left_natural_ff' (`1 g))
+    (fun p q g => premon_unit_left_natural_from_ff' (`1 g))
+    (fun p q g => premon_unit_right_natural_ff' (`1 g))
+    (fun p q g => premon_unit_right_natural_from_ff' (`1 g))
+    (fun p q r s t u g h i =>
+       premon_joint_assoc_natural (`1 g) (`1 h) (`1 i))
+    (fun p q r s t u g h i =>
+       premon_joint_assoc_natural_from (`1 g) (`1 h) (`1 i))
+    (fun p q => @premon_triangle_ff' C B P (`1 p) (`1 q))
+    (fun p q r s =>
+       @premon_pentagon_ff' C B P (`1 p) (`1 q) (`1 r) (`1 s)).
+
+End PremonoidalCentre.

--- a/Structure/Premonoidal/Freyd.v
+++ b/Structure/Premonoidal/Freyd.v
@@ -16,7 +16,6 @@ Require Import Category.Structure.Binoidal.Central.
 Require Import Category.Structure.Premonoidal.
 Require Import Category.Structure.Premonoidal.Monoidal.
 Require Import Category.Structure.Premonoidal.Centre.
-Require Import Category.Functor.Structure.Monoidal.Strict.
 Require Import Category.Monad.Strong.
 Require Import Category.Monad.Kleisli.
 Require Import Category.Monad.Kleisli.Premonoidal.
@@ -102,7 +101,6 @@ Set Transparent Obligations.
 Section Effectful.
 
 Context {V K : Category}.
-Context `{MV : @Monoidal V}.
 Context `{BK : @Binoidal K}.
 
 Class EffectfulFunctor (J : V ⟶ K) := {

--- a/Structure/Premonoidal/Freyd.v
+++ b/Structure/Premonoidal/Freyd.v
@@ -1,0 +1,419 @@
+Set Warnings "-notation-overridden".
+
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Theory.Monad.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Construction.Subcategory.
+Require Import Category.Construction.Quotient.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Monoidal.Braided.
+Require Import Category.Structure.Monoidal.Symmetric.
+Require Import Category.Structure.Binoidal.
+Require Import Category.Structure.Binoidal.Central.
+Require Import Category.Structure.Premonoidal.
+Require Import Category.Structure.Premonoidal.Monoidal.
+Require Import Category.Structure.Premonoidal.Centre.
+Require Import Category.Functor.Structure.Monoidal.Strict.
+Require Import Category.Monad.Strong.
+Require Import Category.Monad.Kleisli.
+Require Import Category.Monad.Kleisli.Premonoidal.
+
+Generalizable All Variables.
+Set Primitive Projections.
+Set Universe Polymorphism.
+Set Transparent Obligations.
+
+(** * Freyd categories and effectful functors
+
+    nLab: https://ncatlab.org/nlab/show/Freyd+category
+
+    Levy–Power–Thielecke ("Modelling environments in call-by-value
+    programming languages", Inf. Comput. 185(2), 2003) and Power–Thielecke
+    ("Closed Freyd- and kappa-categories", ICALP 1999) distil the
+    categorical semantics of call-by-value effects into a FREYD CATEGORY:
+    an identity-on-objects functor J : V ⟶ K from a monoidal category of
+    values into a premonoidal category of computations, strictly
+    preserving the premonoidal structure and landing in the centre Z(K).
+    Every strong monad on a symmetric monoidal base produces one — the
+    Kleisli premonoidal structure of Monad/Kleisli/Premonoidal.v — and
+    Freyd categories are exactly the monad-independent formulation of
+    that situation.
+
+    The notion is delivered in two layers:
+
+      - [EffectfulFunctor]: the centrality half alone — a functor whose
+        image consists of central morphisms (Structure/Binoidal.v).  Such
+        a functor factors through the centre ([Effectful_Centre]) as a
+        functor V ⟶ Z(K), and the factorization J = Incl ∘ Effectful_Centre
+        holds definitionally ([Effectful_Centre_factors]).  Since Z(K) is
+        monoidal (Structure/Premonoidal/Centre.v, [Centre_Monoidal]), an
+        effectful functor out of a monoidal V is the raw material of a
+        monoidal-to-monoidal comparison.
+
+      - [Freyd]: the full packaging.  Identity-on-objects is rendered
+        strictly, as a section/retraction pair of Leibniz object
+        equalities ([freyd_obj_section]/[freyd_obj_eq]/[freyd_sec_eq]),
+        and strict preservation of unit and tensor is rendered with the
+        library's transported-identity discipline: object-level
+        equalities [freyd_obj_I]/[freyd_obj_tensor], plus morphism-level
+        laws transported along them by [id_cast]
+        (Construction/Quotient.v).  This is the same [match]-shaped
+        formulation as the "Formulation note" of
+        Structure/Monoidal/Strict.v and the strict monoidal functors of
+        Functor/Structure/Monoidal/Strict.v; [id_cast] is deliberately
+        spelled so those fields and these read alike.  In both instances
+        below every object equality is [eq_refl], so every cast reduces
+        to [id] definitionally and the morphism-level fields collapse to
+        the underlying coherence facts.
+
+    Two instances close the file:
+
+      - [Freyd_Kleisli], the flagship (Power–Robinson): for a strong
+        monad M on a symmetric monoidal category C, the pure functor
+        [Kleisli_Pure] : C ⟶ Kl(M) of Monad/Kleisli/Premonoidal.v is a
+        Freyd category over [Kleisli_Binoidal]/[Kleisli_Premonoidal].
+        Objects of Kl(M) ARE the objects of C, so all object equalities
+        are [eq_refl]; centrality of the image is [pure_central]; the
+        two tensoring strictness fields are the pure-morphism transfer
+        laws [pure_inj_left]/[pure_inj_right]; and the structural-map
+        fields hold at reflexivity level because the premonoidal unitors
+        and associator of Kl(M) are themselves [kpure] images.
+
+      - [Freyd_Id], the degenerate example: any monoidal category over
+        itself through [Monoidal_Binoidal]/[Monoidal_Premonoidal]
+        (Structure/Premonoidal/Monoidal.v), with J the identity functor
+        and centrality supplied by [Monoidal_all_central].  For a
+        cartesian V — take [CC_Monoidal] of
+        Structure/Monoidal/Internal/Product.v, or its alias
+        [Cartesian_Monoidal] — this recovers the classical Freyd-category
+        reading "cartesian values inside effectful computations", here at
+        the trivial effect. *)
+
+(** ** Effectful functors
+
+    The centrality half of the Freyd notion, isolated: a functor
+    J : V ⟶ K into a binoidal K is effectful when every morphism in its
+    image is central.  No strictness and no structure preservation is
+    demanded yet, so the class is stated over a bare binoidal target. *)
+
+Section Effectful.
+
+Context {V K : Category}.
+Context `{MV : @Monoidal V}.
+Context `{BK : @Binoidal K}.
+
+Class EffectfulFunctor (J : V ⟶ K) := {
+  eff_central {x y} (f : x ~{V}~> y) : central (fmap[J] f)
+}.
+
+(** The image of an effectful functor lands in the wide subcategory
+    Z(K) = [Centre K] of Structure/Binoidal/Central.v, so J factors as a
+    functor into the centre.  The functor laws are the underlying laws of
+    J because [Sub]-homsets compare first projections. *)
+
+Definition Effectful_Centre_fmap {J : V ⟶ K} `{E : @EffectfulFunctor J}
+    {x y : V} (f : x ~{V}~> y) :
+  ((fobj[J] x; ttt) : Centre K) ~{Centre K}~> ((fobj[J] y; ttt) : Centre K) :=
+  (fmap[J] f; eff_central f).
+
+Lemma Effectful_Centre_respects {J : V ⟶ K} `{E : @EffectfulFunctor J}
+      (x y : V) :
+  Proper (equiv ==> equiv) (@Effectful_Centre_fmap J E x y).
+Proof.
+  intros f g eqv; simpl.
+  now rewrite eqv.
+Qed.
+
+Lemma Effectful_Centre_id {J : V ⟶ K} `{E : @EffectfulFunctor J} (x : V) :
+  @Effectful_Centre_fmap J E x x (@id V x)
+    ≈ @id (Centre K) (fobj[J] x; ttt).
+Proof.
+  simpl.
+  apply fmap_id.
+Qed.
+
+Lemma Effectful_Centre_comp {J : V ⟶ K} `{E : @EffectfulFunctor J}
+      {x y z : V} (f : y ~{V}~> z) (g : x ~{V}~> y) :
+  @Effectful_Centre_fmap J E x z (f ∘ g)
+    ≈ @compose (Centre K) (fobj[J] x; ttt) (fobj[J] y; ttt) (fobj[J] z; ttt)
+        (Effectful_Centre_fmap f) (Effectful_Centre_fmap g).
+Proof.
+  simpl.
+  apply fmap_comp.
+Qed.
+
+Definition Effectful_Centre {J : V ⟶ K} `{E : @EffectfulFunctor J} :
+  V ⟶ Centre K := {|
+  fobj := fun x : V => ((fobj[J] x; ttt) : Centre K);
+  fmap := fun (x y : V) (f : x ~{V}~> y) => Effectful_Centre_fmap f;
+  fmap_respects := Effectful_Centre_respects;
+  fmap_id := Effectful_Centre_id;
+  fmap_comp := fun (x y z : V) (f : y ~{V}~> z) (g : x ~{V}~> y) =>
+                 Effectful_Centre_comp f g
+|}.
+
+(** The factorization J = Incl ∘ Effectful_Centre is definitional on
+    morphisms: including the centred image back into K returns exactly
+    the original action of J. *)
+
+Corollary Effectful_Centre_factors {J : V ⟶ K} `{E : @EffectfulFunctor J}
+          {x y : V} (f : x ~{V}~> y) :
+  fmap[Incl K (@CentralSub K BK)] (fmap[@Effectful_Centre J E] f)
+    ≈ fmap[J] f.
+Proof. reflexivity. Qed.
+
+End Effectful.
+
+(** ** Freyd categories
+
+    A Freyd category over the monoidal (V, ⨂, I) and the premonoidal
+    (K, ⊗, premon_I) is a functor J : V ⟶ K that
+
+      - has a central image ([freyd_central]);
+      - is bijective on objects, witnessed strictly by a section together
+        with both Leibniz round-trip equalities;
+      - preserves the unit and the tensor strictly on objects, and
+        preserves the tensorings and the structural isomorphisms on
+        morphisms up to the [id_cast] transports along those object
+        equalities.
+
+    The two tensoring fields relate V's joint tensor with an identity in
+    one slot to K's one-sided tensorings ⋉ / ⋊, one field per slot; the
+    unitor and associator fields express that J sends V's structural
+    isomorphisms to K's, modulo the cast bookkeeping that connects
+    J-images of compound objects with compounds of J-images.  In a fully
+    strict situation (both instances in this file) every equality is
+    [eq_refl], the composite equalities [eq_trans _ (f_equal _ _)]
+    compute to [eq_refl], and every [id_cast] disappears
+    definitionally. *)
+
+Section Freyd.
+
+Context {V K : Category}.
+Context `{MV : @Monoidal V}.
+Context `{BK : @Binoidal K}.
+Context `{PK : @Premonoidal K BK}.
+
+Class Freyd (J : V ⟶ K) := {
+  (* Every morphism in the image of J is central in K. *)
+  freyd_central {x y} (f : x ~{V}~> y) : central (fmap[J] f);
+
+  (* Identity-on-objects, rendered as a strict object bijection. *)
+  freyd_obj_section (k : K) : V;
+  freyd_obj_eq (k : K) : fobj[J] (freyd_obj_section k) = k;
+  freyd_sec_eq (v : V) : freyd_obj_section (fobj[J] v) = v;
+
+  (* Strict preservation of the unit and the tensor on objects. *)
+  freyd_obj_I : fobj[J] (@I V MV) = @premon_I K BK PK;
+  freyd_obj_tensor {x y : V} :
+    fobj[J] ((x ⨂ y)%object) = (fobj[J] x ⊗ fobj[J] y)%object;
+
+  (* Morphism-level strictness of the two tensorings, transported by
+     [id_cast]: tensoring with an identity in V maps to the one-sided
+     tensoring in K. *)
+  freyd_map_left {x y : V} (f : x ~{V}~> y) (z : V) :
+    id_cast (@freyd_obj_tensor y z) ∘ fmap[J] (f ⨂ id[z])
+      ≈ (fmap[J] f ⋉ fobj[J] z) ∘ id_cast (@freyd_obj_tensor x z);
+
+  freyd_map_right {x y : V} (f : x ~{V}~> y) (z : V) :
+    id_cast (@freyd_obj_tensor z y) ∘ fmap[J] (id[z] ⨂ f)
+      ≈ (fobj[J] z ⋊ fmap[J] f) ∘ id_cast (@freyd_obj_tensor z x);
+
+  (* J sends V's structural isomorphisms to K's, across the casts that
+     mediate between J-images of compound objects and compounds of
+     J-images. *)
+  freyd_unit_left {x : V} :
+    fmap[J] (to (@unit_left V MV x))
+      ≈ to (@premon_unit_left K BK PK (fobj[J] x))
+          ∘ id_cast
+              (eq_trans (@freyd_obj_tensor (@I V MV) x)
+                        (f_equal (fun i : K => (i ⊗ fobj[J] x)%object)
+                                 freyd_obj_I));
+
+  freyd_unit_right {x : V} :
+    fmap[J] (to (@unit_right V MV x))
+      ≈ to (@premon_unit_right K BK PK (fobj[J] x))
+          ∘ id_cast
+              (eq_trans (@freyd_obj_tensor x (@I V MV))
+                        (f_equal (fun i : K => (fobj[J] x ⊗ i)%object)
+                                 freyd_obj_I));
+
+  freyd_assoc {x y z : V} :
+    id_cast
+        (eq_trans (@freyd_obj_tensor x ((y ⨂ z)%object))
+                  (f_equal (fun i : K => (fobj[J] x ⊗ i)%object)
+                           (@freyd_obj_tensor y z)))
+      ∘ fmap[J] (to (@tensor_assoc V MV x y z))
+      ≈ to (@premon_assoc K BK PK (fobj[J] x) (fobj[J] y) (fobj[J] z))
+          ∘ id_cast
+              (eq_trans (@freyd_obj_tensor ((x ⨂ y)%object) z)
+                        (f_equal (fun i : K => (i ⊗ fobj[J] z)%object)
+                                 (@freyd_obj_tensor x y)))
+}.
+
+(** Projecting away the strictness data leaves an effectful functor, so
+    every Freyd category factors through the centre of its computation
+    category ([Freyd_Centre] below, through [Effectful_Centre]).  Since
+    the centre is monoidal ([Centre_Monoidal]), the value category of a
+    Freyd category always maps into a monoidal subcategory of K. *)
+
+Definition Freyd_Effectful {J : V ⟶ K} (F : Freyd J) :
+  @EffectfulFunctor V K BK J :=
+  @Build_EffectfulFunctor V K BK J
+    (fun (x y : V) (f : x ~{V}~> y) => @freyd_central J F x y f).
+
+Definition Freyd_Centre {J : V ⟶ K} (F : Freyd J) : V ⟶ Centre K :=
+  @Effectful_Centre V K BK J (Freyd_Effectful F).
+
+End Freyd.
+
+(** ** The flagship instance: the Kleisli category of a strong monad
+
+    Power–Robinson's motivating example.  For a strong monad M on a
+    symmetric monoidal C, the pure functor [Kleisli_Pure] : C ⟶ Kl(M)
+    is the identity on objects — [obj Kl(M)] is definitionally [obj C] —
+    so the section is the identity and every object equality is
+    [eq_refl].  All casts in the morphism-level fields therefore reduce
+    to [id], and the fields collapse to:
+
+      - the tensoring transfer laws [pure_inj_left]/[pure_inj_right] of
+        Monad/Kleisli/Premonoidal.v (the η-compat laws of the two
+        strengths, packaged);
+      - reflexivity-level agreements for the unitors and associator,
+        because the structural isomorphisms of [Kleisli_Premonoidal] are
+        BY CONSTRUCTION the [kpure] images of C's.
+
+    Centrality of the image is [pure_central] — the four double-strength
+    unit laws of Monad/Strong/Symmetric.v, needing no commutativity. *)
+
+Section FreydKleisli.
+
+Context `{@SymmetricMonoidal C}.
+Context {M : C ⟶ C}.
+Context `{@StrongMonad C _ M}.
+
+Lemma Freyd_Kleisli_map_left {x y : C} (f : x ~{C}~> y) (z : C) :
+  @compose Kleisli _ _ _ id (fmap[Kleisli_Pure] (f ⨂ id[z]))
+    ≈ @compose Kleisli _ _ _
+        (fmap[@inj_left Kleisli Kleisli_Binoidal z] (fmap[Kleisli_Pure] f))
+        id.
+Proof.
+  rewrite id_left, id_right.
+  symmetry.
+  apply pure_inj_left.
+Qed.
+
+Lemma Freyd_Kleisli_map_right {x y : C} (f : x ~{C}~> y) (z : C) :
+  @compose Kleisli _ _ _ id (fmap[Kleisli_Pure] (id[z] ⨂ f))
+    ≈ @compose Kleisli _ _ _
+        (fmap[@inj_right Kleisli Kleisli_Binoidal z] (fmap[Kleisli_Pure] f))
+        id.
+Proof.
+  rewrite id_left, id_right.
+  symmetry.
+  apply pure_inj_right.
+Qed.
+
+Lemma Freyd_Kleisli_unit_left {x : C} :
+  fmap[Kleisli_Pure] (to (@unit_left C _ x))
+    ≈ @compose Kleisli _ _ _
+        (to (@premon_unit_left Kleisli Kleisli_Binoidal Kleisli_Premonoidal x))
+        id.
+Proof. now rewrite id_right. Qed.
+
+Lemma Freyd_Kleisli_unit_right {x : C} :
+  fmap[Kleisli_Pure] (to (@unit_right C _ x))
+    ≈ @compose Kleisli _ _ _
+        (to (@premon_unit_right Kleisli Kleisli_Binoidal Kleisli_Premonoidal x))
+        id.
+Proof. now rewrite id_right. Qed.
+
+Lemma Freyd_Kleisli_assoc {x y z : C} :
+  @compose Kleisli _ _ _ id (fmap[Kleisli_Pure] (to (@tensor_assoc C _ x y z)))
+    ≈ @compose Kleisli _ _ _
+        (to (@premon_assoc Kleisli Kleisli_Binoidal Kleisli_Premonoidal x y z))
+        id.
+Proof. now rewrite id_left, id_right. Qed.
+
+Definition Freyd_Kleisli :
+  @Freyd C Kleisli _ Kleisli_Binoidal Kleisli_Premonoidal Kleisli_Pure :=
+  @Build_Freyd C Kleisli _ Kleisli_Binoidal Kleisli_Premonoidal Kleisli_Pure
+    (fun (x y : C) (f : x ~{C}~> y) => pure_central f)
+    (fun k : Kleisli => (k : C))
+    (fun k : Kleisli => eq_refl)
+    (fun v : C => eq_refl)
+    eq_refl
+    (fun x y : C => eq_refl)
+    (fun (x y : C) (f : x ~{C}~> y) (z : C) => Freyd_Kleisli_map_left f z)
+    (fun (x y : C) (f : x ~{C}~> y) (z : C) => Freyd_Kleisli_map_right f z)
+    (fun x : C => Freyd_Kleisli_unit_left)
+    (fun x : C => Freyd_Kleisli_unit_right)
+    (fun x y z : C => Freyd_Kleisli_assoc).
+
+End FreydKleisli.
+
+(** ** The degenerate instance: a monoidal category over itself
+
+    Every monoidal category is a Freyd category over its own premonoidal
+    reading (Structure/Premonoidal/Monoidal.v), with J the identity
+    functor: the identity is bijective on objects on the nose, the
+    binoidal tensor of [Monoidal_Binoidal] is definitionally the
+    monoidal one, and every morphism is central by
+    [Monoidal_all_central].  With a cartesian monoidal V this is the
+    classical base point of the Freyd-category hierarchy: the effect-free
+    computation category is the value category itself. *)
+
+Section FreydId.
+
+Context {V : Category}.
+Context `{MV : @Monoidal V}.
+
+Lemma Freyd_Id_map_left {x y : V} (f : x ~{V}~> y) (z : V) :
+  id ∘ fmap[Id[V]] (f ⨂ id[z])
+    ≈ fmap[@inj_left V (@Monoidal_Binoidal V MV) z] (fmap[Id[V]] f) ∘ id.
+Proof. now rewrite id_left, id_right. Qed.
+
+Lemma Freyd_Id_map_right {x y : V} (f : x ~{V}~> y) (z : V) :
+  id ∘ fmap[Id[V]] (id[z] ⨂ f)
+    ≈ fmap[@inj_right V (@Monoidal_Binoidal V MV) z] (fmap[Id[V]] f) ∘ id.
+Proof. now rewrite id_left, id_right. Qed.
+
+Lemma Freyd_Id_unit_left {x : V} :
+  fmap[Id[V]] (to (@unit_left V MV x))
+    ≈ to (@premon_unit_left V (@Monoidal_Binoidal V MV)
+            (@Monoidal_Premonoidal V MV) x) ∘ id.
+Proof. now rewrite id_right. Qed.
+
+Lemma Freyd_Id_unit_right {x : V} :
+  fmap[Id[V]] (to (@unit_right V MV x))
+    ≈ to (@premon_unit_right V (@Monoidal_Binoidal V MV)
+            (@Monoidal_Premonoidal V MV) x) ∘ id.
+Proof. now rewrite id_right. Qed.
+
+Lemma Freyd_Id_assoc {x y z : V} :
+  id ∘ fmap[Id[V]] (to (@tensor_assoc V MV x y z))
+    ≈ to (@premon_assoc V (@Monoidal_Binoidal V MV)
+            (@Monoidal_Premonoidal V MV) x y z) ∘ id.
+Proof. now rewrite id_left, id_right. Qed.
+
+Definition Freyd_Id :
+  @Freyd V V MV (@Monoidal_Binoidal V MV) (@Monoidal_Premonoidal V MV)
+    (Id[V]) :=
+  @Build_Freyd V V MV (@Monoidal_Binoidal V MV) (@Monoidal_Premonoidal V MV)
+    (Id[V])
+    (fun (x y : V) (f : x ~{V}~> y) => @Monoidal_all_central V MV x y f)
+    (fun v : V => v)
+    (fun v : V => eq_refl)
+    (fun v : V => eq_refl)
+    eq_refl
+    (fun x y : V => eq_refl)
+    (fun (x y : V) (f : x ~{V}~> y) (z : V) => Freyd_Id_map_left f z)
+    (fun (x y : V) (f : x ~{V}~> y) (z : V) => Freyd_Id_map_right f z)
+    (fun x : V => Freyd_Id_unit_left)
+    (fun x : V => Freyd_Id_unit_right)
+    (fun x y z : V => Freyd_Id_assoc).
+
+End FreydId.

--- a/Structure/Premonoidal/Monoidal.v
+++ b/Structure/Premonoidal/Monoidal.v
@@ -152,9 +152,9 @@ Proof.
 Qed.
 
 (* The interleaved binoidal tensor over [Monoidal_Binoidal] agrees with
-   the monoidal [bimap]; recorded here because downstream instances
-   (e.g. Structure/Premonoidal/Freyd.v's identity example) rewrite
-   between the two spellings. *)
+   the monoidal [bimap]; recorded as the bridge between the binoidal
+   [composite_ff'] spelling and the monoidal [bimap] spelling of
+   tensoring a pair of morphisms. *)
 Lemma Monoidal_composite_ff' {x x' y y' : C} (f : x ~> y) (f' : x' ~> y') :
   @composite_ff' C Monoidal_Binoidal x x' y y' f f' ≈ f ⨂ f'.
 Proof. exact (bimap_id_left_right f' f). Qed.
@@ -303,8 +303,8 @@ Definition Premonoidal_Monoidal : @Monoidal C :=
     (fun x y z w => premon_pentagon_ff').
 
 (* The induced monoidal tensor acts on morphism pairs exactly by
-   [composite_ff']; the agreement is definitional and recorded for
-   downstream rewriting. *)
+   [composite_ff']; the agreement is definitional, recorded here as
+   the explicit bridge between the two spellings. *)
 Corollary Premonoidal_Monoidal_bimap {x x' y y' : C}
           (f : x ~> y) (f' : x' ~> y') :
   f ⨂[Premonoidal_Monoidal] f' ≈ composite_ff' f f'.

--- a/Structure/Premonoidal/Monoidal.v
+++ b/Structure/Premonoidal/Monoidal.v
@@ -1,0 +1,313 @@
+Set Warnings "-notation-overridden".
+
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Construction.Product.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Structure.Binoidal.
+Require Import Category.Structure.Binoidal.Central.
+Require Import Category.Structure.Premonoidal.
+
+Generalizable All Variables.
+Set Primitive Projections.
+Set Universe Polymorphism.
+Set Transparent Obligations.
+
+(** * Monoidal categories versus premonoidal categories
+
+    nLab: https://ncatlab.org/nlab/show/premonoidal+category
+    Wikipedia: https://en.wikipedia.org/wiki/Premonoidal_category
+
+    Power–Robinson ("Premonoidal categories and notions of computation",
+    Math. Structures Comput. Sci. 7(5), 1997) observe that a monoidal
+    category is precisely a premonoidal category in which every morphism
+    is central.  This file delivers both directions of that comparison.
+
+    Direction 1 ([Monoidal_Premonoidal]).  A monoidal structure on [C]
+    restricts to a binoidal one, [Monoidal_Binoidal]: the two one-sided
+    tensoring functors are the partial applications [- ⨂ w] and [w ⨂ -]
+    of the tensor bifunctor, packaged as [AFunctor]s so that the object
+    maps stay definitionally the monoidal tensor.  The middle-four
+    interchange laws of a bifunctor ([bimap_id_right_left] /
+    [bimap_id_left_right]) say exactly that the two orders of tensoring
+    a pair of morphisms agree, so EVERY morphism is central
+    ([Monoidal_all_central]).  The monoidal unitors and associator then
+    populate a premonoidal structure field-for-field: the one-variable
+    naturality squares are instances of the joint ones with identities
+    in the untouched positions, and triangle/pentagon carry over
+    verbatim.
+
+    Direction 2 ([Premonoidal_Monoidal], the all-central engine).  In a
+    premonoidal category together with a witness that every morphism is
+    central, the interleaved tensor [composite_ff'] becomes a genuine
+    bifunctor [Premonoidal_Tensor] on [C ∏ C]: interchange in the middle
+    of [fmap_comp] is discharged by [composite_ff'_comp_l], the single
+    point where the centrality witness is consumed.  All remaining
+    [Build_Monoidal] fields are the [composite_ff']-phrased corollaries
+    already derived in Structure/Premonoidal.v — in particular the joint
+    associator naturality [premon_joint_assoc_natural], which needs no
+    centrality at all.
+
+    Downstream, Direction 2 is the funnel that makes the Kleisli
+    category of a commutative strong monad monoidal
+    (Monad/Kleisli/Commutative.v), and Direction 1 supplies the
+    premonoidal reading of a monoidal base category used by Freyd
+    categories (Structure/Premonoidal/Freyd.v). *)
+
+(** ** Direction 1: a monoidal category is premonoidal *)
+
+Section MonoidalPremonoidal.
+
+Context {C : Category}.
+Context `{M : @Monoidal C}.
+
+(** *** The one-sided tensoring functors
+
+    [Monoidal_Tensor_Left w] is [- ⨂ w] and [Monoidal_Tensor_Right w]
+    is [w ⨂ -], each an [AFunctor] over the stated object map so that
+    the binoidal tensor below is definitionally the monoidal one.  The
+    functor laws are the one-variable specializations of bifunctor
+    functoriality ([bimap_id_id], [bimap_comp_id_right] /
+    [bimap_comp_id_left]). *)
+
+Lemma Monoidal_Tensor_Left_respects (w x y : C) :
+  Proper (equiv ==> equiv) (fun f : x ~> y => f ⨂ id[w]).
+Proof.
+  intros f g E.
+  apply bimap_respects; [assumption|reflexivity].
+Qed.
+
+Lemma Monoidal_Tensor_Left_id (w x : C) :
+  id[x] ⨂ id[w] ≈ id[(x ⨂ w)%object].
+Proof. apply bimap_id_id. Qed.
+
+Lemma Monoidal_Tensor_Left_comp (w : C) {x y z : C}
+      (f : y ~> z) (g : x ~> y) :
+  (f ∘ g) ⨂ id[w] ≈ (f ⨂ id[w]) ∘ (g ⨂ id[w]).
+Proof. apply bimap_comp_id_right. Qed.
+
+Definition Monoidal_Tensor_Left (w : C) :
+  @AFunctor C C (fun x : C => (x ⨂ w)%object) :=
+  @Build_AFunctor C C (fun x : C => (x ⨂ w)%object)
+    (fun x y (f : x ~> y) => f ⨂ id[w])
+    (fun x y => Monoidal_Tensor_Left_respects w x y)
+    (fun x => Monoidal_Tensor_Left_id w x)
+    (fun x y z f g => Monoidal_Tensor_Left_comp w f g).
+
+Lemma Monoidal_Tensor_Right_respects (w y z : C) :
+  Proper (equiv ==> equiv) (fun f : y ~> z => id[w] ⨂ f).
+Proof.
+  intros f g E.
+  apply bimap_respects; [reflexivity|assumption].
+Qed.
+
+Lemma Monoidal_Tensor_Right_id (w y : C) :
+  id[w] ⨂ id[y] ≈ id[(w ⨂ y)%object].
+Proof. apply bimap_id_id. Qed.
+
+Lemma Monoidal_Tensor_Right_comp (w : C) {x y z : C}
+      (f : y ~> z) (g : x ~> y) :
+  id[w] ⨂ (f ∘ g) ≈ (id[w] ⨂ f) ∘ (id[w] ⨂ g).
+Proof. apply bimap_comp_id_left. Qed.
+
+Definition Monoidal_Tensor_Right (w : C) :
+  @AFunctor C C (fun y : C => (w ⨂ y)%object) :=
+  @Build_AFunctor C C (fun y : C => (w ⨂ y)%object)
+    (fun y z (f : y ~> z) => id[w] ⨂ f)
+    (fun y z => Monoidal_Tensor_Right_respects w y z)
+    (fun y => Monoidal_Tensor_Right_id w y)
+    (fun x y z f g => Monoidal_Tensor_Right_comp w f g).
+
+Definition Monoidal_Binoidal : @Binoidal C :=
+  @Build_Binoidal C
+    (fun x y : C => (x ⨂ y)%object)
+    Monoidal_Tensor_Left
+    Monoidal_Tensor_Right.
+
+(** *** Every morphism of a monoidal category is central
+
+    Under [Monoidal_Binoidal] the tensorings of [f] and [f'] in the two
+    orders are [bimap f id ∘ bimap id f'] and [bimap id f' ∘ bimap f id];
+    both reduce to [bimap f f'] by the middle-four interchange, so the
+    two defining squares of [central] are a single lemma applied twice
+    with the roles of [f] and [f'] exchanged. *)
+
+Lemma Monoidal_central_square {x y x' y' : C} (f : x ~> y) (f' : x' ~> y') :
+  (f ⨂ id[y']) ∘ (id[x] ⨂ f') ≈ (id[y] ⨂ f') ∘ (f ⨂ id[x']).
+Proof.
+  rewrite bimap_id_right_left.
+  rewrite bimap_id_left_right.
+  reflexivity.
+Qed.
+
+Lemma Monoidal_all_central {x y : C} (f : x ~> y) :
+  @central C Monoidal_Binoidal x y f.
+Proof.
+  intros x' y' f'; split.
+  - exact (Monoidal_central_square f f').
+  - exact (Monoidal_central_square f' f).
+Qed.
+
+(* The interleaved binoidal tensor over [Monoidal_Binoidal] agrees with
+   the monoidal [bimap]; recorded here because downstream instances
+   (e.g. Structure/Premonoidal/Freyd.v's identity example) rewrite
+   between the two spellings. *)
+Lemma Monoidal_composite_ff' {x x' y y' : C} (f : x ~> y) (f' : x' ~> y') :
+  @composite_ff' C Monoidal_Binoidal x x' y y' f f' ≈ f ⨂ f'.
+Proof. exact (bimap_id_left_right f' f). Qed.
+
+(** *** One-variable associator naturality
+
+    Each of the three premonoidal associator squares is the joint square
+    [to_tensor_assoc_natural] with identities in the two untouched
+    positions.  For the left and right squares one [bimap id id ≈ id]
+    cleanup aligns the identity-padded corner with the plain identity of
+    the compound object; the middle square is on the nose. *)
+
+Lemma Monoidal_assoc_natural_left {x y z w : C} (g : x ~> y) :
+  (g ⨂ id[(z ⨂ w)%object]) ∘ to (@tensor_assoc C M x z w)
+    ≈ to (@tensor_assoc C M y z w) ∘ ((g ⨂ id[z]) ⨂ id[w]).
+Proof.
+  transitivity ((g ⨂ (id[z] ⨂ id[w])) ∘ to (@tensor_assoc C M x z w)).
+  - apply compose_respects; [|reflexivity].
+    apply bimap_respects; [reflexivity|].
+    symmetry; apply bimap_id_id.
+  - apply to_tensor_assoc_natural.
+Qed.
+
+Lemma Monoidal_assoc_natural_right {x y z w : C} (i : z ~> w) :
+  (id[x] ⨂ (id[y] ⨂ i)) ∘ to (@tensor_assoc C M x y z)
+    ≈ to (@tensor_assoc C M x y w) ∘ (id[(x ⨂ y)%object] ⨂ i).
+Proof.
+  transitivity (to (@tensor_assoc C M x y w) ∘ ((id[x] ⨂ id[y]) ⨂ i)).
+  - apply to_tensor_assoc_natural.
+  - apply compose_respects; [reflexivity|].
+    apply bimap_respects; [|reflexivity].
+    apply bimap_id_id.
+Qed.
+
+(** *** The premonoidal structure of a monoidal category
+
+    Every field is the corresponding monoidal datum: the unit, unitors
+    and associator are shared, centrality of the structural maps is the
+    all-central lemma, the unitor naturality squares and the coherence
+    laws coincide definitionally (the binoidal ⋉ / ⋊ over
+    [Monoidal_Binoidal] reduce to [bimap] with an identity), and the
+    associator squares are the one-variable lemmas above. *)
+
+Definition Monoidal_Premonoidal : @Premonoidal C Monoidal_Binoidal :=
+  @Build_Premonoidal C Monoidal_Binoidal
+    (@I C M)
+    (fun x => @unit_left C M x)
+    (fun x => @unit_right C M x)
+    (fun x y z => @tensor_assoc C M x y z)
+    (fun x => Monoidal_all_central (to (@unit_left C M x)))
+    (fun x => Monoidal_all_central (to (@unit_right C M x)))
+    (fun x y z => Monoidal_all_central (to (@tensor_assoc C M x y z)))
+    (fun x y g => to_unit_left_natural g)
+    (fun x y g => to_unit_right_natural g)
+    (fun x y z w g => Monoidal_assoc_natural_left g)
+    (fun x z w y h => to_tensor_assoc_natural (id[x]) h (id[y]))
+    (fun x y z w i => Monoidal_assoc_natural_right i)
+    (fun x y => triangle_identity)
+    (fun x y z w => pentagon_identity).
+
+End MonoidalPremonoidal.
+
+(** ** Direction 2: an all-central premonoidal category is monoidal
+
+    The converse engine.  [all_central] is taken as an explicit
+    hypothesis rather than a class field so that consumers can
+    instantiate it with a computed witness — Monad/Kleisli/Commutative.v
+    applies it with the centrality of all Kleisli morphisms of a
+    commutative strong monad, and Structure/Premonoidal/Centre.v uses
+    the same recipe with `1-projections for the centre. *)
+
+Section AllCentralMonoidal.
+
+Context {C : Category}.
+Context `{B : @Binoidal C}.
+Context `{P : @Premonoidal C B}.
+
+Variable all_central : ∀ (x y : C) (f : x ~> y), central f.
+
+(** *** The tensor bifunctor
+
+    On objects the tensor is the binoidal one; on morphisms it is the
+    interleaved composite [composite_ff'].  Identity preservation is
+    [composite_id_left] plus functoriality of the one-sided tensoring;
+    composition preservation is the one-sided interchange
+    [composite_ff'_comp_l], whose centrality hypothesis is the sole use
+    of [all_central]. *)
+
+Lemma Premonoidal_Tensor_respects (x y : C ∏ C) :
+  Proper (equiv ==> equiv)
+         (fun fg : x ~{C ∏ C}~> y => composite_ff' (fst fg) (snd fg)).
+Proof.
+  intros f g E.
+  destruct E as [E1 E2].
+  now rewrite E1, E2.
+Qed.
+
+Lemma Premonoidal_Tensor_id (x : C ∏ C) :
+  composite_ff' (id[fst x]) (id[snd x]) ≈ id[(fst x ⊗ snd x)%object].
+Proof.
+  rewrite composite_id_left.
+  exact (@fmap_id C C (@inj_right C B (fst x)) (snd x)).
+Qed.
+
+Lemma Premonoidal_Tensor_comp {x y z : C ∏ C}
+      (f : y ~{C ∏ C}~> z) (g : x ~{C ∏ C}~> y) :
+  composite_ff' (fst f ∘ fst g) (snd f ∘ snd g)
+    ≈ composite_ff' (fst f) (snd f) ∘ composite_ff' (fst g) (snd g).
+Proof using all_central.
+  apply composite_ff'_comp_l.
+  apply all_central.
+Qed.
+
+Definition Premonoidal_Tensor : (C ∏ C) ⟶ C :=
+  @Build_Functor (C ∏ C) C
+    (fun p => (fst p ⊗ snd p)%object)
+    (fun x y (fg : x ~{C ∏ C}~> y) => composite_ff' (fst fg) (snd fg))
+    Premonoidal_Tensor_respects
+    Premonoidal_Tensor_id
+    (fun x y z f g => Premonoidal_Tensor_comp f g).
+
+(** *** The monoidal structure
+
+    With [bimap] over [Premonoidal_Tensor] definitionally equal to
+    [composite_ff'], every [Build_Monoidal] field is one of the
+    [composite_ff']-phrased corollaries of Structure/Premonoidal.v: the
+    identity-padded unitor squares and their from-forms, the joint
+    associator squares (derived there from the three one-variable ones
+    with no centrality hypothesis), and the padded triangle and
+    pentagon. *)
+
+Definition Premonoidal_Monoidal : @Monoidal C :=
+  @Build_Monoidal C
+    (@premon_I C B P)
+    Premonoidal_Tensor
+    (fun x => @premon_unit_left C B P x)
+    (fun x => @premon_unit_right C B P x)
+    (fun x y z => @premon_assoc C B P x y z)
+    (fun x y g => premon_unit_left_natural_ff' g)
+    (fun x y g => premon_unit_left_natural_from_ff' g)
+    (fun x y g => premon_unit_right_natural_ff' g)
+    (fun x y g => premon_unit_right_natural_from_ff' g)
+    (fun x y z w v u g h i => premon_joint_assoc_natural g h i)
+    (fun x y z w v u g h i => premon_joint_assoc_natural_from g h i)
+    (fun x y => premon_triangle_ff')
+    (fun x y z w => premon_pentagon_ff').
+
+(* The induced monoidal tensor acts on morphism pairs exactly by
+   [composite_ff']; the agreement is definitional and recorded for
+   downstream rewriting. *)
+Corollary Premonoidal_Monoidal_bimap {x x' y y' : C}
+          (f : x ~> y) (f' : x' ~> y') :
+  f ⨂[Premonoidal_Monoidal] f' ≈ composite_ff' f f'.
+Proof. reflexivity. Qed.
+
+End AllCentralMonoidal.

--- a/_CoqProject
+++ b/_CoqProject
@@ -199,6 +199,7 @@ Monad/Eilenberg/Moore.v
 Monad/Graded.v
 Monad/Kleisli.v
 Monad/Kleisli/Premonoidal.v
+Monad/Kleisli/Commutative.v
 Monad/Monoid.v
 Monad/Strong.v
 Monad/Strong/Symmetric.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -222,6 +222,7 @@ Structure/Binoidal/Central.v
 Structure/Premonoidal.v
 Structure/Premonoidal/Monoidal.v
 Structure/Premonoidal/Centre.v
+Structure/Premonoidal/Freyd.v
 Structure/Cartesian.v
 Structure/Cartesian/Closed.v
 Structure/Cartesian/Closed/Product.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -198,6 +198,7 @@ Monad/Distributive.v
 Monad/Eilenberg/Moore.v
 Monad/Graded.v
 Monad/Kleisli.v
+Monad/Kleisli/Premonoidal.v
 Monad/Monoid.v
 Monad/Strong.v
 Monad/Strong/Symmetric.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -216,6 +216,7 @@ Structure/BiCCC.v
 Structure/Bicartesian.v
 Structure/Binoidal.v
 Structure/Binoidal/Central.v
+Structure/Premonoidal.v
 Structure/Cartesian.v
 Structure/Cartesian/Closed.v
 Structure/Cartesian/Closed/Product.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -218,6 +218,7 @@ Structure/Binoidal.v
 Structure/Binoidal/Central.v
 Structure/Premonoidal.v
 Structure/Premonoidal/Monoidal.v
+Structure/Premonoidal/Centre.v
 Structure/Cartesian.v
 Structure/Cartesian/Closed.v
 Structure/Cartesian/Closed/Product.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -196,6 +196,7 @@ Monad/Algebra.v
 Monad/Compose.v
 Monad/Distributive.v
 Monad/Eilenberg/Moore.v
+Monad/Graded.v
 Monad/Kleisli.v
 Monad/Monoid.v
 Monad/Strong.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -203,6 +203,7 @@ Monad/Kleisli/Commutative.v
 Monad/Monoid.v
 Monad/Strong.v
 Monad/Strong/Symmetric.v
+Monad/Thunkable.v
 Monad/Transformer.v
 Natural/Transformation/Applicative.v
 Natural/Transformation/Monoidal.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -198,6 +198,7 @@ Monad/Eilenberg/Moore.v
 Monad/Kleisli.v
 Monad/Monoid.v
 Monad/Strong.v
+Monad/Strong/Symmetric.v
 Monad/Transformer.v
 Natural/Transformation/Applicative.v
 Natural/Transformation/Monoidal.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -131,6 +131,7 @@ Instance/StrictCat.v
 Instance/StrictCat/ToCat.v
 Instance/StrictCat/Terminal.v
 Instance/StrictCat/Funny.v
+Instance/StrictCat/Premonoid.v
 Instance/Comp.v
 Instance/Cones.v
 Instance/Cones/Comma.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -217,6 +217,7 @@ Structure/Bicartesian.v
 Structure/Binoidal.v
 Structure/Binoidal/Central.v
 Structure/Premonoidal.v
+Structure/Premonoidal/Monoidal.v
 Structure/Cartesian.v
 Structure/Cartesian/Closed.v
 Structure/Cartesian/Closed/Product.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -212,6 +212,7 @@ Solver/Reify.v
 Structure/BiCCC.v
 Structure/Bicartesian.v
 Structure/Binoidal.v
+Structure/Binoidal/Central.v
 Structure/Cartesian.v
 Structure/Cartesian/Closed.v
 Structure/Cartesian/Closed/Product.v


### PR DESCRIPTION
## Summary

Final PR of the stack (base: `johnw/ct-phase3`). 11 new files, 13 commits, built to a 48-item completion checklist.

- `Structure/Binoidal/Central.v` + `Structure/Premonoidal.v` — the central-morphism kit, the centre `Z(C)` as a wide subcategory, and the Premonoidal class over the existing `Binoidal.v` (from-forms and joint naturality derived, not axiomatized)
- `Premonoidal/Monoidal.v` + `Premonoidal/Centre.v` — Monoidal ⟺ all-central premonoidal (both directions, the converse assembling all fourteen fields), and `Z(C)` is monoidal — discharging the promise recorded in `Binoidal.v`
- `Monad/Strong/Symmetric.v` — packages the derived right strength as a full `RightStrongFunctor`/`RightStrongMonad`, using Phase 1's braid-unitor coherences to prove exactly the laws `Monad/Strong.v`'s closing note said were unavailable (that note is now updated), plus the bidirectional `commutative_sm` ⟷ `CommutativeStrongMonad` bridge
- `Monad/Kleisli/Premonoidal.v` + `Commutative.v` — Power–Robinson: `Kl(M)` is premonoidal for any strong monad, pure morphisms central; commutative ⟺ all-central, yielding Monoidal/Braided/Symmetric structure and a transferred CopyDiscard supply on `Kl(M)`
- `Monad/Thunkable.v` — Führmann: pure ⇒ thunkable ⇒ central unconditionally; the wide subcategory `Thunk`; thunkable ⇒ deterministic for the transferred Kleisli supply (bridging to Phase 1)
- `Structure/Premonoidal/Freyd.v` — effectful functors and Freyd categories, with the Kleisli structure as flagship instance
- `Instance/StrictCat/Premonoid.v` — **strict premonoidal structure = monoid object in (StrictCat, □)**, the funny-tensor characterization, both directions with round trips
- `Monad/Graded.v` — graded monads with the degenerate-grading bridge to `Monad` and a concrete instance

## Verification

Qed-clean; all `Print Assumptions` closed; 48-item closure checklist verified complete on the first pass; adversarial review (17 findings → 8 confirmed, all comment-level, all fixed); campaign-wide no-holes audit; `make todo` silent; `nix build` + `flake check` green at this tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011k7xm8t5nbGeDDYvSpkuDP