### PR TITLE
Phase 6: comonad theory and monad resolutions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ Example: `f ∘[C] g` specifies category C when needed.
 - **Theory/Adjunction.v**: The most important concept - adjunctions
 - **Theory/Monad.v**: Monads as endofunctors with structure
 - **Monad/Strong.v**: Strong monads — a monad whose functor carries a tensorial strength compatible with η and μ (Kock/Moggi)
+- **Comonad/Core.v**: Covariant comonad API over the one-line `Comonad := @Monad (C^op) (M^op)` — extract/duplicate/extend as definitional op-reads; co-Kleisli category (Comonad/CoKleisli.v), co-Eilenberg-Moore coalgebras (Comonad/Coalgebra.v), costrength (Comonad/Strong.v), and the adjunction-induced comonad with co-resolutions by duality (Comonad/Duality.v); Env/Store/Traced instances in Instance/Coq/Comonad/. Monad resolutions: the Kleisli and Eilenberg-Moore free/forgetful adjunctions in Monad/Kleisli/Adjunction.v and Monad/Eilenberg/Moore/Adjunction.v
 - **Theory/Kan/Extension.v**: Universal property of Kan extensions
 - **Theory/Equivalence.v**: Equivalence of categories — quasi-inverse class with the Full+Faithful+essentially-surjective characterization (Equivalence/FullFaithful.v), adjoint equivalences (Equivalence/Adjoint.v), preservation/reflection/creation of limits and transport of adjunctions and monoidal structure along equivalences (Equivalence/{Limit,Adjunction,Monoidal,Bundled}.v); RAPL/LAPC in Adjunction/Continuity.v over the preservation vocabulary of Structure/Limit/Preservation.v; adjunction composition in Adjunction/Compose.v
 

--- a/Comonad/CoKleisli.v
+++ b/Comonad/CoKleisli.v
@@ -35,11 +35,14 @@ Generalizable All Variables.
    reflexivity, the covariant components of this construction are
    definitionally the expected ones: the hom-sets are literally
    W x ~{C}~> y ([cokleisli_hom], which holds by reflexivity), the identity
-   is literally [extract] ([cokleisli_id]), and composition is literally
-   f ∘ extend g ([cokleisli_compose_extend]).  The category laws, inherited
-   from Monad/Kleisli.v by duality and re-read covariantly, are the
-   co-Kleisli triple laws [extract_extend], [extend_extract] and
-   [extend_comp] of Comonad/Core.v; they appear below as [comonad_id_left],
+   is literally [extract] ([cokleisli_id]), and the categorical composite
+   [cokleisli_compose f g] (f after g) is literally f ∘ extend g.  The
+   fish operators name this the other way round: [f =>= g] runs the LEFT
+   operand first (Monad/Kleisli.v convention), so [f =>= g ≈ g ∘ extend f]
+   ([cokleisli_compose_extend]).  The category laws, inherited from
+   Monad/Kleisli.v by duality and re-read covariantly, are the co-Kleisli
+   triple laws [extract_extend], [extend_extract] and [extend_comp] of
+   Comonad/Core.v; they appear below as [comonad_id_left],
    [comonad_id_right] and [comonad_comp_assoc]. *)
 
 Section CoKleisli.

