### PR TITLE
docs(Comonad): the theory and utility of comonads, in depth

### DIFF
--- a/Comonad/CoKleisli.v
+++ b/Comonad/CoKleisli.v
@@ -45,6 +45,56 @@ Generalizable All Variables.
    Comonad/Core.v; they appear below as [comonad_id_left],
    [comonad_id_right] and [comonad_comp_assoc]. *)
 
+(* Context-dependent maps, dataflow, and linear logic
+
+   nLab:  https://ncatlab.org/nlab/show/exponential+modality
+   Paper: Uustalu, Vene, "The Essence of Dataflow Programming", APLAS
+          2005, LNCS 3780, pp. 2-18
+   Paper: Petricek, Orchard, Mycroft, "Coeffects: a calculus of
+          context-dependent computation", ICFP 2014
+
+   The co-Kleisli category is where the computational reading of a
+   comonad becomes a category of programs.  A co-Kleisli morphism
+   W x ~> y consumes not a bare x but an x in its W-context, and the
+   composite of two such morphisms first promotes the earlier one to a
+   context-preserving transformation ([extend]) so that the later one
+   may read its result in context; arrows that observe their
+   surroundings thereby compose as ordinary functions do.  The analogy
+   with Kleisli categories runs in parallel throughout: as those model
+   call-by-value languages, co-Kleisli categories model call-by-name,
+   and for an idempotent comonad the construction collapses to the
+   coreflective subcategory of the comonad's modal types.  Haskell's
+   comonad package (Kmett) states the comonad laws in this vocabulary,
+   with extract the identity of co-Kleisli composition, just as
+   [comonad_id_left], [comonad_id_right] and [comonad_comp_assoc] do
+   below.
+
+   Dataflow programming supplies the motivating example.  Uustalu and
+   Vene observed that both general and causal stream functions can be
+   characterized as the co-Kleisli arrows of suitable stream comonads —
+   causality meaning that the output at a given moment depends only on
+   the input's past and present, which is to say on the input value in
+   its history-context — and on that observation built a generic
+   comonadic interpreter, recovering effects where needed through a
+   distributive law of the comonad over a monad (APLAS 2005).  A
+   co-Kleisli arrow of the stream comonad is a digital filter, and
+   [extend] produces the filtered stream (Milewski, 2017).  The coeffect
+   calculi of Petricek, Orchard and Mycroft (ICFP 2014) supply type
+   systems for this class of programs; dataflow, implicit parameters,
+   liveness and bounded usage are among their instances.
+
+   Linear logic supplies the proof-theoretic example.  In models of
+   linear logic the exponential modality ! is a comonad (Girard 1987,
+   the comonadic reading developed by Seely 1989, de Paiva 1989, and
+   Benton–Bierman–de Paiva–Hyland 1992): !A is A made freely duplicable
+   and discardable.  When the linear category is closed symmetric
+   monoidal, the co-Kleisli category of ! is cartesian closed — a
+   categorical form of the translation of intuitionistic logic into
+   linear logic (Seely) — and Benton (1995) showed that the !-comonad
+   is induced by a monoidal adjunction between a cartesian monoidal and
+   a symmetric monoidal category, the linear–non-linear adjunction.
+   The category built below is the common shape behind both readings. *)
+
 Section CoKleisli.
 
 Context {C : Category} {W : C ⟶ C} {H : @Comonad C W}.

--- a/Comonad/Coalgebra.v
+++ b/Comonad/Coalgebra.v
@@ -48,6 +48,64 @@ Generalizable All Variables.
    carriers and underlying morphisms, and the natural isomorphisms
    witnessing the two round trips have identity components. *)
 