--- a/Comonad/CoKleisli.v
+++ b/Comonad/CoKleisli.v
@@ -1,0 +1,118 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Functor.
+Require Import Category.Theory.Monad.
+Require Import Category.Construction.Opposite.
+Require Import Category.Functor.Opposite.
+Require Import Category.Monad.Kleisli.
+Require Import Category.Comonad.Core.
+
+Generalizable All Variables.
+
+(** * The co-Kleisli category of a comonad *)
+
+(* nLab:      https://ncatlab.org/nlab/show/co-Kleisli+category
+   Wikipedia: https://en.wikipedia.org/wiki/Kleisli_category
+
+   The co-Kleisli category C_W of a comonad (W, extract, duplicate) =
+   (W, ε, δ) on C has the same objects as C, while a co-Kleisli morphism
+   x ⇸ y is an ordinary C-morphism W x ~> y.  The identity on x is the
+   counit extract (ε_x), and the co-Kleisli composite of f : W y ~> z after
+   g : W x ~> y is
+
+       f ∘_W g  ≈  f ∘ fmap[W] g ∘ duplicate    (f ∘ W g ∘ δ),
+
+   which is exactly f composed onto the extension of g (f ∘ extend g).
+
+   Since [Comonad C W] is by definition [@Monad (C^op) (W^op)], the
+   co-Kleisli category is obtained here as the opposite of the Kleisli
+   category of that opposite monad, rather than by re-proving the category
+   laws:
+
+       CoKleisli := (Kleisli (C^op) (W^op))^op
+
+   Because duality is built into this library so that C^op^op = C holds by
+   reflexivity, the covariant components of this construction are
+   definitionally the expected ones: the hom-sets are literally
+   W x ~{C}~> y ([cokleisli_hom], which holds by reflexivity), the identity
+   is literally [extract] ([cokleisli_id]), and composition is literally
+   f ∘ extend g ([cokleisli_compose_extend]).  The category laws, inherited
+   from Monad/Kleisli.v by duality and re-read covariantly, are the
+   co-Kleisli triple laws [extract_extend], [extend_extract] and
+   [extend_comp] of Comonad/Core.v; they appear below as [comonad_id_left],
+   [comonad_id_right] and [comonad_comp_assoc]. *)
+
+Section CoKleisli.
+
+Context {C : Category} {W : C ⟶ C} {H : @Comonad C W}.
+
+Definition CoKleisli : Category := (@Kleisli (C^op) (W^op) H)^op.
+
+(** The hom-sets of the co-Kleisli category are definitionally the
+    covariant hom-sets [W x ~> y] of the base category. *)
+Lemma cokleisli_hom (x y : C) : (x ~{CoKleisli}~> y) = (W x ~{C}~> y).
+Proof. reflexivity. Qed.
+
+(** The identity at x is the counit ε_x. *)
+Lemma cokleisli_id {x : C} : @id CoKleisli x ≈ @extract C W H x.
+Proof. reflexivity. Qed.
+
+Definition cokleisli_compose `(f : W b ~{C}~> c) `(g : W a ~{C}~> b) :
+  W a ~{C}~> c := @compose CoKleisli a b c f g.
+
+(* Co-Kleisli composition operators, following the library's fish-operator
+   convention (Monad/Kleisli.v [>=>]/[<=<]): in the right-pointing [=>=] the
+   LEFT operand runs first, so [f =>= g] extends [f] and then applies [g]
+   ([g ∘ extend f]).  Its transpose [f =<= g] runs the right operand first
+   ([f ∘ extend g]) — the co-Kleisli dual of [<=<].  This matches the
+   direction of [>=>] on the monad side rather than Haskell's Control.Comonad
+   [=>=], whose right-pointing operator runs the right operand first. *)
+Notation "f =>= g" :=
+  (cokleisli_compose g f) (at level 40, left associativity) : morphism_scope.
+Notation "f =<= g" :=
+  (cokleisli_compose f g) (at level 40, left associativity) : morphism_scope.
+
+(** Co-Kleisli composition agrees with the extension operator [extend] of
+    Comonad/Core.v; by the built-in duality the agreement is definitional.
+    [f] on the left runs first, so [f =>= g ≈ g ∘ extend f]. *)
+Lemma cokleisli_compose_extend `(f : W a ~{C}~> b) `(g : W b ~{C}~> c) :
+  f =>= g ≈ g ∘ extend f.
+Proof. reflexivity. Qed.
+
+Corollary cokleisli_compose_extend_flip
+  `(f : W b ~{C}~> c) `(g : W a ~{C}~> b) :
+  f =<= g ≈ f ∘ extend g.
+Proof. reflexivity. Qed.
+
+(* The comonad laws, re-expressed in terms of this category: dually to the
+   monoid reading in Monad/Kleisli.v, they exhibit [extract] as the unit of
+   co-Kleisli composition, with associativity mediated by [extend].  Each is
+   the corresponding category law of [CoKleisli], read across the definitional
+   agreements above. *)
+
+Corollary comonad_id_left `(f : W x ~{C}~> y) : extract =>= f ≈ f.
+Proof. unfold cokleisli_compose; cat. Qed.
+
+Corollary comonad_id_right `(f : W x ~{C}~> y) : f =>= extract ≈ f.
+Proof. unfold cokleisli_compose; cat. Qed.
+
+Corollary comonad_comp_assoc `(f : W x ~{C}~> y) `(g : W y ~{C}~> z)
+  `(h : W z ~{C}~> w) : f =>= (g =>= h) ≈ (f =>= g) =>= h.
+Proof. exact (@comp_assoc_sym CoKleisli x y z w h g f). Qed.
+
+End CoKleisli.
+
+Notation "f =>= g" :=
+  (cokleisli_compose g f)
+  (at level 40, left associativity) : morphism_scope.
+Notation "f =<= g" :=
+  (cokleisli_compose f g)
+  (at level 40, left associativity) : morphism_scope.
+
+(* Explicit-endofunctor forms, the robust fallback when higher-order
+   unification cannot infer [W] through the bare [=>=]/[=<=] holes
+   (Monad/Kleisli.v exports the analogous [>=[ M ]=>]/[<=[ M ]=<]). *)
+Notation "f =>[ W ]=> g" := (@cokleisli_compose _ W _ _ _ g _ f)
+  (at level 40, left associativity) : morphism_scope.
+Notation "f =<[ W ]=< g" := (@cokleisli_compose _ W _ _ _ f _ g)
+  (at level 40, left associativity) : morphism_scope.

--- a/Comonad/Coalgebra.v
+++ b/Comonad/Coalgebra.v
@@ -1,0 +1,251 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Theory.Monad.
+Require Import Category.Construction.Opposite.
+Require Import Category.Functor.Opposite.
+Require Import Category.Monad.Algebra.
+Require Import Category.Monad.Eilenberg.Moore.
+Require Import Category.Comonad.Core.
+Require Import Category.Instance.Cat.
+
+Generalizable All Variables.
+
+(** * Coalgebras over a comonad; the co-Eilenberg–Moore category *)
+
+(* nLab:      https://ncatlab.org/nlab/show/coalgebra+over+a+comonad
+   Wikipedia: https://en.wikipedia.org/wiki/Monad_(category_theory)#Comonads
+
+   For a comonad (W, extract, duplicate) = (W, ε, δ) on a category C — see
+   Comonad/Core.v for the covariant API — a W-coalgebra on an object a is a
+   costructure map γ : a ~> W a ([w_coalg]) satisfying the counit law
+   ε ∘ γ ≈ id ([w_counit_law]) and the coaction law W γ ∘ γ ≈ δ ∘ γ
+   ([w_coaction]).  A morphism of W-coalgebras (a, γ^a) ~> (b, γ^b) is a
+   C-morphism f : a ~> b intertwining the costructure maps,
+   γ^b ∘ f ≈ W f ∘ γ^a ([w_coalg_hom_commutes]).
+
+   Since [Comonad C W] is by definition [@Monad (C^op) (W^op)]
+   (Theory/Monad.v), a W-coalgebra is exactly an Eilenberg–Moore algebra
+   ([TAlgebra], Monad/Algebra.v) for that opposite monad, and the category
+   of W-coalgebras — the co-Eilenberg–Moore category C_W — is obtained
+   here, dually to Monad/Eilenberg/Moore.v, as the opposite of the
+   Eilenberg–Moore category of the opposite monad, rather than by
+   re-proving the category laws:
+
+       CoEilenbergMoore := (EilenbergMoore (W^op))^op
+
+   Because duality is built into this library so that C^op^op = C holds by
+   reflexivity, the two presentations agree definitionally: the classes
+   [WCoalgebra]/[WCoalgebraHom] below are covariant re-readings of
+   [TAlgebra]/[TAlgebraHom] over the opposite monad, converted in both
+   directions field by field with [exact] (no proofs are re-done), and the
+   hom-sets of [CoEilenbergMoore] are literally the algebra homomorphisms
+   of the opposite monad ([coeilenberg_moore_hom], which holds by
+   reflexivity).  The covariant category [WCoalgebras] assembled from the
+   classes below is isomorphic in Cat to [CoEilenbergMoore]
+   ([WCoalgebras_CoEilenbergMoore_Iso]); both functors are the identity on
+   carriers and underlying morphisms, and the natural isomorphisms
+   witnessing the two round trips have identity components. *)
+
+(* The covariant coalgebra class.  Its three fields are, definitionally,
+   the fields of [@TAlgebra (C^op) (W^op) H a]: the costructure map read
+   covariantly, the counit law as the op-read of [t_id] (whose [ret] is
+   [extract]), and the coaction law as the op-read of [t_action] (whose
+   [join] is [duplicate] and whose [fmap] is [fmap[W]], with each composite
+   read backwards).  See [WCoalgebra_to_TAlgebra] below. *)
+
+Class WCoalgebra {C : Category} (W : C ⟶ C) {H : @Comonad C W} (a : C) := {
+  w_coalg : a ~> W a;
+
+  w_counit_law : @extract C W H a ∘ w_coalg ≈ id;
+  w_coaction :
+    fmap[W] w_coalg ∘ w_coalg ≈ @duplicate C W H a ∘ w_coalg
+}.
+
+Notation "w_coalg[ F ]" := (@w_coalg _ _ _ _ F)
+  (at level 9, format "w_coalg[ F ]") : morphism_scope.
+
+(* A homomorphism of W-coalgebras: an underlying arrow f : a ~> b commuting
+   with the costructure maps, γ^b ∘ f ≈ W f ∘ γ^a.  Definitionally this is
+   [TAlgebraHom] over the opposite monad with source and target swapped
+   (the op-read reverses homs); see [WCoalgebraHom_to_TAlgebraHom]. *)
+
+Class WCoalgebraHom {C : Category} (W : C ⟶ C) {H : @Comonad C W}
+      (a b : C) (F : @WCoalgebra C W H a) (G : @WCoalgebra C W H b) := {
+  w_coalg_hom : a ~> b;
+
+  w_coalg_hom_commutes :
+    w_coalg[G] ∘ w_coalg_hom ≈ fmap[W] w_coalg_hom ∘ w_coalg[F]
+}.
+
+Notation "w_coalg_hom[ f ]" := (@w_coalg_hom _ _ _ _ _ _ _ f)
+  (at level 9, format "w_coalg_hom[ f ]") : morphism_scope.
+
+Section CoEilenbergMoore.
+
+Context {C : Category} {W : C ⟶ C} {H : @Comonad C W}.
+
+(** ** Definitional conversions with algebras over the opposite monad
+
+    Each conversion transports every field by [exact]: the statements are
+    definitionally equal, so no equational reasoning is involved. *)
+
+Definition WCoalgebra_to_TAlgebra {a : C} (F : @WCoalgebra C W H a) :
+  @TAlgebra (C^op) (W^op) H a :=
+  @Build_TAlgebra (C^op) (W^op) H a
+    (@w_coalg C W H a F)
+    (@w_counit_law C W H a F)
+    (@w_coaction C W H a F).
+
+Definition TAlgebra_to_WCoalgebra {a : C} (F : @TAlgebra (C^op) (W^op) H a) :
+  @WCoalgebra C W H a :=
+  @Build_WCoalgebra C W H a
+    (@t_alg (C^op) (W^op) H a F)
+    (@t_id (C^op) (W^op) H a F)
+    (@t_action (C^op) (W^op) H a F).
+
+(** The costructure map is untouched by the round trip (and likewise in the
+    other direction): the conversions only repackage fields. *)
+
+Lemma WCoalgebra_to_TAlgebra_alg {a : C} (F : @WCoalgebra C W H a) :
+  t_alg[WCoalgebra_to_TAlgebra F] ≈ w_coalg[F].
+Proof. reflexivity. Qed.
+
+Lemma TAlgebra_to_WCoalgebra_coalg {a : C} (F : @TAlgebra (C^op) (W^op) H a) :
+  w_coalg[TAlgebra_to_WCoalgebra F] ≈ t_alg[F].
+Proof. reflexivity. Qed.
+
+(* A coalgebra homomorphism (a, γ^a) ~> (b, γ^b) is an algebra homomorphism
+   over the opposite monad from (b, γ^b) to (a, γ^a): the op-read reverses
+   the direction of the underlying arrow, while the commuting square is the
+   same C-equation. *)
+
+Definition WCoalgebraHom_to_TAlgebraHom {a b : C}
+  {F : @WCoalgebra C W H a} {G : @WCoalgebra C W H b}
+  (f : @WCoalgebraHom C W H a b F G) :
+  @TAlgebraHom (C^op) (W^op) H b a
+    (WCoalgebra_to_TAlgebra G) (WCoalgebra_to_TAlgebra F) :=
+  @Build_TAlgebraHom (C^op) (W^op) H b a
+    (WCoalgebra_to_TAlgebra G) (WCoalgebra_to_TAlgebra F)
+    (@w_coalg_hom C W H a b F G f)
+    (@w_coalg_hom_commutes C W H a b F G f).
+
+Definition TAlgebraHom_to_WCoalgebraHom {a b : C}
+  {F : @TAlgebra (C^op) (W^op) H a} {G : @TAlgebra (C^op) (W^op) H b}
+  (f : @TAlgebraHom (C^op) (W^op) H b a G F) :
+  @WCoalgebraHom C W H a b
+    (TAlgebra_to_WCoalgebra F) (TAlgebra_to_WCoalgebra G) :=
+  @Build_WCoalgebraHom C W H a b
+    (TAlgebra_to_WCoalgebra F) (TAlgebra_to_WCoalgebra G)
+    (@t_alg_hom (C^op) (W^op) H b a G F f)
+    (@t_alg_hom_commutes (C^op) (W^op) H b a G F f).
+
+(** ** The co-Eilenberg–Moore category, by duality *)
+
+Definition CoEilenbergMoore : Category :=
+  (@EilenbergMoore (C^op) (W^op) H)^op.
+
+(** The hom-sets of the co-Eilenberg–Moore category are definitionally the
+    algebra homomorphisms of the opposite monad, source and target
+    swapped. *)
+
+Lemma coeilenberg_moore_hom (x y : CoEilenbergMoore) :
+  (x ~{CoEilenbergMoore}~> y) =
+  @TAlgebraHom (C^op) (W^op) H ``y ``x (projT2 y) (projT2 x).
+Proof. reflexivity. Qed.
+
+(** ** The covariant category of W-coalgebras
+
+    Mirrors Monad/Eilenberg/Moore.v: objects are pairs of a carrier and a
+    coalgebra on it, morphisms are coalgebra homomorphisms compared on
+    their underlying arrows, and identities and composition are inherited
+    from C.  The composition obligation pastes the two commuting squares,
+    dually to the corresponding obligation there. *)
+
+Program Definition WCoalgebras : Category := {|
+  obj     := ∃ a : C, @WCoalgebra C W H a;
+  hom     := fun x y => @WCoalgebraHom C W H ``x ``y (projT2 x) (projT2 y);
+  homset  := fun _ _ => {| equiv := fun f g => w_coalg_hom[f] ≈ w_coalg_hom[g] |};
+  id      := fun _ => {| w_coalg_hom := id |};
+  compose := fun _ _ _ f g => {| w_coalg_hom := w_coalg_hom[f] ∘ w_coalg_hom[g] |}
+|}.
+Next Obligation.
+  rewrite fmap_comp.
+  rewrite comp_assoc.
+  rewrite w_coalg_hom_commutes.
+  rewrite <- comp_assoc.
+  rewrite w_coalg_hom_commutes.
+  now rewrite comp_assoc.
+Qed.
+
+(** ** The isomorphism of categories, in Cat
+
+    Both functors keep the carrier and the underlying arrow fixed and
+    convert the packaging; on hom-setoids they are the identity.  The two
+    round trips are witnessed by natural isomorphisms whose components
+    have identity underlying arrows. *)
+
+#[local] Obligation Tactic := program_simpl.
+
+Program Definition WCoalgebras_to_CoEM : WCoalgebras ⟶ CoEilenbergMoore := {|
+  fobj := fun x => (``x; WCoalgebra_to_TAlgebra (projT2 x));
+  fmap := fun x y f => WCoalgebraHom_to_TAlgebraHom f
+|}.
+Next Obligation. proper. Qed.
+Next Obligation. reflexivity. Qed.
+Next Obligation. reflexivity. Qed.
+
+Program Definition CoEM_to_WCoalgebras : CoEilenbergMoore ⟶ WCoalgebras := {|
+  fobj := fun x => (``x; TAlgebra_to_WCoalgebra (projT2 x));
+  fmap := fun x y f => TAlgebraHom_to_WCoalgebraHom f
+|}.
+Next Obligation. proper. Qed.
+Next Obligation. reflexivity. Qed.
+Next Obligation. reflexivity. Qed.
+
+(* The two round trips fix the carrier and the costructure map on the
+   nose; only the record packaging is rebuilt.  Each component of the two
+   natural isomorphisms is therefore carried by an identity arrow. *)
+
+Program Definition coem_roundtrip (x : CoEilenbergMoore) :
+  WCoalgebras_to_CoEM (CoEM_to_WCoalgebras x) ≅[CoEilenbergMoore] x := {|
+  to   := {| t_alg_hom := id |};
+  from := {| t_alg_hom := id |}
+|}.
+Next Obligation. cat. Qed.
+Next Obligation. cat. Qed.
+Next Obligation. cat. Qed.
+Next Obligation. cat. Qed.
+
+Program Definition wcoalgebras_roundtrip (x : WCoalgebras) :
+  CoEM_to_WCoalgebras (WCoalgebras_to_CoEM x) ≅[WCoalgebras] x := {|
+  to   := {| w_coalg_hom := id |};
+  from := {| w_coalg_hom := id |}
+|}.
+Next Obligation. cat. Qed.
+Next Obligation. cat. Qed.
+Next Obligation. cat. Qed.
+Next Obligation. cat. Qed.
+
+Lemma WCoalgebras_to_CoEM_inverse :
+  WCoalgebras_to_CoEM ◯ CoEM_to_WCoalgebras ≈ Id[CoEilenbergMoore].
+Proof.
+  exists coem_roundtrip.
+  intros x y f; cbn; cat.
+Qed.
+
+Lemma CoEM_to_WCoalgebras_inverse :
+  CoEM_to_WCoalgebras ◯ WCoalgebras_to_CoEM ≈ Id[WCoalgebras].
+Proof.
+  exists wcoalgebras_roundtrip.
+  intros x y f; cbn; cat.
+Qed.
+
+Definition WCoalgebras_CoEilenbergMoore_Iso :
+  WCoalgebras ≅[Cat] CoEilenbergMoore :=
+  @Build_Isomorphism Cat WCoalgebras CoEilenbergMoore
+    WCoalgebras_to_CoEM CoEM_to_WCoalgebras
+    WCoalgebras_to_CoEM_inverse CoEM_to_WCoalgebras_inverse.
+
+End CoEilenbergMoore.

--- a/Comonad/Core.v
+++ b/Comonad/Core.v
@@ -1,0 +1,164 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Functor.
+Require Import Category.Theory.Monad.
+Require Import Category.Construction.Opposite.
+Require Import Category.Functor.Opposite.
+
+Generalizable All Variables.
+
+(** * Comonads: the covariant API *)
+
+(* nLab:      https://ncatlab.org/nlab/show/comonad
+   Wikipedia: https://en.wikipedia.org/wiki/Monad_(category_theory)#Comonads
+
+   A comonad on a category C is an endofunctor W : C ⟶ C equipped with a
+   counit ε : W ⟹ Id (here [extract]) and a comultiplication δ : W ⟹ W ○ W
+   (here [duplicate]), subject to the two counit laws ε ∘ δ ≈ id and
+   W ε ∘ δ ≈ id, and to coassociativity δ ∘ δ ≈ W δ ∘ δ (writing W ε and W δ
+   for the fmap image of a component, and reading each composite through the
+   appropriate instance of W).
+
+   Theory/Monad.v defines [Comonad := @Monad (C^op) (W^op)]: a comonad is
+   exactly a monad on the opposite category.  Because duality is built into
+   this library so that C^op^op = C holds by reflexivity, each comonad law IS
+   the corresponding monad law with its composites read backwards — no
+   separate record is needed, and none is introduced here.  This file
+   provides the covariant reading of that definition: the accessors
+   [extract], [duplicate] and [extend] are definitional op-reads of [ret],
+   [join] and [bind], and every law below is the corresponding monad law
+   transported by [exact] (at most up to symmetry of ≈, where the op-read
+   arrives in the reversed orientation). *)
+
+(* [Comonad C W] is a Definition that unfolds to the class
+   [@Monad (C^op) (W^op)], but typeclass resolution keys on the head constant
+   of a goal and does not look through this unfolding.  Declaring [Comonad]
+   an existing class lets a comonad witness in scope be found when the
+   accessors below insert their implicit [Comonad] argument, mirroring how
+   [ret] and [join] resolve their implicit [Monad] argument.  Goals headed by
+   [Monad] are untouched: the two heads are distinct, so neither search space
+   leaks into the other.
+
+   The declaration is kept here, in the comonad API module, rather than beside
+   the [Comonad] definition in Theory/Monad.v: this file is the canonical
+   entry point for the comonad API, so any code wanting class behaviour for
+   [Comonad] holes and [Context] binders imports it, and imposing library-wide
+   class resolution on the bare definition is avoided. *)
+Existing Class Comonad.
+
+Section ComonadAPI.
+
+Context {C : Category} {W : C ⟶ C} {H : @Comonad C W}.
+
+(** The counit ε : W ⟹ Id, componentwise: the op-read of [ret]. *)
+Definition extract {x : C} : W x ~> x := @ret (C^op) (W^op) H x.
+
+(** The comultiplication δ : W ⟹ W ○ W, componentwise: the op-read of
+    [join]. *)
+Definition duplicate {x : C} : W x ~> W (W x) := @join (C^op) (W^op) H x.
+
+(** Co-Kleisli extension (cobind): the op-read of [bind], see
+    [extend_op_bind] just below. *)
+Definition extend {x y : C} (f : W x ~> y) : W x ~> W y :=
+  fmap[W] f ∘ duplicate.
+
+(** [extend] agrees definitionally with the [bind] of the opposite monad. *)
+Lemma extend_op_bind {x y : C} (f : W x ~> y) :
+  extend f ≈ @bind (C^op) (W^op) H y x f.
+Proof. reflexivity. Qed.
+
+(** Naturality of the counit — ε is a natural transformation W ⟹ Id.
+    Op-read of [fmap_ret]. *)
+Lemma extract_natural {x y : C} (f : x ~> y) :
+  f ∘ extract ≈ extract ∘ fmap[W] f.
+Proof. exact (@fmap_ret (C^op) (W^op) H y x f). Qed.
+
+(** Naturality of the comultiplication — δ is a natural transformation
+    W ⟹ W ○ W.  Op-read of [join_fmap_fmap]. *)
+Lemma duplicate_natural {x y : C} (f : x ~> y) :
+  fmap[W] (fmap[W] f) ∘ duplicate ≈ duplicate ∘ fmap[W] f.
+Proof. exact (@join_fmap_fmap (C^op) (W^op) H y x f). Qed.
+
+(** Counit law ε_W ∘ δ ≈ id: op-read of the right unit law [join_ret]. *)
+Lemma extract_duplicate {x : C} : extract ∘ duplicate ≈ id[W x].
+Proof. exact (@join_ret (C^op) (W^op) H x). Qed.
+
+(** Counit law W ε ∘ δ ≈ id: op-read of the left unit law [join_fmap_ret]. *)
+Lemma fmap_extract_duplicate {x : C} : fmap[W] extract ∘ duplicate ≈ id[W x].
+Proof. exact (@join_fmap_ret (C^op) (W^op) H x). Qed.
+
+(** Coassociativity δ_W ∘ δ ≈ W δ ∘ δ: op-read of the associativity law
+    [join_fmap_join], which arrives in the symmetric orientation. *)
+Lemma duplicate_duplicate {x : C} :
+  duplicate ∘ @duplicate x ≈ fmap[W] duplicate ∘ @duplicate x.
+Proof.
+  symmetry.
+  exact (@join_fmap_join (C^op) (W^op) H x).
+Qed.
+
+(** The co-Kleisli triple laws for [extend].  Together with [extract] these
+    present the comonad in extension form, dually to the ret/bind
+    presentation of a monad; Comonad/CoKleisli.v uses them to relate
+    co-Kleisli composition to [extend]. *)
+
+Corollary extract_extend {x y : C} (f : W x ~> y) : extract ∘ extend f ≈ f.
+Proof.
+  unfold extend.
+  rewrite comp_assoc.
+  rewrite <- extract_natural.
+  rewrite <- comp_assoc.
+  rewrite extract_duplicate.
+  cat.
+Qed.
+
+Corollary extend_extract {x : C} : extend extract ≈ id[W x].
+Proof. exact fmap_extract_duplicate. Qed.
+
+Corollary extend_comp {x y z : C} (f : W y ~> z) (g : W x ~> y) :
+  extend f ∘ extend g ≈ extend (f ∘ extend g).
+Proof.
+  unfold extend.
+  rewrite !fmap_comp.
+  rewrite <- !comp_assoc.
+  rewrite <- duplicate_duplicate.
+  rewrite (comp_assoc (fmap[W] (fmap[W] g))).
+  rewrite duplicate_natural.
+  now rewrite !comp_assoc.
+Qed.
+
+(** [duplicate] is the extension of the identity, and [fmap] factors through
+    [extend]: the Kleisli-style and functorial presentations agree. *)
+
+Corollary extend_id_duplicate {x : C} : extend (id[W x]) ≈ duplicate.
+Proof. unfold extend; cat. Qed.
+
+Corollary fmap_extend_extract {x y : C} (f : x ~> y) :
+  extend (f ∘ extract) ≈ fmap[W] f.
+Proof.
+  unfold extend.
+  rewrite fmap_comp.
+  rewrite <- comp_assoc.
+  rewrite fmap_extract_duplicate.
+  cat.
+Qed.
+
+End ComonadAPI.
+
+(** [extend] respects ≈ in its morphism argument, so it can be rewritten
+    under.  (Declared outside the section so the instance is exported with
+    fully general arguments.) *)
+#[export] Instance extend_respects
+  {C : Category} {W : C ⟶ C} {H : @Comonad C W} {x y} :
+  Proper (equiv ==> equiv) (@extend C W H x y).
+Proof.
+  proper.
+  unfold extend.
+  now rewrites.
+Qed.
+
+Notation "extract[ W ]" := (@extract _ W _ _)
+  (at level 9, format "extract[ W ]") : category_scope.
+Notation "duplicate[ W ]" := (@duplicate _ W _ _)
+  (at level 9, format "duplicate[ W ]") : category_scope.
+Notation "extend[ W ]" := (@extend _ W _ _ _)
+  (at level 9, format "extend[ W ]") : category_scope.

--- a/Comonad/Duality.v
+++ b/Comonad/Duality.v
@@ -1,0 +1,337 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Theory.Monad.
+Require Import Category.Theory.Adjunction.
+Require Import Category.Construction.Opposite.
+Require Import Category.Functor.Opposite.
+Require Import Category.Adjunction.Opposite.
+Require Import Category.Monad.Adjunction.
+Require Import Category.Monad.Kleisli.
+Require Import Category.Monad.Kleisli.Adjunction.
+Require Import Category.Monad.Algebra.
+Require Import Category.Monad.Eilenberg.Moore.
+Require Import Category.Monad.Eilenberg.Moore.Adjunction.
+Require Import Category.Comonad.Core.
+Require Import Category.Comonad.CoKleisli.
+Require Import Category.Comonad.Coalgebra.
+
+Generalizable All Variables.
+
+(** * Duality for comonads: the transfer package and both resolutions *)
+
+(* nLab:      https://ncatlab.org/nlab/show/comonad
+   nLab:      https://ncatlab.org/nlab/show/co-Kleisli+category
+   nLab:      https://ncatlab.org/nlab/show/coalgebra+over+a+comonad
+   Wikipedia: https://en.wikipedia.org/wiki/Monad_(category_theory)#Comonads
+
+   Theory/Monad.v defines [Comonad := @Monad (C^op) (W^op)], and duality is
+   built into this library so that C^op^op = C and (W^op)^op = W hold by
+   reflexivity.  This file packages the consequences of that choice for the
+   theory of resolutions:
+
+   - the conversions between comonads on C and monads on C^op — and,
+     mirrored, between monads on C and comonads on C^op — are the identity,
+     with round trips holding by [reflexivity]
+     ([op_Monad_of_Comonad], [Comonad_of_op_Monad], [op_Comonad_of_Monad],
+     [Monad_of_op_Comonad]);
+
+   - every adjunction F ⊣ U (F : D ⟶ C the left adjoint) induces a comonad
+     on C with endofunctor F ◯ U ([Adjunction_Comonad]), the formal dual of
+     [Adjunction_Monad] in Monad/Adjunction.v: dualize the adjunction with
+     Adjunction/Opposite.v to U^op ⊣ F^op and take the monad it induces on
+     C^op.  That monad lives on the composite F^op ◯ U^op, while the goal
+     [@Comonad C (F ◯ U)] unfolds to a monad on (F ◯ U)^op.  The two
+     composites share their object and morphism maps definitionally, but
+     Compose rebuilds its functor-law fields per application, so the two
+     functor records are distinct terms; the comonad is therefore assembled
+     by [Build_Monad] with every field taken unchanged from the dual monad
+     (the field types are convertible across the two composites — no law is
+     re-proved);
+
+   - the two canonical resolutions of a comonad arise from the monad
+     resolutions of Monad/Kleisli/Adjunction.v and
+     Monad/Eilenberg/Moore/Adjunction.v by dualizing: for the co-Kleisli
+     category the forgetful functor x ↦ W x is LEFT adjoint to the cofree
+     one ([CoKleisli_Adjunction]), and likewise for the co-Eilenberg–Moore
+     category of coalgebras ([CoEM_Adjunction]) — under op the free/
+     forgetful pair of the monad world trades sides, which is why a comonad
+     is resolved as forgetful ⊣ cofree.  Each adjunction is literally the
+     [Opposite_Adjunction] of its monad counterpart; the covariant reading
+     lemmas beside them record what the functors, units and counits are in
+     terms of [extract], [duplicate] and [extend] of Comonad/Core.v, each
+     holding by [reflexivity] or by a single identity law.  The composite
+     Forget ◯ Cofree recovers W on the nose for both resolutions
+     ([CoKleisli_Comonad_agrees], [CoEM_Comonad_agrees]), dually to
+     [Kleisli_Monad_agrees] and [EM_Monad_agrees]. *)
+
+(** ** The transfer package
+
+    [Comonad C W] IS [@Monad (C^op) (W^op)] by definition, so all four
+    conversions below are the identity function and both round trips hold
+    by [reflexivity].  They are provided as named coercion points: writing
+    [op_Monad_of_Comonad H] in a proof records the direction in which a
+    witness is being read, which the bare [H] does not. *)
+
+Section MonadComonadDuality.
+
+Context {C : Category}.
+Context {W : C ⟶ C}.
+
+Definition op_Monad_of_Comonad (H : @Comonad C W) : @Monad (C^op) (W^op) := H.
+
+Definition Comonad_of_op_Monad (H : @Monad (C^op) (W^op)) : @Comonad C W := H.
+
+Lemma Comonad_of_op_Monad_of_Comonad (H : @Comonad C W) :
+  Comonad_of_op_Monad (op_Monad_of_Comonad H) = H.
+Proof. reflexivity. Qed.
+
+Lemma op_Monad_of_Comonad_of_op_Monad (H : @Monad (C^op) (W^op)) :
+  op_Monad_of_Comonad (Comonad_of_op_Monad H) = H.
+Proof. reflexivity. Qed.
+
+(** Mirrored: a monad on C is the same thing as a comonad on C^op.  Both
+    typecheck because (C^op)^op = C and (W^op)^op = W hold by
+    reflexivity. *)
+
+Definition op_Comonad_of_Monad (H : @Monad C W) : @Comonad (C^op) (W^op) := H.
+
+Definition Monad_of_op_Comonad (H : @Comonad (C^op) (W^op)) : @Monad C W := H.
+
+Lemma Monad_of_op_Comonad_of_Monad (H : @Monad C W) :
+  Monad_of_op_Comonad (op_Comonad_of_Monad H) = H.
+Proof. reflexivity. Qed.
+
+Lemma op_Comonad_of_Monad_of_op_Comonad (H : @Comonad (C^op) (W^op)) :
+  op_Comonad_of_Monad (Monad_of_op_Comonad H) = H.
+Proof. reflexivity. Qed.
+
+End MonadComonadDuality.
+
+(** ** The comonad induced by an adjunction
+
+    Every adjunction F ⊣ U induces the monad U ◯ F on the domain of F
+    (Monad/Adjunction.v) and, dually, the comonad F ◯ U on its codomain:
+    the counit ε is the counit of the adjunction, and the comultiplication
+    is F η U.  (These covariant readings hold inside the sealed proof of the
+    Qed-opaque [Adjunction_Monad], so — unlike the reflexivity-backed
+    agreement lemmas elsewhere in this file — they are not exposed here as
+    lemmas about [extract]/[duplicate] of the induced comonad.)  Rather than
+    re-deriving the laws from the zig-zag
+    identities, dualize: Adjunction/Opposite.v turns A : F ⊣ U into
+    A^op : U^op ⊣ F^op, whose [Adjunction_Monad] is a monad on C^op with
+    endofunctor F^op ◯ U^op.  The target class [@Comonad C (F ◯ U)]
+    unfolds to [@Monad (C^op) ((F ◯ U)^op)]; the two composites agree on
+    objects and morphisms definitionally (only their Qed-sealed functor-law
+    fields are distinct terms), so every monad field transports unchanged
+    and [Build_Monad] just repackages the dual monad. *)
+
+Section AdjunctionComonad.
+
+Context {C : Category}.
+Context {D : Category}.
+Context {F : D ⟶ C}.
+Context {U : C ⟶ D}.
+
+Definition Adjunction_Comonad (A : F ⊣ U) : @Comonad C (F ◯ U) :=
+  let M : @Monad (C^op) (F^op ◯ U^op) :=
+    Adjunction_Monad (Opposite_Adjunction F U A) in
+  @Build_Monad (C^op) ((F ◯ U)^op)
+    (fun x => @ret (C^op) (F^op ◯ U^op) M x)
+    (fun x => @join (C^op) (F^op ◯ U^op) M x)
+    (fun x y f => @fmap_ret (C^op) (F^op ◯ U^op) M x y f)
+    (fun x => @join_fmap_join (C^op) (F^op ◯ U^op) M x)
+    (fun x => @join_fmap_ret (C^op) (F^op ◯ U^op) M x)
+    (fun x => @join_ret (C^op) (F^op ◯ U^op) M x)
+    (fun x y f => @join_fmap_fmap (C^op) (F^op ◯ U^op) M x y f).
+
+End AdjunctionComonad.
+
+(** ** The co-Kleisli resolution: forgetful ⊣ cofree
+
+    Dualizing the Kleisli resolution of the opposite monad
+    (Monad/Kleisli/Adjunction.v) yields the initial resolution of the
+    comonad W through its co-Kleisli category (Comonad/CoKleisli.v):
+
+    - [CoKleisli_Forget] : CoKleisli ⟶ C sends x to W x and a co-Kleisli
+      morphism f : W x ~> y to its extension [extend f] — under the
+      comparison with coalgebras it forgets a cofree coalgebra to its
+      carrier, whence the name;
+    - [CoKleisli_Cofree] : C ⟶ CoKleisli is the identity on objects and
+      sends f : x ~> y to the co-Kleisli morphism f ∘ extract;
+    - [CoKleisli_Adjunction] : CoKleisli_Forget ⊣ CoKleisli_Cofree — for a
+      comonad the forgetful side is the LEFT adjoint, since op trades the
+      sides of the free ⊣ forgetful resolution of the monad W^op.
+
+    Because both hom-sets of the transposition are literally the same
+    setoid W x ~> y, the adjunction isomorphism is the identity map, and
+    the readings of the functors, unit and counit below are definitional
+    except where a single identity law intervenes. *)
+
+Section CoKleisliAdjunction.
+
+Context {C : Category}.
+Context {W : C ⟶ C}.
+Context {H : @Comonad C W}.
+
+Definition CoKleisli_Forget : @CoKleisli C W H ⟶ C :=
+  Opposite_Functor (@Kleisli_Forget (C^op) (W^op) H).
+
+Definition CoKleisli_Cofree : C ⟶ @CoKleisli C W H :=
+  Opposite_Functor (@Kleisli_Free (C^op) (W^op) H).
+
+(** Covariant readings of the two functors, all definitional. *)
+
+Lemma CoKleisli_Forget_obj (x : C) : CoKleisli_Forget x = W x.
+Proof. reflexivity. Qed.
+
+Lemma CoKleisli_Forget_fmap {x y : C} (f : W x ~{C}~> y) :
+  fmap[CoKleisli_Forget] f ≈ extend f.
+Proof. reflexivity. Qed.
+
+Lemma CoKleisli_Cofree_obj (x : C) : CoKleisli_Cofree x = x.
+Proof. reflexivity. Qed.
+
+Lemma CoKleisli_Cofree_fmap {x y : C} (f : x ~{C}~> y) :
+  fmap[CoKleisli_Cofree] f ≈ f ∘ extract.
+Proof. reflexivity. Qed.
+
+Definition CoKleisli_Adjunction : CoKleisli_Forget ⊣ CoKleisli_Cofree :=
+  Opposite_Adjunction _ _ (@Kleisli_Adjunction (C^op) (W^op) H).
+
+(** The counit of the adjunction is the counit of the comonad. *)
+
+Lemma CoKleisli_counit_agrees {x : C} :
+  @counit _ _ _ _ CoKleisli_Adjunction x ≈ @extract C W H x.
+Proof. reflexivity. Qed.
+
+(** The unit at x is the identity arrow on W x, read as the co-Kleisli
+    morphism x ~{CoKleisli}~> CoKleisli_Cofree (W x). *)
+
+Lemma CoKleisli_unit_agrees {x : C} :
+  @unit _ _ _ _ CoKleisli_Adjunction x ≈ id[W x].
+Proof. reflexivity. Qed.
+
+(** The comultiplication of the comonad induced by this adjunction (dually
+    to Monad/Adjunction.v it is the CoKleisli_Forget-image of the unit) is
+    duplicate. *)
+
+Lemma CoKleisli_duplicate_agrees {x : C} :
+  fmap[CoKleisli_Forget] (@unit _ _ _ _ CoKleisli_Adjunction x)
+    ≈ @duplicate C W H x.
+Proof.
+  simpl.
+  rewrite fmap_id.
+  cat.
+Qed.
+
+(** The resolution recovers W: the composite Forget ◯ Cofree is naturally
+    isomorphic to W, with identity components. *)
+
+Theorem CoKleisli_Comonad_agrees : CoKleisli_Forget ◯ CoKleisli_Cofree ≈ W.
+Proof.
+  exists (fun x => iso_id).
+  intros x y f; simpl.
+  rewrite id_left, id_right.
+  exact (@fmap_extend_extract C W H x y f).
+Qed.
+
+End CoKleisliAdjunction.
+
+(** ** The co-Eilenberg–Moore resolution: forgetful ⊣ cofree
+
+    Dualizing the Eilenberg–Moore resolution of the opposite monad
+    (Monad/Eilenberg/Moore/Adjunction.v) yields the terminal resolution of
+    W through its category of coalgebras (Comonad/Coalgebra.v):
+
+    - [CoEM_Forget] : CoEilenbergMoore ⟶ C projects a coalgebra to its
+      carrier and a coalgebra homomorphism to its underlying arrow;
+    - [CoEM_Cofree] : C ⟶ CoEilenbergMoore sends x to the cofree coalgebra
+      (W x, δ_x) — its costructure map is duplicate — and f : x ~> y to
+      the homomorphism carried by fmap[W] f;
+    - [CoEM_Adjunction] : CoEM_Forget ⊣ CoEM_Cofree, with the forgetful
+      side again the left adjoint. *)
+
+Section CoEilenbergMooreAdjunction.
+
+Context {C : Category}.
+Context {W : C ⟶ C}.
+Context {H : @Comonad C W}.
+
+Definition CoEM_Forget : @CoEilenbergMoore C W H ⟶ C :=
+  Opposite_Functor (@EM_Forget (C^op) (W^op) H).
+
+Definition CoEM_Cofree : C ⟶ @CoEilenbergMoore C W H :=
+  Opposite_Functor (@EM_Free (C^op) (W^op) H).
+
+(** Covariant readings of the two functors, all definitional. *)
+
+Lemma CoEM_Forget_obj (x : @CoEilenbergMoore C W H) : CoEM_Forget x = `1 x.
+Proof. reflexivity. Qed.
+
+Lemma CoEM_Forget_fmap {x y : @CoEilenbergMoore C W H}
+      (f : x ~{@CoEilenbergMoore C W H}~> y) :
+  fmap[CoEM_Forget] f ≈ t_alg_hom[f].
+Proof. reflexivity. Qed.
+
+Lemma CoEM_Cofree_carrier (x : C) : `1 (CoEM_Cofree x) = W x.
+Proof. reflexivity. Qed.
+
+(** The costructure map of the cofree coalgebra on x is duplicate. *)
+
+Lemma CoEM_Cofree_coalg (x : C) :
+  t_alg[`2 (CoEM_Cofree x)] ≈ @duplicate C W H x.
+Proof. reflexivity. Qed.
+
+Lemma CoEM_Cofree_fmap {x y : C} (f : x ~{C}~> y) :
+  t_alg_hom[fmap[CoEM_Cofree] f] ≈ fmap[W] f.
+Proof. reflexivity. Qed.
+
+Definition CoEM_Adjunction : CoEM_Forget ⊣ CoEM_Cofree :=
+  Opposite_Adjunction _ _ (@EM_Adjunction (C^op) (W^op) H).
+
+(** The counit of the adjunction is the counit of the comonad. *)
+
+Lemma CoEM_counit_agrees {x : C} :
+  @counit _ _ _ _ CoEM_Adjunction x ≈ @extract C W H x.
+Proof.
+  unfold counit; cbn.
+  cat.
+Qed.
+
+(** The unit at a coalgebra acts by its costructure map, stated on the
+    underlying arrow of the coalgebra homomorphism. *)
+
+Lemma CoEM_unit_agrees {y : @CoEilenbergMoore C W H} :
+  t_alg_hom[@unit _ _ _ _ CoEM_Adjunction y] ≈ t_alg[`2 y].
+Proof.
+  unfold unit; cbn.
+  rewrite fmap_id.
+  cat.
+Qed.
+
+(** The comultiplication of the comonad induced by this adjunction is
+    duplicate. *)
+
+Lemma CoEM_duplicate_agrees {x : C} :
+  fmap[CoEM_Forget] (@unit _ _ _ _ CoEM_Adjunction (CoEM_Cofree x))
+    ≈ @duplicate C W H x.
+Proof.
+  cbn.
+  rewrite fmap_id.
+  cat.
+Qed.
+
+(** The resolution recovers W: the composite Forget ◯ Cofree is naturally
+    isomorphic to W, with identity components. *)
+
+Theorem CoEM_Comonad_agrees : CoEM_Forget ◯ CoEM_Cofree ≈ W.
+Proof.
+  exists (fun x => iso_id).
+  intros x y f; simpl.
+  rewrite id_left, id_right.
+  reflexivity.
+Qed.
+
+End CoEilenbergMooreAdjunction.

--- a/Comonad/Strong.v
+++ b/Comonad/Strong.v
@@ -1,0 +1,427 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Theory.Naturality.
+Require Import Category.Theory.Monad.
+Require Import Category.Functor.Bifunctor.
+Require Import Category.Structure.Monoidal.
+Require Import Category.Functor.Strong.
+Require Import Category.Monad.Strong.
+Require Import Category.Construction.Opposite.
+Require Import Category.Functor.Opposite.
+Require Import Category.Construction.Opposite.Monoidal.
+Require Import Category.Comonad.Core.
+
+Generalizable All Variables.
+
+(** * Costrong comonads *)
+
+(* nLab:      https://ncatlab.org/nlab/show/strong+monad
+   nLab:      https://ncatlab.org/nlab/show/tensorial+strength
+   Wikipedia: https://en.wikipedia.org/wiki/Strong_monad
+
+   A costrong comonad on a monoidal category (C, ⨂, I) is a comonad
+   (W, ε = extract, δ = duplicate) whose endofunctor carries a tensorial
+   costrength: a family
+
+     costrength : W (x ⨂ y) ~> x ⨂ W y
+
+   natural in both variables and coherent with the left unitor λ and the
+   associator α ([costrength_id_left], [costrength_assoc], both arriving in
+   their inverse orientations, as dualization inverts the structural
+   isomorphisms), and compatible with the comonad structure:
+
+     - ε-compat ([costrength_extract]):
+         (id ⨂ ε) ∘ costrength ≈ ε            at  W (x ⨂ y) ~> x ⨂ y
+     - δ-compat ([costrength_duplicate]):
+         (id ⨂ δ) ∘ costrength ≈ costrength ∘ W costrength ∘ δ
+                                                at  W (x ⨂ y) ~> x ⨂ W (W y)
+
+   The notion is the formal dual of a (left) strong monad: a costrength for
+   W over (C, ⨂) is exactly a strength for W^op over (C^op, ⨂^op).  Duality
+   is built into this library so that (C^op)^op = C and (W^op)^op = W hold
+   by reflexivity, and Construction/Opposite/Monoidal.v transports monoidal
+   structure to the opposite category, so [CostrongComonad] is DEFINED as
+   the in-tree [StrongMonad] (Monad/Strong.v) instantiated at
+   (C^op, Monoidal_op M) on W^op — no second axiomatization.  The covariant
+   accessors and laws below are definitional op-reads of the [StrongMonad]
+   fields, in the style of Comonad/Core.v, and [Build_CostrongComonad]
+   assembles the bundled structure back out of covariant data, so the
+   unfolding runs in both directions.
+
+   Following the [Monoidal_op] precedent, [CostrongComonad] and all the
+   transfers in this file are Definitions, not Instances: registering them
+   would let instance resolution silently equip a category with a
+   (co)strength, which is rarely what an unannotated goal means.  Callers
+   select them explicitly.
+
+   Double-op caveat (see Construction/Opposite/Monoidal.v): although the
+   underlying category and functor round-trip on the nose, the transported
+   monoidal structure does not — [Monoidal_op (Monoidal_op M)] is not
+   definitionally M, because the transport rebuilds the functor-law and
+   coherence fields as fresh Qed-opaque proof terms.  A strong monad on
+   (C, M) and a costrong comonad on (C^op, Monoidal_op M) are therefore
+   interchanged by rebuilding the record field by field (every data and law
+   component IS convertible across the two monoidal structures), and the
+   resulting round trips are stated up to ≈ on the structure maps rather
+   than as record equalities: see [StrongMonad_to_op_CostrongComonad],
+   [op_CostrongComonad_to_StrongMonad] and the round-trip lemmas at the end
+   of this file. *)
+
+Definition CostrongComonad {C : Category} (M : @Monoidal C) (W : C ⟶ C) : Type :=
+  @StrongMonad (C^op) (@Monoidal_op C M) (W^op).
+
+(* Mirroring [Existing Class Comonad] in Comonad/Core.v: [CostrongComonad]
+   unfolds to the class [StrongMonad], but typeclass resolution keys on the
+   head constant of a goal and does not look through this unfolding.
+   Declaring [CostrongComonad] an existing class lets a costrong witness in
+   scope be found when the accessors below insert their implicit argument.
+   No instance of it is registered anywhere in this file, so no search space
+   changes. *)
+Existing Class CostrongComonad.
+
+(* ================================================================== *)
+(** ** The covariant API: definitional op-reads of the bundled fields  *)
+(* ================================================================== *)
+
+Section CostrongComonadAPI.
+
+Context {C : Category}.
+Context {M : @Monoidal C}.
+Context {W : C ⟶ C}.
+Context {CS : CostrongComonad M W}.
+
+(** The underlying comonad: the op-read of [strongmonad_is_monad]. *)
+Definition costrong_is_comonad : @Comonad C W :=
+  @strongmonad_is_monad (C^op) (@Monoidal_op C M) (W^op) CS.
+
+(* Let [extract] and [duplicate] from Comonad/Core.v resolve against the
+   underlying comonad in the statements below.  The registration is
+   section-local and is dropped when the section closes. *)
+#[local] Existing Instance costrong_is_comonad.
+
+(** The underlying strong endofunctor over (C^op, Monoidal_op M): the
+    op-read of [strongmonad_is_strong]. *)
+Definition costrong_is_strong :
+  @StrongFunctor (C^op) (@Monoidal_op C M) (W^op) :=
+  @strongmonad_is_strong (C^op) (@Monoidal_op C M) (W^op) CS.
+
+(** The costrength W (x ⨂ y) ~> x ⨂ W y: the covariant reading of
+    [strength] at (C^op, Monoidal_op M, W^op). *)
+Definition costrength {x y : C} : W (x ⨂ y) ~> x ⨂ W y :=
+  @strength (C^op) (@Monoidal_op C M) (W^op) costrong_is_strong x y.
+
+(** Joint naturality in both variables: the op-read of [strength_natural].
+    The bundled field states the square with the two variables acted on
+    separately (via the [Mapping] instances of Theory/Naturality.v); the
+    bifunctor interchange law [bimap_id_right_left] merges the per-variable
+    actions into the usual joint form. *)
+Lemma costrength_natural {x y z w : C} (f : x ~> y) (k : z ~> w) :
+  costrength ∘ fmap[W] (f ⨂ k) ≈ (f ⨂ fmap[W] k) ∘ costrength.
+Proof.
+  pose proof (@strength_natural (C^op) (@Monoidal_op C M) (W^op)
+                costrong_is_strong y x f w z k) as SN.
+  simpl in SN.
+  rewrite <- fmap_comp in SN.
+  rewrite bimap_id_right_left in SN.
+  rewrite comp_assoc in SN.
+  rewrite bimap_id_right_left in SN.
+  exact SN.
+Qed.
+
+(** Left-unitor coherence: the op-read of [strength_id_left].  Dualization
+    inverts the unitor, so in C the law reads against λ⁻¹: precomposing the
+    costrength with W (λ⁻¹) is λ⁻¹ at W x. *)
+Lemma costrength_id_left {x : C} :
+  costrength ∘ fmap[W] (from (@unit_left C M x))
+    ≈ from (@unit_left C M (W x)).
+Proof.
+  exact (@strength_id_left (C^op) (@Monoidal_op C M) (W^op)
+           costrong_is_strong x).
+Qed.
+
+(** Associator coherence: the op-read of [strength_assoc], with α likewise
+    arriving in its inverse orientation. *)
+Lemma costrength_assoc {x y z : C} :
+  costrength ∘ fmap[W] (from (@tensor_assoc C M x y z))
+    ≈ from (@tensor_assoc C M x y (W z)) ∘ (id[x] ⨂ costrength) ∘ costrength.
+Proof.
+  rewrite <- comp_assoc.
+  exact (@strength_assoc (C^op) (@Monoidal_op C M) (W^op)
+           costrong_is_strong x y z).
+Qed.
+
+(** ε-compatibility, the dual of the Kock/Moggi η-compat law
+    [strength_ret]: discarding the comonadic context of the right factor
+    after applying the costrength is exactly extracting from the whole
+    tensor. *)
+Lemma costrength_extract {x y : C} :
+  (id[x] ⨂ extract) ∘ costrength ≈ (extract : W (x ⨂ y) ~> x ⨂ y).
+Proof.
+  exact (@strength_ret (C^op) (@Monoidal_op C M) (W^op) CS x y).
+Qed.
+
+(** δ-compatibility, the dual of the μ-compat law [strength_join]:
+    duplicating the right factor after applying the costrength agrees with
+    duplicating the whole tensor and sliding the costrength through both
+    W-layers. *)
+Lemma costrength_duplicate {x y : C} :
+  (id[x] ⨂ duplicate (x:=y)) ∘ costrength
+    ≈ costrength ∘ fmap[W] costrength ∘ duplicate.
+Proof.
+  rewrite <- comp_assoc.
+  exact (@strength_join (C^op) (@Monoidal_op C M) (W^op) CS x y).
+Qed.
+
+End CostrongComonadAPI.
+
+(* [costrength[W]] names the costrength of a given costrong comonad on W at
+   implicit arguments, mirroring the [strength[F]] convention. *)
+Notation "costrength[ W ]" := (@costrength _ _ W%functor _ _ _)
+  (at level 9, format "costrength[ W ]") : morphism_scope.
+
+(* ================================================================== *)
+(** ** Building the bundled structure from covariant data              *)
+(* ================================================================== *)
+
+Section BuildCostrongComonad.
+
+Context {C : Category}.
+Context {M : @Monoidal C}.
+Context {W : C ⟶ C}.
+
+(* Predictable obligation alignment (the Monad/Kleisli.v precedent): with
+   [program_simpl] the unitor and counit compatibility obligations are
+   discharged by the tactic itself — their op-statements are convertible
+   to the supplied hypotheses [sigma_id_left] and [sigma_extract], so it
+   closes them from the local context.  Exactly three obligations remain,
+   in order: naturality, the associator law, and δ-compatibility, each a
+   re-bracketing of the corresponding covariant hypothesis. *)
+#[local] Obligation Tactic := program_simpl.
+
+(** [Build_CostrongComonad] assembles a [CostrongComonad] from a comonad
+    together with a covariant costrength family satisfying the covariant
+    laws — the inverse reading of the accessor layer above.  The data
+    round trip is definitional: see [Build_CostrongComonad_costrength] and
+    [Build_CostrongComonad_comonad] just below. *)
+Program Definition Build_CostrongComonad
+  (H : @Comonad C W)
+  (sigma : forall x y : C, W (x ⨂ y) ~> x ⨂ W y)
+  (sigma_natural : forall (x y z w : C) (f : x ~> y) (k : z ~> w),
+    sigma y w ∘ fmap[W] (f ⨂ k) ≈ (f ⨂ fmap[W] k) ∘ sigma x z)
+  (sigma_id_left : forall x : C,
+    sigma I x ∘ fmap[W] (from (@unit_left C M x))
+      ≈ from (@unit_left C M (W x)))
+  (sigma_assoc : forall x y z : C,
+    sigma ((x ⨂ y)%object) z ∘ fmap[W] (from (@tensor_assoc C M x y z))
+      ≈ from (@tensor_assoc C M x y (W z)) ∘ (id[x] ⨂ sigma y z)
+          ∘ sigma x ((y ⨂ z)%object))
+  (sigma_extract : forall x y : C,
+    (id[x] ⨂ extract) ∘ sigma x y ≈ (extract : W (x ⨂ y) ~> x ⨂ y))
+  (sigma_duplicate : forall x y : C,
+    (id[x] ⨂ duplicate (x:=y)) ∘ sigma x y
+      ≈ sigma x (W y) ∘ fmap[W] (sigma x y) ∘ duplicate)
+  : CostrongComonad M W :=
+  @Build_StrongMonad (C^op) (@Monoidal_op C M) (W^op) H
+    (@Build_StrongFunctor (C^op) (@Monoidal_op C M) (W^op)
+       (fun x y => sigma x y) _ _ _)
+    _ _.
+Next Obligation.
+  (* strength_natural in C^op: merge the separated actions and apply the
+     covariant naturality. *)
+  rewrite <- fmap_comp.
+  rewrite bimap_id_right_left.
+  rewrite comp_assoc.
+  rewrite bimap_id_right_left.
+  apply sigma_natural.
+Qed.
+Next Obligation.
+  (* strength_assoc in C^op: the op-read arrives right-bracketed. *)
+  rewrite comp_assoc.
+  apply sigma_assoc.
+Qed.
+Next Obligation.
+  (* strength_join in C^op: likewise a re-bracketing of δ-compat. *)
+  rewrite comp_assoc.
+  apply sigma_duplicate.
+Qed.
+
+End BuildCostrongComonad.
+
+Section BuildCostrongComonadAgreement.
+
+Context {C : Category}.
+Context {M : @Monoidal C}.
+Context {W : C ⟶ C}.
+Context (H : @Comonad C W).
+Context (sigma : forall x y : C, W (x ⨂ y) ~> x ⨂ W y).
+Context (sigma_natural : forall (x y z w : C) (f : x ~> y) (k : z ~> w),
+  sigma y w ∘ fmap[W] (f ⨂ k) ≈ (f ⨂ fmap[W] k) ∘ sigma x z).
+Context (sigma_id_left : forall x : C,
+  sigma I x ∘ fmap[W] (from (@unit_left C M x))
+    ≈ from (@unit_left C M (W x))).
+Context (sigma_assoc : forall x y z : C,
+  sigma ((x ⨂ y)%object) z ∘ fmap[W] (from (@tensor_assoc C M x y z))
+    ≈ from (@tensor_assoc C M x y (W z)) ∘ (id[x] ⨂ sigma y z)
+        ∘ sigma x ((y ⨂ z)%object)).
+Context (sigma_extract : forall x y : C,
+  (id[x] ⨂ extract) ∘ sigma x y ≈ (extract : W (x ⨂ y) ~> x ⨂ y)).
+Context (sigma_duplicate : forall x y : C,
+  (id[x] ⨂ duplicate (x:=y)) ∘ sigma x y
+    ≈ sigma x (W y) ∘ fmap[W] (sigma x y) ∘ duplicate).
+
+(** Reading the costrength back off the assembled structure returns the
+    supplied family on the nose. *)
+Lemma Build_CostrongComonad_costrength {x y : C} :
+  @costrength C M W
+    (Build_CostrongComonad H sigma sigma_natural sigma_id_left
+       sigma_assoc sigma_extract sigma_duplicate) x y
+    ≈ sigma x y.
+Proof. reflexivity. Qed.
+
+(** The underlying comonad passes through the assembly unchanged. *)
+Lemma Build_CostrongComonad_comonad :
+  @costrong_is_comonad C M W
+    (Build_CostrongComonad H sigma sigma_natural sigma_id_left
+       sigma_assoc sigma_extract sigma_duplicate) = H.
+Proof. reflexivity. Qed.
+
+End BuildCostrongComonadAgreement.
+
+(* ================================================================== *)
+(** ** Transfers: costrong comonads are strong monads on the opposite  *)
+(* ================================================================== *)
+
+(* On a FIXED base (C, M) the correspondence is definitional — a costrong
+   comonad on (C, M) literally is a strong monad on (C^op, Monoidal_op M),
+   so both passages are the identity and the round trips hold by
+   reflexivity. *)
+
+Definition CostrongComonad_to_op_StrongMonad
+  {C : Category} {M : @Monoidal C} {W : C ⟶ C}
+  (CS : CostrongComonad M W) :
+  @StrongMonad (C^op) (@Monoidal_op C M) (W^op) := CS.
+
+Definition op_StrongMonad_to_CostrongComonad
+  {C : Category} {M : @Monoidal C} {W : C ⟶ C}
+  (S : @StrongMonad (C^op) (@Monoidal_op C M) (W^op)) :
+  CostrongComonad M W := S.
+
+Lemma CostrongComonad_op_roundtrip
+  {C : Category} {M : @Monoidal C} {W : C ⟶ C} (CS : CostrongComonad M W) :
+  op_StrongMonad_to_CostrongComonad (CostrongComonad_to_op_StrongMonad CS)
+    = CS.
+Proof. reflexivity. Qed.
+
+Lemma op_StrongMonad_roundtrip
+  {C : Category} {M : @Monoidal C} {W : C ⟶ C}
+  (S : @StrongMonad (C^op) (@Monoidal_op C M) (W^op)) :
+  CostrongComonad_to_op_StrongMonad (op_StrongMonad_to_CostrongComonad S)
+    = S.
+Proof. reflexivity. Qed.
+
+Section StrongMonadOpposite.
+
+Context {C : Category}.
+Context {M : @Monoidal C}.
+Context {T : C ⟶ C}.
+
+(* The other direction of the duality — a strong monad on (C, M) as a
+   costrong comonad on (C^op, Monoidal_op M) — is where the double-op
+   caveat bites: the target type unfolds to a [StrongMonad] over
+   [Monoidal_op (Monoidal_op M)], which is not definitionally M (its law
+   fields are rebuilt Qed-opaque; see Construction/Opposite/Monoidal.v).
+   The records are therefore rebuilt field by field.  Every field converts:
+   the tensor's object and morphism actions, and the to/from components of
+   the transported unitors and associator, all reduce to those of M, so
+   each projection of S is accepted at the reindexed type as it stands.
+   Only the record types themselves differ, which is why the round trips
+   below are stated on the structure maps (up to ≈, or as the literal
+   passthrough of the monad component) rather than as record equalities. *)
+
+Definition StrongMonad_to_op_CostrongComonad (S : @StrongMonad C M T) :
+  @CostrongComonad (C^op) (@Monoidal_op C M) (T^op) :=
+  @Build_StrongMonad ((C^op)^op)
+    (@Monoidal_op (C^op) (@Monoidal_op C M)) ((T^op)^op)
+    (@strongmonad_is_monad C M T S)
+    (@Build_StrongFunctor ((C^op)^op)
+       (@Monoidal_op (C^op) (@Monoidal_op C M)) ((T^op)^op)
+       (fun x y => @strength C M T (@strongmonad_is_strong C M T S) x y)
+       (@strength_natural C M T (@strongmonad_is_strong C M T S))
+       (@strength_id_left C M T (@strongmonad_is_strong C M T S))
+       (@strength_assoc C M T (@strongmonad_is_strong C M T S)))
+    (@strength_ret C M T S)
+    (@strength_join C M T S).
+
+Definition op_CostrongComonad_to_StrongMonad
+  (S : @CostrongComonad (C^op) (@Monoidal_op C M) (T^op)) :
+  @StrongMonad C M T :=
+  @Build_StrongMonad C M T
+    (@strongmonad_is_monad ((C^op)^op)
+       (@Monoidal_op (C^op) (@Monoidal_op C M)) ((T^op)^op) S)
+    (@Build_StrongFunctor C M T
+       (fun x y => @strength ((C^op)^op)
+          (@Monoidal_op (C^op) (@Monoidal_op C M)) ((T^op)^op)
+          (@strongmonad_is_strong ((C^op)^op)
+             (@Monoidal_op (C^op) (@Monoidal_op C M)) ((T^op)^op) S) x y)
+       (@strength_natural ((C^op)^op)
+          (@Monoidal_op (C^op) (@Monoidal_op C M)) ((T^op)^op)
+          (@strongmonad_is_strong ((C^op)^op)
+             (@Monoidal_op (C^op) (@Monoidal_op C M)) ((T^op)^op) S))
+       (@strength_id_left ((C^op)^op)
+          (@Monoidal_op (C^op) (@Monoidal_op C M)) ((T^op)^op)
+          (@strongmonad_is_strong ((C^op)^op)
+             (@Monoidal_op (C^op) (@Monoidal_op C M)) ((T^op)^op) S))
+       (@strength_assoc ((C^op)^op)
+          (@Monoidal_op (C^op) (@Monoidal_op C M)) ((T^op)^op)
+          (@strongmonad_is_strong ((C^op)^op)
+             (@Monoidal_op (C^op) (@Monoidal_op C M)) ((T^op)^op) S)))
+    (@strength_ret ((C^op)^op)
+       (@Monoidal_op (C^op) (@Monoidal_op C M)) ((T^op)^op) S)
+    (@strength_join ((C^op)^op)
+       (@Monoidal_op (C^op) (@Monoidal_op C M)) ((T^op)^op) S).
+
+(** Covariantly read, the costrength of the opposite costrong comonad IS
+    the strength of the strong monad it came from. *)
+Lemma op_costrength_strength (S : @StrongMonad C M T) {x y : C} :
+  @costrength (C^op) (@Monoidal_op C M) (T^op)
+    (StrongMonad_to_op_CostrongComonad S) x y
+    ≈ @strength C M T (@strongmonad_is_strong C M T S) x y.
+Proof. reflexivity. Qed.
+
+(** Round trips.  The strength data survives both passages on the nose (so
+    ≈ holds by reflexivity), and the underlying monad is passed through
+    untouched; only the enclosing records differ, per the double-op caveat
+    in the header. *)
+
+Lemma StrongMonad_op_roundtrip_strength (S : @StrongMonad C M T) {x y : C} :
+  @strength C M T
+    (@strongmonad_is_strong C M T
+       (op_CostrongComonad_to_StrongMonad
+          (StrongMonad_to_op_CostrongComonad S))) x y
+    ≈ @strength C M T (@strongmonad_is_strong C M T S) x y.
+Proof. reflexivity. Qed.
+
+Lemma StrongMonad_op_roundtrip_monad (S : @StrongMonad C M T) :
+  @strongmonad_is_monad C M T
+    (op_CostrongComonad_to_StrongMonad (StrongMonad_to_op_CostrongComonad S))
+    = @strongmonad_is_monad C M T S.
+Proof. reflexivity. Qed.
+
+Lemma op_CostrongComonad_roundtrip_costrength
+  (S : @CostrongComonad (C^op) (@Monoidal_op C M) (T^op)) {x y : C} :
+  @costrength (C^op) (@Monoidal_op C M) (T^op)
+    (StrongMonad_to_op_CostrongComonad (op_CostrongComonad_to_StrongMonad S))
+    x y
+    ≈ @costrength (C^op) (@Monoidal_op C M) (T^op) S x y.
+Proof. reflexivity. Qed.
+
+Lemma op_CostrongComonad_roundtrip_comonad
+  (S : @CostrongComonad (C^op) (@Monoidal_op C M) (T^op)) :
+  @costrong_is_comonad (C^op) (@Monoidal_op C M) (T^op)
+    (StrongMonad_to_op_CostrongComonad (op_CostrongComonad_to_StrongMonad S))
+    = @costrong_is_comonad (C^op) (@Monoidal_op C M) (T^op) S.
+Proof. reflexivity. Qed.
+
+End StrongMonadOpposite.

--- a/Instance/Coq/Comonad/Env.v
+++ b/Instance/Coq/Comonad/Env.v
@@ -1,0 +1,130 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Functor.
+Require Import Category.Theory.Monad.
+Require Import Category.Construction.Opposite.
+Require Import Category.Functor.Opposite.
+Require Import Category.Comonad.Core.
+Require Import Category.Instance.Coq.
+
+Generalizable All Variables.
+
+(** * The environment (coreader) comonad on COQ *)
+
+(* nLab:      https://ncatlab.org/nlab/show/coreader+comonad
+   Wikipedia: https://en.wikipedia.org/wiki/Monad_(functional_programming)
+
+   The environment comonad — also called the coreader, product, or (after
+   Haskell's Control.Comonad.Env) Env comonad — is the endofunctor e × − on
+   COQ, for a fixed type e of "environments", with
+
+       extract   (e0, v) = v               (read the value, drop the context)
+       duplicate (e0, v) = (e0, (e0, v))   (expose the context to the value)
+
+   It is dual to the writer monad m × −: where writer requires a monoid
+   structure on m to merge accumulated output, the environment comonad
+   requires a comonoid structure on e to copy and discard the ambient
+   context, and in the cartesian category COQ every type carries one
+   canonically (the diagonal and the terminal map).  Morphisms W x ~> y of
+   its co-Kleisli category (Comonad/CoKleisli.v) are exactly the functions
+   e * x → y that consult an ambient environment.
+
+   Following Theory/Monad.v's [Comonad := @Monad (C^op) (W^op)], the witness
+   [Env_Comonad] below is literally a [Monad] on COQ^op; the covariant
+   accessors of Comonad/Core.v then read [extract], [duplicate] and [extend]
+   off it definitionally (the *_spec lemmas at the end hold by
+   [reflexivity]).
+
+   COQ's morphism equivalence is pointwise Leibniz equality, so every law
+   here is proved by destructuring the pair argument and [reflexivity]: no
+   functional extensionality — indeed no axiom of any kind — enters this
+   file, and every definition below is closed under the global context. *)
+
+(** The action of e × − on morphisms: apply f under the environment. *)
+Definition env_map {e x y : Type} (f : x → y) (p : e * x) : e * y :=
+  match p with (e0, v) => (e0, f v) end.
+
+Lemma env_map_respects {e x y : Type} (f g : x → y) :
+  (∀ v, f v = g v) → ∀ p : e * x, env_map f p = env_map g p.
+Proof.
+  intros Hfg [e0 v]; simpl.
+  now rewrite Hfg.
+Qed.
+
+Lemma env_map_id {e x : Type} (p : e * x) : env_map (λ v : x, v) p = p.
+Proof. now destruct p. Qed.
+
+Lemma env_map_comp {e x y z : Type} (f : y → z) (g : x → y) (p : e * x) :
+  env_map (λ v, f (g v)) p = env_map f (env_map g p).
+Proof. now destruct p. Qed.
+
+(** The environment endofunctor e × − on COQ. *)
+Definition EnvF (e : Type) : Coq ⟶ Coq := @Build_Functor Coq Coq
+  (λ x : Type, (e * x)%type)
+  (λ (x y : Type) (f : x → y), @env_map e x y f)
+  (λ x y : Type, @env_map_respects e x y)
+  (λ x : Type, @env_map_id e x)
+  (λ (x y z : Type) (f : y → z) (g : x → y), @env_map_comp e x y z f g).
+
+(** The counit ε: project out the value. *)
+Definition env_extract {e x : Type} (p : e * x) : x := snd p.
+
+(** The comultiplication δ: copy the environment into the payload. *)
+Definition env_duplicate {e x : Type} (p : e * x) : e * (e * x) :=
+  match p with (e0, v) => (e0, (e0, v)) end.
+
+(** Naturality of the counit — the op-read of [fmap_ret]. *)
+Lemma env_extract_natural {e x y : Type} (f : x → y) (p : e * x) :
+  f (env_extract p) = env_extract (env_map f p).
+Proof. now destruct p. Qed.
+
+(** Coassociativity W δ ∘ δ ≈ δ ∘ δ — the op-read of [join_fmap_join]. *)
+Lemma env_duplicate_coassoc {e x : Type} (p : e * x) :
+  env_map env_duplicate (env_duplicate p) = env_duplicate (env_duplicate p).
+Proof. now destruct p. Qed.
+
+(** Counit law W ε ∘ δ ≈ id — the op-read of [join_fmap_ret]. *)
+Lemma env_fmap_extract_duplicate {e x : Type} (p : e * x) :
+  env_map env_extract (env_duplicate p) = p.
+Proof. now destruct p. Qed.
+
+(** Counit law ε ∘ δ ≈ id — the op-read of [join_ret]. *)
+Lemma env_extract_duplicate {e x : Type} (p : e * x) :
+  env_extract (env_duplicate p) = p.
+Proof. now destruct p. Qed.
+
+(** Naturality of the comultiplication — the op-read of [join_fmap_fmap]. *)
+Lemma env_duplicate_natural {e x y : Type} (f : x → y) (p : e * x) :
+  env_map (env_map f) (env_duplicate p) = env_duplicate (env_map f p).
+Proof. now destruct p. Qed.
+
+(** The comonad witness: per Theory/Monad.v, a comonad on COQ IS a monad on
+    COQ^op, so the record is assembled with [Build_Monad] at (COQ^op,
+    (EnvF e)^op) — [ret] is the counit and [join] the comultiplication, and
+    each monad law is the corresponding lemma above, read through the
+    opposite category's reversed composition. *)
+#[export] Instance Env_Comonad (e : Type) : @Comonad Coq (EnvF e) :=
+  @Build_Monad (Coq^op) ((EnvF e)^op)
+    (λ x : Type, @env_extract e x)                (* ret  = ε *)
+    (λ x : Type, @env_duplicate e x)              (* join = δ *)
+    (λ (x y : Type) (f : y → x), @env_extract_natural e y x f)
+    (λ x : Type, @env_duplicate_coassoc e x)
+    (λ x : Type, @env_fmap_extract_duplicate e x)
+    (λ x : Type, @env_extract_duplicate e x)
+    (λ (x y : Type) (f : y → x), @env_duplicate_natural e y x f).
+
+(** The covariant accessors of Comonad/Core.v compute on this witness
+    exactly as promised: [extract] is [snd], [duplicate] copies the
+    environment, and [extend f] runs f with the environment kept in scope. *)
+
+Lemma Env_extract_spec {e x : Type} (p : e * x) :
+  extract[EnvF e] p = snd p.
+Proof. reflexivity. Qed.
+
+Lemma Env_duplicate_spec {e x : Type} (e0 : e) (v : x) :
+  duplicate[EnvF e] (e0, v) = (e0, (e0, v)).
+Proof. reflexivity. Qed.
+
+Lemma Env_extend_spec {e x y : Type} (f : e * x → y) (e0 : e) (v : x) :
+  extend[EnvF e] f (e0, v) = (e0, f (e0, v)).
+Proof. reflexivity. Qed.

--- a/Instance/Coq/Comonad/Store.v
+++ b/Instance/Coq/Comonad/Store.v
@@ -1,0 +1,368 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Functor.
+Require Import Category.Theory.Monad.
+Require Import Category.Construction.Opposite.
+Require Import Category.Functor.Opposite.
+Require Import Category.Comonad.Core.
+Require Import Category.Instance.Sets.
+
+Generalizable All Variables.
+
+(** * The store (costate) comonad *)
+
+(* nLab:      https://ncatlab.org/nlab/show/store+comonad
+   Wikipedia: https://en.wikipedia.org/wiki/Monad_(category_theory)#Comonads
+
+   The store comonad — also called the costate comonad — over a fixed object
+   s of "positions" sends x to (s ⇒ x) × s: a store is an observation
+   function h from positions to values together with a currently focused
+   position s0, with
+
+       extract   (h, s0) = h s0                 (observe at the current focus)
+       duplicate (h, s0) = ((λ σ, (h, σ)), s0)  (a store of stores: at every
+                                                 position σ, the same
+                                                 observation refocused at σ)
+
+   Abstractly it is the comonad F ◯ U of the currying adjunction
+   (− × s) ⊣ (s ⇒ −) on a cartesian closed category, dually to the state
+   monad U ◯ F = s ⇒ (− × s).  Its coalgebras are the "very well-behaved
+   lenses" of functional programming.
+
+   Following Theory/Monad.v's [Comonad := @Monad (C^op) (W^op)], the witness
+   [Store_Comonad] below is literally a [Monad] on the opposite category; the
+   covariant accessors of Comonad/Core.v then read [extract], [duplicate] and
+   [extend] off it definitionally (the *_spec lemmas at the end hold by
+   [reflexivity]). *)
+
+(** ** The store data over raw types, and why the witness is hosted on Sets
+
+    Instance/Coq/Comonad/Env.v hosts the environment comonad on COQ, whose
+    morphism equivalence is pointwise Leibniz equality.  For the store
+    functor every comonad *equation* of the corresponding raw data likewise
+    holds pointwise and definitionally: the [coq_store_*] lemmas below check
+    all of them by destructuring alone, with no axiom involved.
+
+    What resists is not any equation but the *setoid respectfulness* of the
+    functor action, the [fmap_respects] field a [Functor] on COQ must carry.
+    Because a store places the observation function h : s → x inside the
+    object, respectfulness at pointwise-= homs asks for Leibniz equality of
+    function components given only pointwise-equal inputs, and
+    [coq_store_map_proper_entails_funext] shows that the very first instance
+    of that obligation already implies functional extensionality for
+    functions out of an inhabited s.  The obligation is therefore not merely
+    inconvenient: it is out of reach for axiom-free Coq.
+
+    This is precisely the corner named by the plan's Phase 6 risk note
+    (doc/classical-completion-plan.md), together with the sanctioned move:
+    "if a corner genuinely resists, move that single instance to Sets
+    (setoid homs make the law proper-trivial) and record the move in the
+    phase PR — the deliverable is the comonad witness, not its host
+    category."  The bundled witness
+    [Store_Comonad] accordingly lives on [Sets], where the store object
+    carries a componentwise setoid and respectfulness is a one-line
+    pointwise argument.  The file keeps its planned location. *)
+
+(** The plan-prescribed action on raw types: apply f to every observation,
+    keep the focus. *)
+Definition coq_store_map {s x y : Type} (f : x → y) (p : (s → x) * s) :
+  (s → y) * s :=
+  match p with (h, s0) => ((λ σ, f (h σ)), s0) end.
+
+(** The counit on raw types: observe at the current focus. *)
+Definition coq_store_extract {s x : Type} (p : (s → x) * s) : x :=
+  match p with (h, s0) => h s0 end.
+
+(** The comultiplication on raw types: refocus at every position. *)
+Definition coq_store_duplicate {s x : Type} (p : (s → x) * s) :
+  (s → (s → x) * s) * s :=
+  match p with (h, s0) => ((λ σ, (h, σ)), s0) end.
+
+(** Both functor equations hold pointwise; eta for functions is part of
+    Coq's definitional equality, so destructuring the pair suffices. *)
+
+Lemma coq_store_map_id {s x : Type} (p : (s → x) * s) :
+  coq_store_map (λ v : x, v) p = p.
+Proof. now destruct p. Qed.
+
+Lemma coq_store_map_comp {s x y z : Type} (f : y → z) (g : x → y)
+  (p : (s → x) * s) :
+  coq_store_map (λ v, f (g v)) p = coq_store_map f (coq_store_map g p).
+Proof. now destruct p. Qed.
+
+(** So do all five comonad equations, stated in the op-read orientation of
+    Theory/Monad.v's monad laws (cf. Instance/Coq/Comonad/Env.v). *)
+
+Lemma coq_store_extract_natural {s x y : Type} (f : x → y)
+  (p : (s → x) * s) :
+  f (coq_store_extract p) = coq_store_extract (coq_store_map f p).
+Proof. now destruct p. Qed.
+
+Lemma coq_store_duplicate_coassoc {s x : Type} (p : (s → x) * s) :
+  coq_store_map coq_store_duplicate (coq_store_duplicate p)
+    = coq_store_duplicate (coq_store_duplicate p).
+Proof. now destruct p. Qed.
+
+Lemma coq_store_fmap_extract_duplicate {s x : Type} (p : (s → x) * s) :
+  coq_store_map coq_store_extract (coq_store_duplicate p) = p.
+Proof. now destruct p. Qed.
+
+Lemma coq_store_extract_duplicate {s x : Type} (p : (s → x) * s) :
+  coq_store_extract (coq_store_duplicate p) = p.
+Proof. now destruct p. Qed.
+
+Lemma coq_store_duplicate_natural {s x y : Type} (f : x → y)
+  (p : (s → x) * s) :
+  coq_store_map (coq_store_map f) (coq_store_duplicate p)
+    = coq_store_duplicate (coq_store_map f p).
+Proof. now destruct p. Qed.
+
+(** The obstruction, machine-checked: the respectfulness a COQ-hosted store
+    functor would owe — at the single instance x := s, with the identity
+    observation as the store — is already the statement of functional
+    extensionality for functions out of s, whenever s is inhabited (the
+    final conversion step is definitional eta).  Restricted functional
+    extensionality is independent of Coq's type theory, so no axiom-free
+    [Functor] on COQ can carry this action, and the bundled witness below
+    is hosted on [Sets] instead. *)
+
+Lemma coq_store_map_proper_entails_funext {s y : Type} (s0 : s)
+  (respects : ∀ f g : s → y,
+      (∀ v, f v = g v) →
+      ∀ p : (s → s) * s, coq_store_map f p = coq_store_map g p) :
+  ∀ f g : s → y, (∀ v, f v = g v) → f = g.
+Proof.
+  intros f g Hfg.
+  exact (f_equal fst (respects f g Hfg ((λ σ, σ), s0))).
+Qed.
+
+(** ** The store setoid on [Sets] *)
+
+(* A store over the setoid s is an ≈-respecting observation map paired with
+   a position; two stores are equivalent when the observations agree
+   pointwise (up to the codomain's ≈) and the positions agree (up to s's ≈).
+   This componentwise relation is exactly what makes every obligation below
+   pointwise, in contrast to the Leibniz pairing over raw types above. *)
+
+Definition store_equiv {s x : SetoidObject} :
+  crelation (SetoidMorphism s x * carrier s) :=
+  λ p q, ((∀ σ : carrier s, fst p σ ≈ fst q σ) * (snd p ≈ snd q))%type.
+
+Arguments store_equiv {s x} _ _ /.
+
+#[local] Obligation Tactic := idtac.
+
+Program Definition store_obj (s x : SetoidObject) : SetoidObject := {|
+  carrier := SetoidMorphism s x * carrier s;
+  is_setoid := {| equiv := store_equiv; setoid_equiv := _ |}
+|}.
+Next Obligation.
+  intros s x; constructor.
+  - intros p; split.
+    + intros σ; reflexivity.
+    + reflexivity.
+  - intros p q [Hh Hs]; split.
+    + intros σ; symmetry; apply Hh.
+    + now symmetry.
+  - intros p q r [Hh Hs] [Hg Ht]; split.
+    + intros σ; etransitivity.
+      * apply Hh.
+      * apply Hg.
+    + etransitivity.
+      * exact Hs.
+      * exact Ht.
+Qed.
+
+(** ** The functorial action *)
+
+(* Post-composition under the observation map: f is applied to every
+   observation, the focus is kept. *)
+Program Definition store_map {s x y : SetoidObject} (f : SetoidMorphism x y) :
+  SetoidMorphism (store_obj s x) (store_obj s y) := {|
+  morphism := λ p, (setoid_morphism_compose f (fst p), snd p)
+|}.
+Next Obligation.
+  intros s x y f p q [Hh Hs]; split.
+  - intros σ; simpl.
+    apply proper_morphism, Hh.
+  - exact Hs.
+Qed.
+
+(** [store_map] respects ≈ pointwise — the field whose COQ counterpart is
+    the funext-entailing obligation above; here it is immediate. *)
+Lemma store_map_respects {s x y : SetoidObject} (f g : SetoidMorphism x y) :
+  (∀ v : carrier x, f v ≈ g v) →
+  ∀ p : SetoidMorphism s x * carrier s,
+    store_equiv (store_map f p) (store_map g p).
+Proof.
+  intros Hfg p; split.
+  - intros σ; simpl.
+    apply Hfg.
+  - reflexivity.
+Qed.
+
+Lemma store_map_id {s x : SetoidObject}
+  (p : SetoidMorphism s x * carrier s) :
+  store_equiv (store_map setoid_morphism_id p) p.
+Proof.
+  split.
+  - intros σ; reflexivity.
+  - reflexivity.
+Qed.
+
+Lemma store_map_comp {s x y z : SetoidObject}
+  (f : SetoidMorphism y z) (g : SetoidMorphism x y)
+  (p : SetoidMorphism s x * carrier s) :
+  store_equiv (store_map (setoid_morphism_compose f g) p)
+              (store_map f (store_map g p)).
+Proof.
+  split.
+  - intros σ; reflexivity.
+  - reflexivity.
+Qed.
+
+(** The store endofunctor (s ⇒ −) × s on [Sets]. *)
+Definition StoreF (s : SetoidObject) : Sets ⟶ Sets := @Build_Functor Sets Sets
+  (λ x : SetoidObject, store_obj s x)
+  (λ (x y : SetoidObject) (f : SetoidMorphism x y), @store_map s x y f)
+  (λ x y : SetoidObject, @store_map_respects s x y)
+  (λ x : SetoidObject, @store_map_id s x)
+  (λ (x y z : SetoidObject) (f : SetoidMorphism y z) (g : SetoidMorphism x y),
+     @store_map_comp s x y z f g).
+
+(** ** The comonad structure *)
+
+(** The counit ε: observe at the current focus. *)
+Program Definition store_extract {s x : SetoidObject} :
+  SetoidMorphism (store_obj s x) x := {|
+  morphism := λ p, fst p (snd p)
+|}.
+Next Obligation.
+  intros s x p q [Hh Hs]; simpl.
+  etransitivity.
+  - apply Hh.
+  - now apply proper_morphism.
+Qed.
+
+(* Refocusing: pair the observation map with every position — the
+   observation component of [duplicate]. *)
+Program Definition store_seek {s x : SetoidObject} (h : SetoidMorphism s x) :
+  SetoidMorphism s (store_obj s x) := {|
+  morphism := λ σ, (h, σ)
+|}.
+Next Obligation.
+  intros s x h σ τ Hστ; split.
+  - intros ρ; reflexivity.
+  - exact Hστ.
+Qed.
+
+(** The comultiplication δ: a store of stores, refocused at every position. *)
+Program Definition store_duplicate {s x : SetoidObject} :
+  SetoidMorphism (store_obj s x) (store_obj s (store_obj s x)) := {|
+  morphism := λ p, (store_seek (fst p), snd p)
+|}.
+Next Obligation.
+  intros s x p q [Hh Hs]; split.
+  - intros σ; split.
+    + intros τ; apply Hh.
+    + reflexivity.
+  - exact Hs.
+Qed.
+
+(** Naturality of the counit — the op-read of [fmap_ret]. *)
+Lemma store_extract_natural {s x y : SetoidObject} (f : SetoidMorphism x y)
+  (p : SetoidMorphism s x * carrier s) :
+  f (store_extract p) ≈ store_extract (store_map f p).
+Proof. reflexivity. Qed.
+
+(** Coassociativity W δ ∘ δ ≈ δ ∘ δ — the op-read of [join_fmap_join]. *)
+Lemma store_duplicate_coassoc {s x : SetoidObject}
+  (p : SetoidMorphism s x * carrier s) :
+  store_equiv (store_map store_duplicate (store_duplicate p))
+              (store_duplicate (store_duplicate p)).
+Proof.
+  split.
+  - intros σ; reflexivity.
+  - reflexivity.
+Qed.
+
+(** Counit law W ε ∘ δ ≈ id — the op-read of [join_fmap_ret]. *)
+Lemma store_fmap_extract_duplicate {s x : SetoidObject}
+  (p : SetoidMorphism s x * carrier s) :
+  store_equiv (store_map store_extract (store_duplicate p)) p.
+Proof.
+  split.
+  - intros σ; reflexivity.
+  - reflexivity.
+Qed.
+
+(** Counit law ε ∘ δ ≈ id — the op-read of [join_ret]. *)
+Lemma store_extract_duplicate {s x : SetoidObject}
+  (p : SetoidMorphism s x * carrier s) :
+  store_equiv (store_extract (store_duplicate p)) p.
+Proof.
+  split.
+  - intros σ; reflexivity.
+  - reflexivity.
+Qed.
+
+(** Naturality of the comultiplication — the op-read of [join_fmap_fmap]. *)
+Lemma store_duplicate_natural {s x y : SetoidObject} (f : SetoidMorphism x y)
+  (p : SetoidMorphism s x * carrier s) :
+  store_equiv (store_map (store_map f) (store_duplicate p))
+              (store_duplicate (store_map f p)).
+Proof.
+  split.
+  - intros σ; reflexivity.
+  - reflexivity.
+Qed.
+
+(** The comonad witness: per Theory/Monad.v, a comonad on [Sets] IS a monad
+    on [Sets^op], so the record is assembled with [Build_Monad] at (Sets^op,
+    (StoreF s)^op) — [ret] is the counit and [join] the comultiplication,
+    and each monad law is the corresponding lemma above, read through the
+    opposite category's reversed composition. *)
+#[export] Instance Store_Comonad (s : SetoidObject) :
+  @Comonad Sets (StoreF s) :=
+  @Build_Monad (Sets^op) ((StoreF s)^op)
+    (λ x : SetoidObject, @store_extract s x)          (* ret  = ε *)
+    (λ x : SetoidObject, @store_duplicate s x)        (* join = δ *)
+    (λ (x y : SetoidObject) (f : SetoidMorphism y x),
+       @store_extract_natural s y x f)
+    (λ x : SetoidObject, @store_duplicate_coassoc s x)
+    (λ x : SetoidObject, @store_fmap_extract_duplicate s x)
+    (λ x : SetoidObject, @store_extract_duplicate s x)
+    (λ (x y : SetoidObject) (f : SetoidMorphism y x),
+       @store_duplicate_natural s y x f).
+
+(** The covariant accessors of Comonad/Core.v compute on this witness
+    exactly as the plan's skeleton promises: [extract] observes at the
+    focus, [duplicate] refocuses at every position, and [extend f] runs the
+    co-Kleisli arrow f on every refocused store while keeping the focus. *)
+
+Lemma Store_extract_spec {s x : SetoidObject}
+  (h : SetoidMorphism s x) (s0 : carrier s) :
+  extract[StoreF s] (h, s0) = h s0.
+Proof. reflexivity. Qed.
+
+Lemma Store_duplicate_spec {s x : SetoidObject}
+  (h : SetoidMorphism s x) (s0 : carrier s) :
+  duplicate[StoreF s] (h, s0) = (store_seek h, s0).
+Proof. reflexivity. Qed.
+
+Lemma Store_seek_spec {s x : SetoidObject}
+  (h : SetoidMorphism s x) (s0 σ : carrier s) :
+  fst (duplicate[StoreF s] (h, s0)) σ = (h, σ).
+Proof. reflexivity. Qed.
+
+Lemma Store_extend_spec {s x y : SetoidObject}
+  (f : SetoidMorphism (store_obj s x) y) (h : SetoidMorphism s x)
+  (s0 σ : carrier s) :
+  fst (extend[StoreF s] f (h, s0)) σ = f (h, σ).
+Proof. reflexivity. Qed.
+
+Lemma Store_extend_pos_spec {s x y : SetoidObject}
+  (f : SetoidMorphism (store_obj s x) y) (h : SetoidMorphism s x)
+  (s0 : carrier s) :
+  snd (extend[StoreF s] f (h, s0)) = s0.
+Proof. reflexivity. Qed.

--- a/Instance/Coq/Comonad/Traced.v
+++ b/Instance/Coq/Comonad/Traced.v
@@ -1,0 +1,362 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Functor.
+Require Import Category.Theory.Monad.
+Require Import Category.Construction.Opposite.
+Require Import Category.Functor.Opposite.
+Require Import Category.Comonad.Core.
+Require Import Category.Instance.Sets.
+
+Generalizable All Variables.
+
+(** * The traced (cowriter, exponent) comonad *)
+
+(* Haskell:   Control.Comonad.Traced (the comonad package)
+   Wikipedia: https://en.wikipedia.org/wiki/Monad_(category_theory)#Comonads
+
+   The traced comonad over a monoid (m, mempty, mappend) — Haskell's Traced,
+   also called the cowriter or exponent comonad — is the endofunctor m ⇒ −,
+   sending x to the functions m → x, with
+
+       extract   h = h mempty                  (evaluate at the neutral trace)
+       duplicate h = λ w w', h (mappend w w')  (evaluate under every further
+                                                translation of the context)
+
+   It is dual to the writer monad m × −: the same monoid structure that lets
+   a writer computation merge the output it emits lets a traced computation
+   split the context it consumes.  Both arise by pushing the monoid m through
+   a monoidal functor into the endofunctor category: m × − covariantly
+   (giving a monad), m ⇒ − contravariantly (giving a comonad, since
+   (m ⇒ −) ○ (m ⇒ −) ≅ (m × m) ⇒ − lets mappend and mempty land as the
+   comultiplication δ and the counit ε).  Co-Kleisli arrows (m → x) → y
+   consume a value together with all of its monoid translates — the comonad
+   of cellular automata (m a grid of offsets) and of monoid-weighted contexts
+   generally, with co-Kleisli composition accumulating the offsets.
+
+   Following Theory/Monad.v's [Comonad := @Monad (C^op) (W^op)], the witness
+   [Traced_Comonad] below is literally a [Monad] on the opposite category;
+   the covariant accessors of Comonad/Core.v then read [extract], [duplicate]
+   and [extend] off it definitionally (the *_spec lemmas at the end hold by
+   [reflexivity]). *)
+
+Section Traced.
+
+(** The section-context monoid: ordinary Coq data — a bare type together
+    with a unit, a multiplication, and the three monoid equations as Leibniz
+    laws. *)
+
+Context (m : Type).
+Context (mempty : m).
+Context (mappend : m → m → m).
+
+Hypothesis mempty_left  : ∀ w : m, mappend mempty w = w.
+Hypothesis mempty_right : ∀ w : m, mappend w mempty = w.
+Hypothesis mappend_assoc :
+  ∀ u v w : m, mappend u (mappend v w) = mappend (mappend u v) w.
+
+(** ** The traced data over raw types, and why the witness is hosted on Sets
+
+    Instance/Coq/Comonad/Env.v hosts the environment comonad on COQ, whose
+    morphism equivalence is pointwise Leibniz equality.  For the traced
+    functor, four of the seven functor/comonad equations of the corresponding
+    raw data below are closed by Coq's definitional beta and eta alone, at
+    the full function level (the Leibniz-valued lemmas below, all by
+    [reflexivity]).  The remaining three equations are exactly the ones that
+    consult the monoid laws, and their Leibniz forms compare functions that
+    differ beneath a binder — (λ w', h (mappend mempty w')) against h, and so
+    on.  Each of these holds pointwise, which is the restatement the plan
+    prescribes for this file (doc/classical-completion-plan.md, Phase 6), and
+    is proved below by rewriting the monoid law at the sampled point; the
+    Leibniz form itself is out of reach for axiom-free Coq.  So, moreover, is
+    the [fmap_respects] field a [Functor] on COQ must carry:
+    [coq_traced_map_proper_entails_funext] shows that the very first instance
+    of that obligation already implies functional extensionality for
+    functions out of m — no inhabitation hypothesis needed, the identity
+    trace exhibits it.
+
+    This is precisely the corner named by the plan's Phase 6 risk note,
+    together with the sanctioned move, already exercised by the store comonad
+    in Instance/Coq/Comonad/Store.v: "if a corner genuinely resists, move
+    that single instance to Sets (setoid homs make the law proper-trivial) —
+    the deliverable is the comonad witness, not its host category."  The
+    bundled witness [Traced_Comonad] accordingly lives on [Sets], where the
+    traced object m → x is compared pointwise up to the codomain's ≈ and
+    every equation above literally becomes its pointwise restatement.  The
+    monoid itself remains the ordinary Coq data of this section, and the
+    file keeps its planned location. *)
+
+(** The plan-prescribed action on raw types: post-compose the observation. *)
+Definition coq_traced_map {x y : Type} (f : x → y) (h : m → x) : m → y :=
+  λ w, f (h w).
+
+(** The counit on raw types: evaluate at the neutral trace. *)
+Definition coq_traced_extract {x : Type} (h : m → x) : x := h mempty.
+
+(** The comultiplication on raw types: evaluate under every translation. *)
+Definition coq_traced_duplicate {x : Type} (h : m → x) : m → m → x :=
+  λ w w', h (mappend w w').
+
+(** Four of the equations are definitional at the function level: beta and
+    eta for functions are part of Coq's conversion. *)
+
+Lemma coq_traced_map_id {x : Type} (h : m → x) :
+  coq_traced_map (λ v : x, v) h = h.
+Proof. reflexivity. Qed.
+
+Lemma coq_traced_map_comp {x y z : Type} (f : y → z) (g : x → y)
+  (h : m → x) :
+  coq_traced_map (λ v, f (g v)) h = coq_traced_map f (coq_traced_map g h).
+Proof. reflexivity. Qed.
+
+(** Naturality of the counit — the op-read of [fmap_ret]. *)
+Lemma coq_traced_extract_natural {x y : Type} (f : x → y) (h : m → x) :
+  f (coq_traced_extract h) = coq_traced_extract (coq_traced_map f h).
+Proof. reflexivity. Qed.
+
+(** Naturality of the comultiplication — the op-read of [join_fmap_fmap]. *)
+Lemma coq_traced_duplicate_natural {x y : Type} (f : x → y) (h : m → x) :
+  coq_traced_map (coq_traced_map f) (coq_traced_duplicate h)
+    = coq_traced_duplicate (coq_traced_map f h).
+Proof. reflexivity. Qed.
+
+(** The remaining three equations consult the monoid laws and hold pointwise
+    — each is the plan's restatement of the corresponding law at a sampled
+    trace. *)
+
+(** Counit law ε ∘ δ ≈ id, pointwise — the op-read of [join_ret]. *)
+Lemma coq_traced_extract_duplicate {x : Type} (h : m → x) (w : m) :
+  coq_traced_extract (coq_traced_duplicate h) w = h w.
+Proof using mempty_left.
+  unfold coq_traced_extract, coq_traced_duplicate.
+  now rewrite mempty_left.
+Qed.
+
+(** Counit law W ε ∘ δ ≈ id, pointwise — the op-read of [join_fmap_ret]. *)
+Lemma coq_traced_fmap_extract_duplicate {x : Type} (h : m → x) (w : m) :
+  coq_traced_map coq_traced_extract (coq_traced_duplicate h) w = h w.
+Proof using mempty_right.
+  unfold coq_traced_map, coq_traced_extract, coq_traced_duplicate.
+  now rewrite mempty_right.
+Qed.
+
+(** Coassociativity W δ ∘ δ ≈ δ ∘ δ, pointwise — the op-read of
+    [join_fmap_join]. *)
+Lemma coq_traced_duplicate_coassoc {x : Type} (h : m → x) (a b c : m) :
+  coq_traced_map coq_traced_duplicate (coq_traced_duplicate h) a b c
+    = coq_traced_duplicate (coq_traced_duplicate h) a b c.
+Proof using mappend_assoc.
+  unfold coq_traced_map, coq_traced_duplicate.
+  now rewrite mappend_assoc.
+Qed.
+
+(** The obstruction, machine-checked: the respectfulness a COQ-hosted traced
+    functor would owe — at the single instance x := m, with the identity
+    trace as the argument — is already the statement of functional
+    extensionality for functions out of the monoid (the final conversion
+    step is definitional eta).  Restricted functional extensionality is
+    independent of Coq's type theory, so no axiom-free [Functor] on COQ can
+    carry this action, and the bundled witness below is hosted on [Sets]
+    instead. *)
+
+Lemma coq_traced_map_proper_entails_funext {y : Type}
+  (respects : ∀ f g : m → y,
+      (∀ v, f v = g v) →
+      ∀ h : m → m, coq_traced_map f h = coq_traced_map g h) :
+  ∀ f g : m → y, (∀ v, f v = g v) → f = g.
+Proof.
+  intros f g Hfg.
+  exact (respects f g Hfg (λ w, w)).
+Qed.
+
+(** ** The traced setoid on [Sets] *)
+
+(* A traced value over the raw monoid m is a bare function m → x into the
+   setoid x; two of them are equivalent when they agree at every trace, up to
+   the codomain's ≈.  This componentwise relation is exactly what makes every
+   obligation below pointwise, in contrast to the Leibniz function
+   equalities demanded over raw types above.  The monoid needs no setoid of
+   its own: it enters only through the (Leibniz) rewriting of its laws at
+   sampled points. *)
+
+Definition traced_equiv {x : SetoidObject} : crelation (m → carrier x) :=
+  λ h k, ∀ w : m, h w ≈ k w.
+
+Arguments traced_equiv {x} _ _ /.
+
+#[local] Obligation Tactic := idtac.
+
+Program Definition traced_obj (x : SetoidObject) : SetoidObject := {|
+  carrier := m → carrier x;
+  is_setoid := {| equiv := traced_equiv; setoid_equiv := _ |}
+|}.
+Next Obligation.
+  intros x; constructor.
+  - intros h w.
+    reflexivity.
+  - intros h k Hhk w.
+    symmetry; apply Hhk.
+  - intros h k l Hhk Hkl w.
+    etransitivity.
+    + apply Hhk.
+    + apply Hkl.
+Qed.
+
+(** ** The functorial action *)
+
+(* Post-composition under the trace: f is applied to the value observed at
+   every trace. *)
+Program Definition traced_map {x y : SetoidObject} (f : SetoidMorphism x y) :
+  SetoidMorphism (traced_obj x) (traced_obj y) := {|
+  morphism := λ h w, f (h w)
+|}.
+Next Obligation.
+  intros x y f h k Hhk w; simpl.
+  apply proper_morphism, Hhk.
+Qed.
+
+(** [traced_map] respects ≈ pointwise — the field whose COQ counterpart is
+    the funext-entailing obligation above; here it is immediate. *)
+Lemma traced_map_respects {x y : SetoidObject} (f g : SetoidMorphism x y) :
+  (∀ v : carrier x, f v ≈ g v) →
+  ∀ h : m → carrier x, traced_equiv (traced_map f h) (traced_map g h).
+Proof.
+  intros Hfg h w; simpl.
+  apply Hfg.
+Qed.
+
+Lemma traced_map_id {x : SetoidObject} (h : m → carrier x) :
+  traced_equiv (traced_map setoid_morphism_id h) h.
+Proof.
+  intros w; simpl.
+  reflexivity.
+Qed.
+
+Lemma traced_map_comp {x y z : SetoidObject}
+  (f : SetoidMorphism y z) (g : SetoidMorphism x y) (h : m → carrier x) :
+  traced_equiv (traced_map (setoid_morphism_compose f g) h)
+               (traced_map f (traced_map g h)).
+Proof.
+  intros w; simpl.
+  reflexivity.
+Qed.
+
+(** The traced endofunctor m ⇒ − on [Sets]. *)
+Definition TracedF : Sets ⟶ Sets := @Build_Functor Sets Sets
+  (λ x : SetoidObject, traced_obj x)
+  (λ (x y : SetoidObject) (f : SetoidMorphism x y), @traced_map x y f)
+  (λ x y : SetoidObject, @traced_map_respects x y)
+  (λ x : SetoidObject, @traced_map_id x)
+  (λ (x y z : SetoidObject) (f : SetoidMorphism y z) (g : SetoidMorphism x y),
+     @traced_map_comp x y z f g).
+
+(** ** The comonad structure *)
+
+(** The counit ε: evaluate at the neutral trace. *)
+Program Definition traced_extract {x : SetoidObject} :
+  SetoidMorphism (traced_obj x) x := {|
+  morphism := λ h, h mempty
+|}.
+Next Obligation.
+  intros x h k Hhk; simpl.
+  apply Hhk.
+Qed.
+
+(** The comultiplication δ: evaluate under every further translation. *)
+Program Definition traced_duplicate {x : SetoidObject} :
+  SetoidMorphism (traced_obj x) (traced_obj (traced_obj x)) := {|
+  morphism := λ h w w', h (mappend w w')
+|}.
+Next Obligation.
+  intros x h k Hhk w w'; simpl.
+  apply Hhk.
+Qed.
+
+(** Naturality of the counit — the op-read of [fmap_ret]. *)
+Lemma traced_extract_natural {x y : SetoidObject} (f : SetoidMorphism x y)
+  (h : m → carrier x) :
+  f (traced_extract h) ≈ traced_extract (traced_map f h).
+Proof. reflexivity. Qed.
+
+(** Coassociativity W δ ∘ δ ≈ δ ∘ δ — the op-read of [join_fmap_join]. *)
+Lemma traced_duplicate_coassoc {x : SetoidObject} (h : m → carrier x) :
+  traced_equiv (traced_map traced_duplicate (traced_duplicate h))
+               (traced_duplicate (traced_duplicate h)).
+Proof using mappend_assoc.
+  intros a b c; simpl.
+  now rewrite mappend_assoc.
+Qed.
+
+(** Counit law W ε ∘ δ ≈ id — the op-read of [join_fmap_ret]. *)
+Lemma traced_fmap_extract_duplicate {x : SetoidObject} (h : m → carrier x) :
+  traced_equiv (traced_map traced_extract (traced_duplicate h)) h.
+Proof using mempty_right.
+  intros w; simpl.
+  now rewrite mempty_right.
+Qed.
+
+(** Counit law ε ∘ δ ≈ id — the op-read of [join_ret]. *)
+Lemma traced_extract_duplicate {x : SetoidObject} (h : m → carrier x) :
+  traced_equiv (traced_extract (traced_duplicate h)) h.
+Proof using mempty_left.
+  intros w; simpl.
+  now rewrite mempty_left.
+Qed.
+
+(** Naturality of the comultiplication — the op-read of [join_fmap_fmap]. *)
+Lemma traced_duplicate_natural {x y : SetoidObject} (f : SetoidMorphism x y)
+  (h : m → carrier x) :
+  traced_equiv (traced_map (traced_map f) (traced_duplicate h))
+               (traced_duplicate (traced_map f h)).
+Proof.
+  intros w w'; simpl.
+  reflexivity.
+Qed.
+
+(** The comonad witness: per Theory/Monad.v, a comonad on [Sets] IS a monad
+    on [Sets^op], so the record is assembled with [Build_Monad] at (Sets^op,
+    TracedF^op) — [ret] is the counit and [join] the comultiplication, and
+    each monad law is the corresponding lemma above, read through the
+    opposite category's reversed composition. *)
+Definition Traced_Comonad : @Comonad Sets TracedF :=
+  @Build_Monad (Sets^op) (TracedF^op)
+    (λ x : SetoidObject, @traced_extract x)           (* ret  = ε *)
+    (λ x : SetoidObject, @traced_duplicate x)         (* join = δ *)
+    (λ (x y : SetoidObject) (f : SetoidMorphism y x),
+       @traced_extract_natural y x f)
+    (λ x : SetoidObject, @traced_duplicate_coassoc x)
+    (λ x : SetoidObject, @traced_fmap_extract_duplicate x)
+    (λ x : SetoidObject, @traced_extract_duplicate x)
+    (λ (x y : SetoidObject) (f : SetoidMorphism y x),
+       @traced_duplicate_natural y x f).
+
+#[local] Existing Instance Traced_Comonad.
+
+(** The covariant accessors of Comonad/Core.v compute on this witness
+    exactly as the plan's skeleton promises: [extract] evaluates at the
+    neutral trace, [duplicate] evaluates under every further translation,
+    and [extend f] runs the co-Kleisli arrow f on every translate of its
+    argument. *)
+
+Lemma Traced_extract_spec {x : SetoidObject} (h : m → carrier x) :
+  extract[TracedF] h = h mempty.
+Proof. reflexivity. Qed.
+
+Lemma Traced_duplicate_spec {x : SetoidObject} (h : m → carrier x)
+  (w w' : m) :
+  duplicate[TracedF] h w w' = h (mappend w w').
+Proof. reflexivity. Qed.
+
+Lemma Traced_extend_spec {x y : SetoidObject}
+  (f : SetoidMorphism (traced_obj x) y) (h : m → carrier x) (w : m) :
+  extend[TracedF] f h w = f (λ w' : m, h (mappend w w')).
+Proof. reflexivity. Qed.
+
+End Traced.
+
+(* No [#[export] Existing Instance] here: the monoid supply (mempty, mappend,
+   and the three laws) is a section premise not determined by the instance
+   head [@Comonad Sets (TracedF m)], so a global registration would force
+   typeclass resolution to backtrack through undischargeable subgoals.
+   Callers apply [Traced_Comonad] with explicit monoid arguments; the
+   [#[local] Existing Instance] above already serves the in-section spec
+   lemmas. *)

--- a/Monad/Eilenberg/Moore.v
+++ b/Monad/Eilenberg/Moore.v
@@ -27,12 +27,22 @@ Generalizable All Variables.
 
    The forgetful functor U^T : C^T → C, (a, ν) ↦ a, has the free-algebra
    functor F^T : C → C^T, x ↦ (T x, μ_x), as left adjoint, and the monad
-   U^T ∘ F^T arising from F^T ⊣ U^T is exactly T. This is the terminal such
-   resolution of T; the Kleisli category (see Monad/Kleisli.v) is the initial
+   U^T ∘ F^T arising from F^T ⊣ U^T is exactly T; that adjunction is
+   constructed in Monad/Eilenberg/Moore/Adjunction.v ([EM_Free] ⊣ [EM_Forget]
+   as [EM_Adjunction], recovering T via [EM_Monad_agrees]). This is the
+   terminal such resolution of T; the Kleisli category (see Monad/Kleisli.v,
+   whose own resolution lives in Monad/Kleisli/Adjunction.v) is the initial
    one, sitting inside C^T as the full subcategory of free algebras. *)
 
-Program Definition EilenbergMoore `(T : C ⟶ C) `{@Monad C T} : Category := {|
-  obj     := ∃ a : C, TAlgebra T a;
+(* The monad instance is bound by name so that [TAlgebra]'s instance argument
+   can be given explicitly in [obj]: were it left to Program, the elaborator
+   would seal that argument behind a Qed-opaque obligation constant, and
+   algebras built against the ambient instance [H] — such as the free algebras
+   (T a, μ_a) of Moore/Adjunction.v — would not be recognized as objects of
+   this category. *)
+
+Program Definition EilenbergMoore `(T : C ⟶ C) `{H : @Monad C T} : Category := {|
+  obj     := ∃ a : C, @TAlgebra C T H a;
   hom     := fun x y => TAlgebraHom T ``x ``y (projT2 x) (projT2 y);
   homset  := fun _ _ => {| equiv := fun f g => t_alg_hom[f] ≈ t_alg_hom[g] |};
   id      := fun _ => {| t_alg_hom := id |};

--- a/Monad/Eilenberg/Moore/Adjunction.v
+++ b/Monad/Eilenberg/Moore/Adjunction.v
@@ -1,0 +1,226 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Theory.Monad.
+Require Import Category.Theory.Adjunction.
+Require Import Category.Monad.Algebra.
+Require Import Category.Monad.Eilenberg.Moore.
+Require Import Category.Instance.Sets.
+
+Generalizable All Variables.
+
+(** * The Eilenberg–Moore free/forgetful adjunction
+
+    nLab: https://ncatlab.org/nlab/show/Eilenberg-Moore+category
+    Wikipedia: https://en.wikipedia.org/wiki/Monad_(category_theory)
+
+    Monad/Adjunction.v shows that every adjunction F ⊣ U induces a monad
+    U ◯ F on the domain of F.  This file provides the terminal converse
+    resolution, through the Eilenberg–Moore category C^T of algebras
+    (Monad/Eilenberg/Moore.v) of a monad (T, ret, join) = (T, η, μ) on C:
+
+    - [EM_Forget] U^T : C^T ⟶ C sends an algebra (a, ν) to its carrier a,
+      and an algebra homomorphism to its underlying C-arrow;
+    - [EM_Free] F^T : C ⟶ C^T sends x to the free algebra (T x, μ_x): the
+      structure map is the multiplication join, whose algebra laws are the
+      monad laws [join_ret] and [join_fmap_join], and a morphism f : x ~> y
+      becomes the homomorphism fmap[T] f, which intertwines the two free
+      actions by the multiplication naturality [join_fmap_fmap];
+    - [EM_Adjunction] F^T ⊣ U^T: the transpose ⌊g⌋ of an algebra map
+      g : (T x, μ_x) ~> (b, ν) is t_alg_hom[g] ∘ ret, and the transpose
+      ⌈f⌉ of f : x ~> b is its universal extension ν ∘ fmap[T] f, packaged
+      as an algebra homomorphism by [EM_extend].  That the two transposes
+      are mutually inverse is the universal property of the free algebra:
+      [EM_extend_ret] (extension restricted along η recovers f) and
+      [EM_extend_unique] (every algebra map out of a free algebra is the
+      extension of its own restriction).
+
+    The adjunction presents the monad we started with:
+    [EM_Monad_agrees] identifies the composite U^T ◯ F^T with T (a natural
+    isomorphism whose components are identities), [EM_unit_agrees]
+    identifies the adjunction unit with ret, and [EM_join_agrees]
+    identifies the U^T-image of the counit — which is exactly the
+    multiplication of the monad that Monad/Adjunction.v extracts from this
+    adjunction — with join.  The counit itself acts at (b, ν) by the
+    structure map ν ([EM_counit_agrees]).
+
+    This is the terminal resolution of T; the initial one is the Kleisli
+    adjunction of Monad/Kleisli/Adjunction.v, whose comparison into C^T
+    lands in the free algebras. *)
+
+Section EilenbergMooreAdjunction.
+
+Context {C : Category}.
+Context (T : C ⟶ C).
+Context `{H : @Monad C T}.
+
+#[local] Obligation Tactic := program_simpl.
+
+(** The forgetful functor C^T ⟶ C: project the carrier of an algebra and
+    the underlying arrow of an algebra homomorphism.  Since equivalence of
+    algebra homomorphisms in C^T is equivalence of their underlying arrows,
+    all three functor laws hold on the nose. *)
+
+Program Definition EM_Forget : EilenbergMoore T ⟶ C := {|
+  fobj := fun a => `1 a;
+  fmap := fun _ _ f => t_alg_hom[f]
+|}.
+Next Obligation. proper. Qed.
+Next Obligation. reflexivity. Qed.
+Next Obligation. reflexivity. Qed.
+
+(** The free-algebra functor C ⟶ C^T: on objects, the free algebra
+    (T x, μ_x); on morphisms, fmap[T].  The algebra laws for μ_x are the
+    monad unit law join_ret and the associativity join_fmap_join, and the
+    homomorphism square for fmap[T] f is the multiplication naturality
+    join_fmap_fmap. *)
+
+Program Definition EM_Free : C ⟶ EilenbergMoore T := {|
+  fobj := fun a => (T a; {| t_alg := @join C T H a |});
+  fmap := fun x y f => {| t_alg_hom := fmap[T] f |}
+|}.
+Next Obligation. apply join_ret. Qed.
+Next Obligation. apply join_fmap_join. Qed.
+Next Obligation. symmetry; apply join_fmap_fmap. Qed.
+Next Obligation. proper; now rewrites. Qed.
+Next Obligation. apply fmap_id. Qed.
+Next Obligation. apply fmap_comp. Qed.
+
+(** The universal property of the free algebra, on underlying arrows.  Fix
+    an algebra (b, ν) and an arrow f : x ~> b.  Its extension ν ∘ fmap[T] f
+    is an algebra homomorphism (T x, μ_x) ~> (b, ν)
+    ([EM_extend_is_alg_hom]); it restricts along η back to f
+    ([EM_extend_ret]); and it is the only such homomorphism, in that any
+    algebra map g out of the free algebra is the extension of g ∘ η
+    ([EM_extend_unique]). *)
+
+Lemma EM_extend_is_alg_hom {x b : C} (N : @TAlgebra C T H b)
+      (f : x ~{C}~> b) :
+  (t_alg[N] ∘ fmap[T] f) ∘ join ≈ t_alg[N] ∘ fmap[T] (t_alg[N] ∘ fmap[T] f).
+Proof.
+  rewrite fmap_comp.
+  rewrite comp_assoc.
+  rewrite (@t_action _ _ _ _ N).
+  rewrite <- !comp_assoc.
+  rewrite join_fmap_fmap.
+  reflexivity.
+Qed.
+
+Lemma EM_extend_ret {x b : C} (N : @TAlgebra C T H b) (f : x ~{C}~> b) :
+  (t_alg[N] ∘ fmap[T] f) ∘ ret ≈ f.
+Proof.
+  rewrite <- comp_assoc.
+  rewrite <- fmap_ret.
+  rewrite comp_assoc.
+  rewrite (@t_id _ _ _ _ N).
+  apply id_left.
+Qed.
+
+Lemma EM_extend_unique {x b : C} (N : @TAlgebra C T H b) (g : T x ~{C}~> b)
+      (Hg : g ∘ join ≈ t_alg[N] ∘ fmap[T] g) :
+  t_alg[N] ∘ fmap[T] (g ∘ ret) ≈ g.
+Proof.
+  rewrite fmap_comp.
+  rewrite comp_assoc.
+  rewrite <- Hg.
+  rewrite <- comp_assoc.
+  rewrite join_fmap_ret.
+  apply id_right.
+Qed.
+
+(** The extension, packaged as a morphism of C^T out of a free algebra. *)
+
+Program Definition EM_extend {x : C} {y : EilenbergMoore T}
+        (f : x ~{C}~> `1 y) : EM_Free x ~{EilenbergMoore T}~> y := {|
+  t_alg_hom := t_alg[`2 y] ∘ fmap[T] f
+|}.
+Next Obligation. apply EM_extend_is_alg_hom. Qed.
+
+(** [EM_extend_unique], restated for a morphism of C^T out of a free
+    algebra: extending the restriction of g recovers g.  The structure map
+    of the free algebra is definitionally join, so the commuting square of
+    g is exactly the hypothesis that [EM_extend_unique] consumes. *)
+
+Lemma EM_restrict_extend {x : C} {y : EilenbergMoore T}
+      (g : EM_Free x ~{EilenbergMoore T}~> y) :
+  t_alg[`2 y] ∘ fmap[T] (t_alg_hom[g] ∘ ret) ≈ t_alg_hom[g].
+Proof.
+  apply EM_extend_unique.
+  apply (@t_alg_hom_commutes _ _ _ _ _ _ _ g).
+Qed.
+
+(** The transposition isomorphism of hom-setoids: an algebra homomorphism
+    F^T x ~{C^T}~> (b, ν) corresponds to a C-arrow x ~> b, forward by
+    restriction along η, backward by [EM_extend]. *)
+
+Program Definition EM_adj_iso (x : C) (y : EilenbergMoore T) :
+  @Isomorphism Sets
+    {| carrier   := @hom (EilenbergMoore T) (EM_Free x) y
+     ; is_setoid := @homset (EilenbergMoore T) (EM_Free x) y |}
+    {| carrier   := @hom C x (EM_Forget y)
+     ; is_setoid := @homset C x (EM_Forget y) |} := {|
+  to   := {| morphism := fun g => t_alg_hom[g] ∘ ret |};
+  from := {| morphism := fun f => EM_extend f |}
+|}.
+Next Obligation. proper. Qed.
+Next Obligation. proper; now rewrites. Qed.
+Next Obligation. apply EM_extend_ret. Qed.
+Next Obligation. apply EM_restrict_extend. Qed.
+
+(** Naturality of the transposition in the source argument, on underlying
+    arrows: restricting after precomposition with a free arrow fmap[T] g is
+    restricting first and then precomposing with g in C. *)
+
+Lemma EM_transpose_nat_l {x y b : C} (h : T y ~{C}~> b) (g : x ~{C}~> y) :
+  (h ∘ fmap[T] g) ∘ ret ≈ (h ∘ ret) ∘ g.
+Proof.
+  rewrite <- comp_assoc.
+  rewrite <- fmap_ret.
+  now rewrite !comp_assoc.
+Qed.
+
+Program Definition EM_Adjunction : EM_Free ⊣ EM_Forget :=
+  @Build_Adjunction' (EilenbergMoore T) C EM_Free EM_Forget EM_adj_iso _ _.
+Next Obligation. apply EM_transpose_nat_l. Qed.
+Next Obligation. apply comp_assoc_sym. Qed.
+
+(** The unit of the adjunction is the unit of the monad. *)
+
+Lemma EM_unit_agrees {x : C} :
+  @unit _ _ _ _ EM_Adjunction x ≈ ret[T].
+Proof. apply id_left. Qed.
+
+(** The counit at an algebra (b, ν) acts by the structure map ν, stated on
+    the underlying arrow of the algebra homomorphism. *)
+
+Lemma EM_counit_agrees {y : EilenbergMoore T} :
+  t_alg_hom[@counit _ _ _ _ EM_Adjunction y] ≈ t_alg[`2 y].
+Proof.
+  cbn.
+  rewrite fmap_id.
+  apply id_right.
+Qed.
+
+(** The multiplication of the monad induced by this adjunction (per
+    Monad/Adjunction.v it is the U^T-image of the counit) is join. *)
+
+Lemma EM_join_agrees {x : C} :
+  fmap[EM_Forget] (@counit _ _ _ _ EM_Adjunction (EM_Free x)) ≈ join[T].
+Proof.
+  cbn.
+  rewrite fmap_id.
+  apply id_right.
+Qed.
+
+(** The resolution recovers T: the composite U^T ◯ F^T is naturally
+    isomorphic to T, with identity components. *)
+
+Theorem EM_Monad_agrees : EM_Forget ◯ EM_Free ≈ T.
+Proof.
+  exists (fun x => iso_id).
+  intros x y f; cbn.
+  cat.
+Qed.
+
+End EilenbergMooreAdjunction.

--- a/Monad/Kleisli/Adjunction.v
+++ b/Monad/Kleisli/Adjunction.v
@@ -1,0 +1,167 @@
+Require Import Category.Lib.
+Require Import Category.Theory.Category.
+Require Import Category.Theory.Isomorphism.
+Require Import Category.Theory.Functor.
+Require Import Category.Theory.Monad.
+Require Import Category.Theory.Adjunction.
+Require Import Category.Monad.Kleisli.
+Require Import Category.Instance.Sets.
+
+Generalizable All Variables.
+
+(** * The Kleisli free/forgetful adjunction
+
+    nLab: https://ncatlab.org/nlab/show/Kleisli+category
+    Wikipedia: https://en.wikipedia.org/wiki/Kleisli_category
+
+    Monad/Adjunction.v shows that every adjunction F ⊣ U induces a monad
+    U ◯ F on the domain of F.  This file provides the converse resolution
+    through the Kleisli category C_M of a monad M on C (Monad/Kleisli.v):
+
+    - [Kleisli_Free] F_M : C ⟶ C_M is the identity on objects and sends
+      f : x ~> y to the pure Kleisli morphism ret ∘ f;
+    - [Kleisli_Forget] U_M : C_M ⟶ C sends x to M x, and a Kleisli
+      morphism f : x ~> M y to its extension join ∘ fmap[M] f (its bind);
+    - [Kleisli_Adjunction] F_M ⊣ U_M: because F_M x = x and U_M y = M y,
+      the two hom-setoids of the transposition are literally the same
+      setoid x ~> M y, and the adjunction isomorphism [Kleisli_adj_iso]
+      is the identity map in both directions.
+
+    The adjunction presents the monad we started with:
+    [Kleisli_Monad_agrees] identifies the composite U_M ◯ F_M with M (a
+    natural isomorphism whose components are identities),
+    [Kleisli_unit_agrees] identifies the adjunction unit with ret, and
+    [Kleisli_join_agrees] identifies the U_M-image of the counit — which
+    is exactly the multiplication of the monad that Monad/Adjunction.v
+    extracts from this adjunction — with join.
+
+    The other canonical resolution of a monad, through the Eilenberg–Moore
+    category of algebras, lives in Monad/Eilenberg/Moore/Adjunction.v. *)
+
+Section KleisliAdjunction.
+
+Context `{@Monad C M}.
+
+#[local] Obligation Tactic := program_simpl.
+
+(** The free functor C ⟶ C_M: identity on objects; a morphism f becomes
+    the pure Kleisli computation ret ∘ f.  Identity preservation is the
+    right unit law of composition, and functoriality is the unit
+    naturality [fmap_ret] against the left unit law [join_fmap_ret]. *)
+
+Program Definition Kleisli_Free : C ⟶ Kleisli := {|
+  fobj := fun x => x;
+  fmap := fun x y f => ret ∘ f
+|}.
+Next Obligation. proper. Qed.
+Next Obligation. cat. Qed.
+Next Obligation.
+  (* ret ∘ (f ∘ g) ≈ join ∘ fmap[M] (ret ∘ f) ∘ (ret ∘ g) *)
+  rewrite fmap_comp.
+  rewrite (comp_assoc join).
+  rewrite join_fmap_ret.
+  rewrite id_left.
+  rewrite (comp_assoc (fmap f)).
+  rewrite <- fmap_ret.
+  now rewrite comp_assoc.
+Qed.
+
+(** The forgetful functor C_M ⟶ C: on objects, the carrier M x of the free
+    algebra on x; on morphisms, Kleisli extension.  Identity preservation
+    is the left unit law [join_fmap_ret], and functoriality combines the
+    associativity [join_fmap_join] with the multiplication naturality
+    [join_fmap_fmap], exactly as in the composition law of Kleisli. *)
+
+Program Definition Kleisli_Forget : Kleisli ⟶ C := {|
+  fobj := fun x => M x;
+  fmap := fun x y f => join ∘ fmap[M] f
+|}.
+Next Obligation. proper. now rewrites. Qed.
+Next Obligation. apply join_fmap_ret. Qed.
+Next Obligation.
+  (* join ∘ fmap[M] (join ∘ fmap[M] f ∘ g)
+       ≈ (join ∘ fmap[M] f) ∘ (join ∘ fmap[M] g) *)
+  rewrite !fmap_comp.
+  rewrite !comp_assoc.
+  rewrite join_fmap_join.
+  rewrite <- !comp_assoc.
+  rewrite (comp_assoc join (fmap (fmap _))).
+  rewrite join_fmap_fmap; cat.
+Qed.
+
+(** The transposition isomorphism: a Kleisli morphism F_M x ~{C_M}~> y and
+    a C-morphism x ~> U_M y are one and the same arrow x ~> M y, so the
+    hom-setoid isomorphism of the adjunction is the identity map. *)
+
+Program Definition Kleisli_adj_iso (x y : C) :
+  @Isomorphism Sets
+    {| carrier   := @hom Kleisli (Kleisli_Free x) y
+     ; is_setoid := @homset Kleisli (Kleisli_Free x) y |}
+    {| carrier   := @hom C x (Kleisli_Forget y)
+     ; is_setoid := @homset C x (Kleisli_Forget y) |} := {|
+  to   := {| morphism := fun f => f |};
+  from := {| morphism := fun f => f |}
+|}.
+Next Obligation. proper. Qed.
+Next Obligation. proper. Qed.
+Next Obligation. reflexivity. Qed.
+Next Obligation. reflexivity. Qed.
+
+(** Naturality of the transposition in the source argument, stated on the
+    underlying arrows: precomposing a Kleisli morphism with a pure one is
+    plain precomposition in C. *)
+
+Lemma kleisli_transpose_nat_l {x y z : C} (f : y ~{C}~> M z) (g : x ~{C}~> y) :
+  join ∘ fmap[M] f ∘ (ret ∘ g) ≈ f ∘ g.
+Proof.
+  rewrite comp_assoc.
+  rewrite <- (comp_assoc join (fmap[M] f) ret).
+  rewrite <- fmap_ret.
+  rewrite (comp_assoc join ret f).
+  rewrite join_ret.
+  cat.
+Qed.
+
+Program Definition Kleisli_Adjunction : Kleisli_Free ⊣ Kleisli_Forget :=
+  @Build_Adjunction' Kleisli C Kleisli_Free Kleisli_Forget Kleisli_adj_iso _ _.
+Next Obligation. apply kleisli_transpose_nat_l. Qed.
+Next Obligation. reflexivity. Qed.
+
+(** The unit of the adjunction is the unit of the monad. *)
+
+Lemma Kleisli_unit_agrees {x : C} :
+  @unit _ _ _ _ Kleisli_Adjunction x ≈ ret[M].
+Proof. reflexivity. Qed.
+
+(** The counit at x is the identity arrow on M x, read as the Kleisli
+    morphism F_M (U_M x) ~{C_M}~> x that runs the computation. *)
+
+Lemma Kleisli_counit_agrees {x : C} :
+  @counit _ _ _ _ Kleisli_Adjunction x ≈ id[M x].
+Proof. reflexivity. Qed.
+
+(** The multiplication of the monad induced by this adjunction (per
+    Monad/Adjunction.v it is the U_M-image of the counit) is join. *)
+
+Lemma Kleisli_join_agrees {x : C} :
+  fmap[Kleisli_Forget] (@counit _ _ _ _ Kleisli_Adjunction x) ≈ join[M].
+Proof.
+  simpl.
+  rewrite fmap_id.
+  cat.
+Qed.
+
+(** The resolution recovers M: the composite U_M ◯ F_M is naturally
+    isomorphic to M, with identity components. *)
+
+Theorem Kleisli_Monad_agrees : Kleisli_Forget ◯ Kleisli_Free ≈ M.
+Proof.
+  exists (fun x => iso_id).
+  intros x y f; simpl.
+  rewrite fmap_comp.
+  rewrite comp_assoc.
+  rewrite join_fmap_ret.
+  cat.
+Qed.
+
+End KleisliAdjunction.

--- a/_CoqProject
+++ b/_CoqProject
@@ -147,6 +147,7 @@ Instance/Coq.v
 Instance/Coq/Applicative.v
 Instance/Coq/Monad.v
 Instance/Coq/Comonad/Env.v
+Instance/Coq/Comonad/Store.v
 Instance/Coq/Par.v
 Instance/Coq/ParE.v
 Instance/Ens.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -201,6 +201,7 @@ Monad/Algebra.v
 Monad/Compose.v
 Monad/Distributive.v
 Monad/Eilenberg/Moore.v
+Monad/Eilenberg/Moore/Adjunction.v
 Monad/Graded.v
 Monad/Kleisli.v
 Monad/Kleisli/Adjunction.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -148,6 +148,7 @@ Instance/Coq/Applicative.v
 Instance/Coq/Monad.v
 Instance/Coq/Comonad/Env.v
 Instance/Coq/Comonad/Store.v
+Instance/Coq/Comonad/Traced.v
 Instance/Coq/Par.v
 Instance/Coq/ParE.v
 Instance/Ens.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -10,6 +10,7 @@ Adjunction/Opposite.v
 Construction/Arrow.v
 Comonad/Core.v
 Comonad/CoKleisli.v
+Comonad/Coalgebra.v
 Construction/Cayley.v
 Construction/Comma.v
 Construction/Comma/Adjunction.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -8,6 +8,7 @@ Adjunction/Natural/Transformation/Opposite.v
 Adjunction/Natural/Transformation/Universal.v
 Adjunction/Opposite.v
 Construction/Arrow.v
+Comonad/Core.v
 Construction/Cayley.v
 Construction/Comma.v
 Construction/Comma/Adjunction.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -146,6 +146,7 @@ Instance/Cones/Limit.v
 Instance/Coq.v
 Instance/Coq/Applicative.v
 Instance/Coq/Monad.v
+Instance/Coq/Comonad/Env.v
 Instance/Coq/Par.v
 Instance/Coq/ParE.v
 Instance/Ens.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -9,6 +9,7 @@ Adjunction/Natural/Transformation/Universal.v
 Adjunction/Opposite.v
 Construction/Arrow.v
 Comonad/Core.v
+Comonad/CoKleisli.v
 Construction/Cayley.v
 Construction/Comma.v
 Construction/Comma/Adjunction.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -12,6 +12,7 @@ Comonad/Core.v
 Comonad/CoKleisli.v
 Comonad/Coalgebra.v
 Comonad/Duality.v
+Comonad/Strong.v
 Construction/Cayley.v
 Construction/Comma.v
 Construction/Comma/Adjunction.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -203,6 +203,7 @@ Monad/Distributive.v
 Monad/Eilenberg/Moore.v
 Monad/Graded.v
 Monad/Kleisli.v
+Monad/Kleisli/Adjunction.v
 Monad/Kleisli/Premonoidal.v
 Monad/Kleisli/Commutative.v
 Monad/Monoid.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -11,6 +11,7 @@ Construction/Arrow.v
 Comonad/Core.v
 Comonad/CoKleisli.v
 Comonad/Coalgebra.v
+Comonad/Duality.v
 Construction/Cayley.v
 Construction/Comma.v
 Construction/Comma/Adjunction.v


### PR DESCRIPTION
## Summary

Second stacked PR (base: `johnw/ct-phase5`). 10 new files, 12 commits.

- **`Comonad/Core.v`** — covariant comonad API (extract/duplicate/extend + the three co-Kleisli triple laws) as **definitional op-reads** of the one-line `Comonad := @Monad (C^op) (W^op)`, nothing re-axiomatized.
- **Co-Kleisli** (`CoKleisli.v`), **co-Eilenberg-Moore coalgebras** (`Coalgebra.v`), **costrength** (`Strong.v`), and the **adjunction-induced comonad with co-resolutions by duality** (`Duality.v`).
- **Monad resolutions**: the Kleisli and Eilenberg-Moore free/forgetful adjunctions (`Monad/Kleisli/Adjunction.v`, `Monad/Eilenberg/Moore/Adjunction.v`), closing the promise in `Moore.v`'s header. The EM commit also repairs `Moore.v`'s opaque-obligation landmine (`obj := ∃ a, @TAlgebra C T H a`) in the same commit.
- **Instances on `Coq`/`Sets`**: Env, Store, Traced comonads.

### Disclosures

- **Store and Traced witnesses are hosted on `Sets`, not `Coq`**, contrary to the plan's literal file-9/10 text. This is forced, not a shortcut: a `Coq`-hosted functor's `fmap_respects` field **entails functional extensionality** — machine-checked by `coq_store_map_proper_entails_funext` (`Store.v:129`) and `coq_traced_map_proper_entails_funext`. Per the plan's own risk-note fallback, the witnesses live on `Sets` instead; all three comonads are axiom-free (`Print Assumptions` closed, zero funext). Env stays on `Coq`.
- The co-Kleisli `f =>= g` runs the **left** operand first (matching the repo's `>=>` convention, not Haskell `Control.Comonad`); behaviorally tested.

## Verification

- Zero holes; `Print Assumptions` closed for all principal artifacts (incl. the three `Coq`/`Sets` comonads — no funext); `make todo` silent; full `make` + 8.19 + 8.20 harvests + `nix build` + `nix flake check` all green.
- Note on process: this phase's automated fix/review/audit steps were completed in-loop (a mid-phase model transition exhausted the subagent credit pool); the fess audit was therefore an in-loop self-audit rather than a separate evaluator, and the confirmed review findings were applied and self-verified. Independent re-review welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011k7xm8t5nbGeDDYvSpkuDP