+(* What a coalgebra is for
+
+   nLab:  https://ncatlab.org/nlab/show/comonadic+functor
+   nLab:  https://ncatlab.org/nlab/show/store+comonad
+   Paper: O'Connor, "Functor is to Lens as Applicative is to Biplate:
+          Introducing Multiplate", arXiv:1103.2841, 2011
+   Paper: Bénabou, Roubaud, "Monades et descente", C. R. Acad. Sc. Paris,
+          Sér. A 270, 1970, pp. 96-98
+
+   A W-coalgebra is an object equipped with coherent access to its own
+   contexts.  The costructure map γ : a ~> W a places each element of a
+   into a W-context; [w_counit_law] states that reading the placement
+   back with ε recovers the element; and [w_coaction] states that
+   placing twice agrees with placing once and duplicating.  Where the
+   cofree coalgebras (W x, δ) supply contexts generically, an arbitrary
+   coalgebra carries its own structured way of being in context.
+
+   Two instances make the definition concrete.  For the store comonad
+   (s ⇒ −) × s (Instance/Coq/Comonad/Store.v), a coalgebra structure on
+   a carrier a amounts to a pair of maps get : a → s and put : s × a → a,
+   and the counit and coaction laws are together equivalent to the three
+   lens laws: put (get a, a) = a; get (put (σ, a)) = σ; and
+   put (τ, put (σ, a)) = put (τ, a).  Coalgebras of the store comonad
+   are therefore exactly the lawful ("very well-behaved") lenses of
+   functional programming, a correspondence due to O'Connor (2010;
+   arXiv:1103.2841).  For the environment comonad e × −
+   (Instance/Coq/Comonad/Env.v) the classification is simpler still: a
+   coalgebra on a is the same thing as a morphism a → e, and the
+   category of coalgebras is isomorphic to the slice category over e.
+
+   The cofree side of the theory dualizes the free algebras over a
+   monad, with one orientation worth fixing in the mind: for a comonad
+   it is the cofree functor that is the RIGHT adjoint, the forgetful
+   functor from coalgebras to C being a left adjoint (Comonad/Duality.v,
+   [CoEM_Adjunction], [CoEM_Cofree]), and the comonad this adjunction
+   induces on C is W itself.  A functor is comonadic when it has a right
+   adjoint and the comparison into the coalgebras of the induced comonad
+   is an equivalence of categories; Beck's monadicity theorem has its
+   exact comonadic dual, with split equalizers in the role that split
+   coequalizers play for monads.  The monad side is formalized in
+   Monad/Monadicity/Beck.v.
+
+   The classical payoff of these categories is descent theory.  For a
+   bifibration satisfying the Beck–Chevalley condition, the descent data
+   along a morphism form the Eilenberg–Moore category of the monad
+   induced by the base-change adjunction (Bénabou–Roubaud 1970); for an
+   adjoint triple f_! ⊣ f^* ⊣ f_* the same data are equally coalgebras
+   over the comonad f^* f_*; and Grothendieck's faithfully flat descent,
+   through the extension-of-scalars adjunction, is the classical
+   instance.  The same resolution machinery yields the simplicial bar
+   construction on an algebra, whose contracting homotopy makes its
+   acyclicity absolute — preserved by every functor — and on which
+   comonad (cotriple) cohomology is founded (Barr–Beck, Springer LNM 80,
+   1969).  Coalgebras over the jet comonad of a base-change adjunction
+   are partial differential equations (Marvan, 1986).  None of this is
+   formalized in this file; the pointers record where the notion earns
+   its keep. *)
+
 (* The covariant coalgebra class.  Its three fields are, definitionally,
    the fields of [@TAlgebra (C^op) (W^op) H a]: the costructure map read
    covariantly, the counit law as the op-read of [t_id] (whose [ret] is

--- a/Comonad/Core.v
+++ b/Comonad/Core.v
@@ -30,6 +30,83 @@ Generalizable All Variables.
    transported by [exact] (at most up to symmetry of ≈, where the op-read
    arrives in the reversed orientation). *)
 
+(* Where comonads come from, and what they are for
+
+   nLab:  https://ncatlab.org/nlab/show/comonad
+   Paper: Eilenberg, Moore, "Adjoint functors and triples", Illinois
+          Journal of Mathematics 9(3), 1965
+   Paper: Uustalu, Vene, "Comonadic Notions of Computation", ENTCS 203(5),
+          2008
+
+   Three views of the same structure organize everything below: the
+   algebraic, the categorical, and the computational.
+
+   Algebraically, a comonad on C is a comonoid in the monoidal category
+   of endofunctors of C, with composition as tensor and Id as unit:
+   [duplicate] is the comultiplication, [extract] is the counit, and the
+   laws below are the comonoid axioms and nothing more.  The reading
+   generalizes to any 2-category E — a comonad on an object X is a
+   comonoid in the hom-category E(X, X) — and this file is the case
+   E = Cat.  The terminology has accumulated in layers: Godement
+   introduced the monad-side notion in 1958 as the "standard
+   construction"; Eilenberg and Moore wrote "triple" in 1965, whence the
+   older synonym "cotriple" for comonads; and the now-standard name
+   "monad" is due to Bénabou (1967).
+
+   Categorically, comonads are the residue that an adjunction leaves on
+   the codomain of its left adjoint.  Every adjunction F ⊣ U induces a
+   comonad there — the endofunctor is F ◯ U, the counit is the
+   adjunction counit ε : F ◯ U ⟹ Id, and the comultiplication is the
+   whiskered unit F η U — an observation that goes back to Huber (1961)
+   and is realized in this library as [Adjunction_Comonad] in
+   Comonad/Duality.v.  Every comonad so arises, and in two canonical
+   ways: the co-Kleisli and co-Eilenberg–Moore resolutions, obtained by
+   duality in Comonad/Duality.v ([CoKleisli_Adjunction],
+   [CoEM_Adjunction]) over the categories built in Comonad/CoKleisli.v
+   and Comonad/Coalgebra.v.
+
+   Computationally, a comonadic value is a value in an observable
+   context.  Where a monadic value T x is a computation that may perform
+   effects while producing an x, a value W x is an x situated in a
+   context that can be read off and re-exposed: [extract] reads the
+   value at the current context, [duplicate] re-exposes the whole
+   context at every point of itself, and [extend] promotes a
+   context-consuming observation W x ~> y to a context-preserving
+   transformation W x ~> W y by running the observation everywhere.
+   Comonads therefore structure context-dependent computation in the
+   same sense that Moggi-style monads structure effectful computation
+   (Uustalu–Vene 2008), and the coeffect calculi of Petricek, Orchard
+   and Mycroft (ICFP 2014) make the duality a type discipline, tracking
+   what a program requires from its context as effect systems track
+   what it does to its surroundings.
+
+   The applications follow the three views.  From the computational
+   reading come the programming uses: dataflow, where general and causal
+   stream functions are the co-Kleisli arrows of stream comonads
+   (Uustalu–Vene, APLAS 2005; see Comonad/CoKleisli.v); cellular
+   automata, where one step of the automaton is [extend] of the local
+   rule over a zipper of cells (Piponi, 2006); spreadsheet-like
+   recurrences, evaluated by a comonadic fixed point in which every cell
+   observes its own context within the whole (Foner, Haskell Symposium
+   2015); and user interfaces, where a comonad models the space of
+   states of an application, [extract] renders the current one, and a
+   paired monad moves through the space (Freeman, 2016).  From the
+   algebraic reading, through its coalgebras, comes the connection to
+   data access: the coalgebras of the store comonad are exactly the
+   lawful lenses of functional programming (O'Connor, 2011; see
+   Comonad/Coalgebra.v and Instance/Coq/Comonad/Store.v).  From the
+   adjunction reading come the mathematical uses: in linear logic the
+   exponential modality ! is a comonad whose co-Kleisli category
+   interprets intuitionistic logic (Girard 1987; Seely 1989; see
+   Comonad/CoKleisli.v), and in descent theory the descent data along a
+   morphism are (co)algebras over the (co)monad of a base-change
+   adjunction (Bénabou–Roubaud 1970), with the simplicial bar resolution
+   of a comonad founding cotriple cohomology (Barr–Beck, Springer LNM
+   80, 1969; see Comonad/Coalgebra.v).  The earliest use of comonads in
+   programming semantics is Brookes–Geva's computational comonads (LMS
+   Lecture Note Series 177, 1992); the first proposal to program with
+   them in Haskell is Kieburtz (1999). *)
+
 (* [Comonad C W] is a Definition that unfolds to the class
    [@Monad (C^op) (W^op)], but typeclass resolution keys on the head constant
    of a goal and does not look through this unfolding.  Declaring [Comonad]

--- a/Comonad/Duality.v
+++ b/Comonad/Duality.v
@@ -66,6 +66,39 @@ Generalizable All Variables.
      ([CoKleisli_Comonad_agrees], [CoEM_Comonad_agrees]), dually to
      [Kleisli_Monad_agrees] and [EM_Monad_agrees]. *)
 
+(* The two resolutions as extremes
+
+   nLab: https://ncatlab.org/nlab/show/Eilenberg-Moore+category
+   nLab: https://ncatlab.org/nlab/show/comonadic+functor
+
+   Among the adjunctions inducing a given comonad, the two resolutions
+   of this file occupy the extreme positions.  On the monad side the
+   Kleisli adjunction is initial and the Eilenberg–Moore adjunction
+   terminal in the category of adjunctions inducing T; and because
+   (−)^op is covariant on functors, dualization preserves that
+   orientation, so the co-Kleisli resolution is likewise initial and the
+   co-Eilenberg–Moore resolution terminal.  Every inducing adjunction
+   therefore receives a canonical comparison functor from the former and
+   sends one into the latter, and the comparison into coalgebras being
+   an equivalence is what it means for the inducing adjunction's left
+   adjoint to be comonadic.
+
+   The transfer package below is what makes this duality a theorem
+   scheme rather than a pair of parallel constructions.  Since
+   [Comonad C W] IS [@Monad (C^op) (W^op)] and the op involution is
+   definitional, every monad theorem in the library is already a comonad
+   theorem: instantiate it at (C^op, W^op) and read the composites
+   backwards.  The files of the Comonad/ directory are exactly such
+   readings, and no comonad law is ever proved twice.
+
+   A single adjunction exhibits the whole family of standard examples.
+   On a cartesian closed category the currying adjunction e × − ⊣ e ⇒ −
+   induces, in one order, the state monad e ⇒ (e × −) and, in the other,
+   the store comonad (e ⇒ −) × e; its left adjoint e × − is itself the
+   environment comonad, and its right adjoint e ⇒ − the reader monad.
+   Env, Reader, State and Store are in this sense one adjunction viewed
+   four ways (Instance/Coq/Comonad/Env.v, Instance/Coq/Comonad/Store.v). *)
+
 (** ** The transfer package
 
     [Comonad C W] IS [@Monad (C^op) (W^op)] by definition, so all four

--- a/Comonad/Strong.v
+++ b/Comonad/Strong.v
@@ -69,6 +69,55 @@ Generalizable All Variables.
    [op_CostrongComonad_to_StrongMonad] and the round-trip lemmas at the end
    of this file. *)
 
+(* Why costrength matters
+
+   nLab:  https://ncatlab.org/nlab/show/tensorial+costrength
+   Paper: Blute, Cockett, Seely, J. Pure Appl. Algebra 116(1-3), 1997,
+          pp. 49-98 (where the term "costrength" is introduced)
+   Paper: Kock, Arch. Math. 23, 1972, pp. 113-120 (tensorial strength)
+
+   Strength is what lets a functor travel through paired data.  In
+   Moggi's semantics a bare monad cannot interpret programs with more
+   than one free variable; the strength carries the ambient environment
+   into the effectful computation, and Monad/Strong.v exists for that
+   reason.  The comonadic situation is the mirror image: a context
+   W (x ⨂ y) spanning a pair must be pushable onto a chosen factor,
+   W (x ⨂ y) ~> x ⨂ W y, before a co-Kleisli program can consume the
+   y-part in context while passing the x-part through.  That map is
+   [costrength].  In Uustalu and Vene's account of dataflow the comonad
+   plays the role that strong monads play in Moggi's semantics, with
+   effects reintroduced through a distributive law of the comonad over
+   a monad (APLAS 2005).
+
+   Orientation deserves care, because the literature does not speak with
+   one voice.  Dually to the left and right strengths
+   x ⨂ F y ~> F (x ⨂ y), a left-costrength is F (x ⨂ y) ~> x ⨂ F y —
+   the form of this file — and a right-costrength is
+   F (x ⨂ y) ~> F x ⨂ y.  On a symmetric base either determines the
+   other through the braiding, and one says simply "costrength"; on a
+   non-symmetric base a full costrength further requires the two induced
+   maps F (x ⨂ (y ⨂ z)) ~> (x ⨂ F y) ⨂ z to agree.  The term is due to
+   Blute, Cockett and Seely (1997); nLab cautions that Power and
+   Robinson (1997) use it for what is here a right-strength.
+
+   Whether strength is data or property depends on the base.  For a
+   closed monoidal V, a strength on an endofunctor of V is the same
+   thing as a V-enrichment of it, so every endofunctor of Set carries a
+   canonical strength; over a general monoidal base nothing of the sort
+   holds, which is why the costrength here is data to be supplied
+   ([Build_CostrongComonad] takes the family and its laws as inputs)
+   rather than property to be derived.
+
+   A final distinction separates strength from monoidality.  The
+   programming face of comonads with monoidal structure is Haskell's
+   ComonadApply, characterized in Kmett's Control.Comonad documentation
+   as "a strong lax symmetric semi-monoidal comonad", under which
+   extract and duplicate become symmetric monoidal natural
+   transformations; it is the interface on which Foner's comonadic
+   fixed point for spreadsheet-like recurrences is built (Haskell
+   Symposium 2015).  Lax (semi)monoidal structure on the endofunctor is
+   a further layer that this file does not axiomatize. *)
+
 Definition CostrongComonad {C : Category} (M : @Monoidal C) (W : C ⟶ C) : Type :=
   @StrongMonad (C^op) (@Monoidal_op C M) (W^op).
 

--- a/Instance/Coq/Comonad/Env.v
+++ b/Instance/Coq/Comonad/Env.v
@@ -40,6 +40,50 @@ Generalizable All Variables.
    functional extensionality — indeed no axiom of any kind — enters this
    file, and every definition below is closed under the global context. *)
 
+(* Coeffects, annotation, and the slice
+
+   nLab:  https://ncatlab.org/nlab/show/coreader+comonad
+   Paper: Petricek, Orchard, Mycroft, "Coeffects: a calculus of
+          context-dependent computation", ICFP 2014
+
+   The co-Kleisli reading e * x → y is the discipline of implicit
+   parameters, also called dynamic scoping: a program consults a
+   read-only ambient environment without threading it by hand.
+   Haskell's Control.Comonad.Env documents exactly this chain of
+   readings, (a -> e -> m) ~ (a, e) -> m ~ Env e a -> m.  In the
+   coeffect calculi of Petricek, Orchard and Mycroft (ICFP 2014),
+   dynamic scoping is a standard instance of a coeffect — a requirement
+   a computation places on its context, tracked by the type system as
+   effect systems track what a computation does to its surroundings.
+   The environment comonad performs exactly the computations of the
+   reader monad, co-Kleisli composition threading one environment to
+   both arrows (Milewski, 2017); and the relation between the two is an
+   adjunction, for on a cartesian closed category e × − is left adjoint
+   to e ⇒ −, the composite e ⇒ (e × −) is the state monad, and the
+   comonad the same adjunction induces is Store
+   (Instance/Coq/Comonad/Store.v; Comonad/Duality.v,
+   [Adjunction_Comonad]).
+
+   An environment layer is also the canonical annotation device:
+   [extract] drops the annotation and [duplicate] makes it observable
+   to every consumer, so a structure can be labelled without being
+   disturbed.  Annotating the nodes of a cofree-comonad syntax tree
+   through an environment transformer layer is the standard
+   application, and Haskell's free package ships precisely that
+   composition.
+
+   The coalgebras complete the picture.  A coalgebra structure on a
+   carrier a for e × − is the same thing as a single morphism a → e,
+   and the category of coalgebras is isomorphic to the slice category
+   over e: to hold an e-annotation coherently is exactly to be an
+   object over e (see Comonad/Coalgebra.v), and the slice projection is
+   thereby a comonadic functor.  The comonoid remark of the header
+   above also generalizes — whenever w is a comonoid in a monoidal
+   category, w ⨂ − carries an analogous comonad structure, and when w
+   is instead a monoid, w × − carries the writer monad.  The
+   copy/discard vocabulary for categories with a comonoid supply is
+   developed in Structure/Monoidal/CopyDiscard.v. *)
+
 (** The action of e × − on morphisms: apply f under the environment. *)
 Definition env_map {e x y : Type} (f : x → y) (p : e * x) : e * y :=
   match p with (e0, v) => (e0, f v) end.

--- a/Instance/Coq/Comonad/Store.v
+++ b/Instance/Coq/Comonad/Store.v
@@ -35,6 +35,44 @@ Generalizable All Variables.
    [extend] off it definitionally (the *_spec lemmas at the end hold by
    [reflexivity]). *)
 
+(* Lenses, grids, and the practical API
+
+   nLab:  https://ncatlab.org/nlab/show/store+comonad
+   Paper: O'Connor, "Functor is to Lens as Applicative is to Biplate:
+          Introducing Multiplate", arXiv:1103.2841, 2011
+
+   The one-line remark above about lenses has a precise statement.  A
+   coalgebra of this comonad on a carrier a — a costructure map
+   a ~> (s ⇒ a) × s satisfying the counit and coaction laws of
+   Comonad/Coalgebra.v — amounts to a pair of maps get : a → s and
+   put : s × a → a, and the two coalgebra laws are together equivalent
+   to the three lens laws: put (get a, a) = a; get (put (σ, a)) = σ;
+   and put (τ, put (σ, a)) = put (τ, a).  Coalgebras of the store
+   comonad are therefore exactly the lawful ("very well-behaved")
+   lenses of functional programming, a correspondence due to O'Connor
+   (November 2010; arXiv:1103.2841, 2011).
+
+   The spatial intuition is a grid of observations with a cursor, and
+   it is what makes this comonad the natural home of cellular
+   computation.  Conway's Game of Life serves as the guiding example in
+   Milewski's exposition (2017).  Piponi's treatment of cellular
+   automata works the same idea over a bi-infinite zipper comonad, one
+   step of the automaton applying the local rule at every refocusing at
+   once — which is [extend] of the rule (2006).  Foner's comonadic
+   fixed point evaluates multi-dimensional spreadsheet-like recurrences
+   in which every cell observes its own context within the whole
+   (Haskell Symposium 2015).
+
+   Kmett's ComonadStore class names the practical vocabulary, and each
+   of its names lands on an artifact of this file.  pos reads the
+   focused position: here [snd], and [extend] preserves it
+   ([Store_extend_pos_spec]).  peek observes at a given position:
+   applying [fst], so that [extract] is peek at pos
+   ([Store_extract_spec]).  seek repositions the store absolutely: the
+   library's [store_seek], whose family over all positions is the
+   observation component of [duplicate] ([Store_seek_spec]).
+   experiment observes many neighbouring positions at once. *)
+
 (** ** The store data over raw types, and why the witness is hosted on Sets
 
     Instance/Coq/Comonad/Env.v hosts the environment comonad on COQ, whose

--- a/Instance/Coq/Comonad/Traced.v
+++ b/Instance/Coq/Comonad/Traced.v
@@ -39,6 +39,39 @@ Generalizable All Variables.
    and [extend] off it definitionally (the *_spec lemmas at the end hold by
    [reflexivity]). *)
 
+(* How much monoid the comonad costs
+
+   Haskell: Control.Comonad.Traced (Kmett's comonad package)
+   Paper:   Eilenberg, Moore, "Adjoint functors and triples", Illinois
+            Journal of Mathematics 9(3), 1965 (the adjoint monad theorem)
+
+   The exponent functor m ⇒ − is made a comonad by exactly the monoid
+   structure on m, and the file keeps the accounting visible: ε
+   consumes the unit, δ consumes the multiplication, and each of the
+   three comonad laws consumes precisely one monoid law.
+   [traced_extract_duplicate] uses only [mempty_left];
+   [traced_fmap_extract_duplicate] uses only [mempty_right]; and
+   [traced_duplicate_coassoc] uses only [mappend_assoc].  The
+   [Proof using] annotations record these dependencies, so the
+   correspondence is checked rather than asserted.  Haskell mirrors the
+   requirement: the Comonad instance for Traced m exists exactly under
+   a Monoid m constraint, and the ComonadTraced class provides
+   trace :: m -> w a -> a — run the observation at a chosen
+   displacement of the context — as the practical vocabulary.
+
+   The comonad also has an adjoint provenance.  Besides the
+   contravariant monoidal push described above, the writer monad m × −
+   is left adjoint to m ⇒ −, and whenever a monad has a right adjoint,
+   that right adjoint canonically carries a comonad structure whose
+   counit and comultiplication are the mates of the monad's unit and
+   multiplication, with the Eilenberg–Moore category of the monad
+   equivalent to the coalgebras of the comonad compatibly with the
+   forgetful functors.  This is the adjoint monad theorem, implicit in
+   Eilenberg–Moore (1965) and explicit in Mac Lane and Moerdijk,
+   "Sheaves in Geometry and Logic", Thm. 2, p. 249.  Writer and Traced
+   are thus paired twice over: dual through the monoid, and adjoint
+   through the exponential. *)
+
 Section Traced.
 
 (** The section-context monoid: ordinary Coq data — a bare type together


### PR DESCRIPTION
This is the in-depth documentation follow-up promised in #197: comment-only changes across the eight comonad files, with no change to any definition, statement, or proof. Its purpose is to make the development legible on its own terms, so that a reader arrives at each construction already knowing what it is for and where its claims come from.

The prose is written in one considered register throughout, and it is organized around explanation rather than enumeration. Where the earlier draft catalogued concepts, this revision states each subject in a single thesis sentence and then elaborates it, so that the applications follow from the theory instead of standing beside it as a list.

- **Core.v** opens on three views of the one structure — the algebraic (a comonoid in the endofunctors), the categorical (the invariant part of an adjunction), and the computational (context-dependent computation) — and lets every later application descend from whichever view explains it.
- **CoKleisli.v** frames the co-Kleisli category as the category of context-consuming programs and grounds it in two worked readings rather than a survey of modalities.
- **Coalgebra.v**, **Duality.v**, and **Strong.v** each name their subject first — coherent access to one's own contexts; the two resolutions as the extreme positions among the adjunctions inducing a comonad; and strength as the means by which a functor travels through paired data — and then unfold it.
- **Env.v**, **Store.v**, and **Traced.v** carry the concrete readings: implicit parameters and the slice over the environment; the lens correspondence, stated precisely rather than gestured at; and the exponent m ⇒ − made a comonad by exactly the monoid structure on m.

Each substantive claim rests on a named source — nLab, the cited papers, or package documentation — checked against the primary source during drafting; claims that could not be so traced were dropped rather than retained. All eight files recompile unchanged in behaviour; every cited in-file identifier exists; and the hygiene scans are silent.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gu7UkJd9yua8VYABaM5K8J
