### PR TITLE
Rename a colliding witness, align the admitted gates, guard the file counts

### DIFF
--- a/.github/workflows/coq-ci.yml
+++ b/.github/workflows/coq-ci.yml
@@ -14,6 +14,8 @@ jobs:
         run: make bench-config-check
       - name: Bench build-config guard self-test (reject path, issue #158)
         run: make bench-config-check-selftest
+      - name: CLAUDE.md file-count guard
+        run: make claude-md-counts-check
 
   build:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,9 @@ make install
 
 # Check for admitted proofs or TODOs
 make todo
+
+# Guard the preamble's file counts against _CoqProject and the tree
+make claude-md-counts-check
 ```
 
 ### Single File Development

--- a/Instance/Grp/EckmannHilton.v
+++ b/Instance/Grp/EckmannHilton.v
@@ -345,10 +345,18 @@ Local Set Default Proof Using "All".
    [make print-assumptions] gate compiles every audited module into ONE
    scope, and Structure/Abelian.v IS required there, so a bare
    [Print Assumptions Abelian.] would resolve to whichever of the two was
-   imported last and could silently audit the wrong constant.  The tree
-   already carries one latent collision of exactly this shape
-   ([BoolSet], Instance/Sets/Quotient.v and Instance/Sets/Pullback.v, both
-   pulled into that same scope), and a second one on a name as central as
+   imported last and could silently audit the wrong constant.  That is not
+   a remote hazard: a sweep of the 277 modules the gate pulls into its one
+   scope counts THIRTY-TWO top-level names declared in two of them at once,
+   of which three were audited under a bare name -- and one of those three,
+   [fp_generators_distinct], was resolving to Instance/Mon/Coproduct.v's
+   monoid theorem where the surrounding gate block plainly means
+   Instance/Grp/Pushout.v's group one.  All three now carry fully-qualified
+   gate entries, which is the only spelling immune to Require-order drift,
+   and the twenty-nine others stay latent because no gate entry names them.
+   [BoolSet] was one of those (declared in both Instance/Sets/Quotient.v and
+   Instance/Sets/Pullback.v until the Pullback.v one was renamed
+   [PbBoolSet]), and a second collision on a name as central as
    [Abelian] is not worth the aesthetics.  [grp_ab_inverse] and
    [eh_probe_instrument] carry suffixes for a WEAKER reason, and an audit
    corrected an earlier draft that said "for the same reason": they collided

--- a/Instance/Sets/Pullback.v
+++ b/Instance/Sets/Pullback.v
@@ -176,7 +176,7 @@ Generalizable All Variables.
        paragraph below.  [graph_even] is the pullback of [Nat.even] along the
        identity of [bool], so its agreement subset is the graph of
        [Nat.even]; two of its elements are exhibited, a third pair is
-       shown excluded, and the mediator out of [NatSet] evaluates on
+       shown excluded, and the mediator out of [PbNatSet] evaluates on
        closed input.  [sets_ker evenM] identifies 0 and 2, and
        [even_ker_not_diagonal] proves the relation is therefore NOT the
        diagonal; the symmetry and transitivity arrows are evaluated on
@@ -260,7 +260,7 @@ Generalizable All Variables.
    [SubsetOf@{u u0 u1}] leaves the MEMBERSHIP universe [u0] free; it is
    forming [sub_obj] that bounds it by the carrier universe, and the
    bound is [u1 <= u0] in that constant's own block.  The concrete
-   witnesses of (E) are polymorphic too -- [NatSet@{u u0}] has [u0 < u],
+   witnesses of (E) are polymorphic too -- [PbNatSet@{u u0}] has [u0 < u],
    five stdlib donor bounds and no identification -- because they are over
    [eq_Setoid] (Lib/Setoid.v:65), which is universe-polymorphic, rather
    than by resolving [eq_equivalence] at an unannotated binder.
@@ -683,19 +683,19 @@ End Preimage.
 (* Two discrete setoids, over [eq_Setoid] of Lib/Setoid.v so that `≈` is
    Leibniz equality on the carriers and the equations below are genuine
    computations rather than instances of a coarse relation. *)
-Definition NatSet : Sets :=
+Definition PbNatSet : Sets :=
   {| carrier := nat; is_setoid := eq_Setoid nat |}.
 
-Definition BoolSet : Sets :=
+Definition PbBoolSet : Sets :=
   {| carrier := bool; is_setoid := eq_Setoid bool |}.
 
-Definition evenM : NatSet ~{Sets}~> BoolSet.
+Definition evenM : PbNatSet ~{Sets}~> PbBoolSet.
 Proof.
   unshelve refine {| morphism := Nat.even |};
   try (intros n m H; rewrite H; reflexivity).
 Defined.
 
-Definition idB : BoolSet ~{Sets}~> BoolSet.
+Definition idB : PbBoolSet ~{Sets}~> PbBoolSet.
 Proof.
   unshelve refine {| morphism := fun c : bool => c |};
   try (intros c c' H; exact H).
@@ -716,21 +716,21 @@ Example graph_even_3_snd :
 
 (* (3, true) is NOT in the agreement subset: no witness can be supplied. *)
 Lemma graph_even_excludes_3_true :
-  @equiv _ BoolSet (evenM 3%nat) (idB true) → False.
+  @equiv _ PbBoolSet (evenM 3%nat) (idB true) → False.
 Proof. discriminate. Qed.
 
 (** ** The mediator computes *)
 
-Lemma even_square : evenM ∘ id[NatSet] ≈ idB ∘ evenM.
+Lemma even_square : evenM ∘ id[PbNatSet] ≈ idB ∘ evenM.
 Proof. intros n; reflexivity. Qed.
 
-Definition even_med : NatSet ~{Sets}~> graph_even :=
-  sets_pb_med evenM idB id[NatSet] evenM even_square.
+Definition even_med : PbNatSet ~{Sets}~> graph_even :=
+  sets_pb_med evenM idB id[PbNatSet] evenM even_square.
 
 (* The mediator produced by the universal property IS that map. *)
 Definition even_med_is_ump :
   unique_obj (ump_pullbacks evenM idB (Sets_Pullback evenM idB)
-                            NatSet id[NatSet] evenM even_square)
+                            PbNatSet id[PbNatSet] evenM even_square)
   = even_med := eq_refl.
 
 Example even_med_5_fst :
@@ -749,7 +749,7 @@ Example even_ker_02_snd : sets_ker_snd evenM even_ker_02 = 2%nat := eq_refl.
 
 (* So the relation genuinely identifies two distinct elements. *)
 Lemma even_ker_not_diagonal :
-  @equiv _ NatSet (sets_ker_fst evenM even_ker_02)
+  @equiv _ PbNatSet (sets_ker_fst evenM even_ker_02)
                   (sets_ker_snd evenM even_ker_02) → False.
 Proof. discriminate. Qed.
 
@@ -777,14 +777,14 @@ Example even_ker_trans_snd :
 
 (** ** The preimage of a subset *)
 
-Definition TrueSub : SubsetOf BoolSet.
+Definition TrueSub : SubsetOf PbBoolSet.
 Proof.
-  refine (Build_SubsetOf BoolSet (fun c : bool => c = true) _).
+  refine (Build_SubsetOf PbBoolSet (fun c : bool => c = true) _).
   intros u v Huv Hm; rewrite <- Huv; exact Hm.
 Defined.
 
 (* The preimage of {true} along [evenM] is the set of even naturals. *)
-Definition even_preimage : SubsetOf NatSet := sets_preimage evenM TrueSub.
+Definition even_preimage : SubsetOf PbNatSet := sets_preimage evenM TrueSub.
 
 Example even_preimage_4 : carrier (sub_obj even_preimage) := (4%nat; eq_refl).
 
@@ -793,7 +793,7 @@ Proof. discriminate. Qed.
 
 (* A non-constant map into the preimage, and the criterion carrying it
    downstairs. *)
-Definition chooseM : BoolSet ~{Sets}~> NatSet.
+Definition chooseM : PbBoolSet ~{Sets}~> PbNatSet.
 Proof.
   unshelve refine {| morphism := fun c : bool => if c then 4%nat else 2%nat |};
   try (intros c c' H; rewrite H; reflexivity).
@@ -821,7 +821,7 @@ Example choose_downstairs_false :
 
 (* The criterion is not vacuous in the negative direction either: the
    constant 3 does not factor through the preimage. *)
-Definition constThree : BoolSet ~{Sets}~> NatSet.
+Definition constThree : PbBoolSet ~{Sets}~> PbNatSet.
 Proof.
   unshelve refine {| morphism := fun _ : bool => 3%nat |};
   try (intros c c' H; reflexivity).

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ minimize-requires:
 	    $(COQ_TOOLS)/minimize-requires.py -i -R . Category {} ::: \
 	    $$(find . -name '*.v')
 
-lint: todo bench-config-check
+lint: todo bench-config-check claude-md-counts-check
 	@echo "Lint checks complete."
 
 format-check:
@@ -55,13 +55,17 @@ format:
 	@find . -name '*.v' -exec perl -pi -e 's/[ \t]+$$//' {} +
 	@echo "Done."
 
-# Count only the harmless aborted-sketch markers ([admit] inside an
-# [Abort.]-terminated proof, and the [Abort.]s themselves).  A live proof
-# hole is caught separately and unconditionally by [admitted-check] below,
-# so it is deliberately excluded from this count.
+# The aborted-sketch budget.  The count uses the SAME criterion as the
+# lefthook [admitted] hook and the flake's [admitted-check] (case-insensitive,
+# no word boundary, [Admitted.] included), so the three gates cannot disagree
+# about the number (maintainer decision, 2026-09-06; before it this target
+# used the narrower '[^_]admit\b' and the flake a third variant).  A live
+# proof hole is still caught separately and unconditionally by
+# [admitted-check] below, so on a clean tree this is the number of
+# [Abort.]-terminated sketches plus the [admit]s inside them.
 admitted-count:
-	@find . -name '*.v' -print0 | xargs -0 grep -ciE '([^_]admit\b|Abort\.)' 2>/dev/null \
-		| awk -F: '{s+=$$2} END {print s}'
+	@find . -name '*.v' -print0 | xargs -0 grep -ciE '(Admitted\.|[^_]admit|Abort\.)' 2>/dev/null \
+		| awk -F: '{s+=$$2} END {print s+0}'
 
 # Two independent gates, kept apart so a safe construct is never scored the
 # same as an unsafe one:
@@ -176,7 +180,35 @@ timing-report: build-timing.log
 build-strict: Makefile.coq
 	$(MAKE) -f Makefile.coq COQEXTRAFLAGS="-w +default"
 
-check: format-check admitted-check bench-config-check category-theory print-assumptions
+# Keep CLAUDE.md's preamble honest about the size of the tree (maintainer
+# decision, 2026-09-06): its sentence "contains N proof files (the
+# `_CoqProject` build set -- M `.v` files exist on disk" must agree with
+# _CoqProject and with the checkout.  Pure file inspection, so it runs on a
+# bare runner without the Coq toolchain, like bench-config-check.
+claude-md-counts-check:
+	@echo "Checking CLAUDE.md's file counts against _CoqProject and the tree..."
+	@stated_built=$$(grep -oE 'contains [0-9]+ proof files' CLAUDE.md | head -1 | grep -oE '[0-9]+'); \
+	stated_disk=$$(grep -oE '[0-9]+ `\.v` files exist on disk' CLAUDE.md | head -1 | grep -oE '^[0-9]+'); \
+	built=$$(grep -cE '\.v[[:space:]]*$$' _CoqProject); \
+	disk=$$(find . -name '*.v' -not -path './.git/*' -not -path './.pa-tmp/*' \
+		| wc -l | tr -d ' '); \
+	rc=0; \
+	if [ -z "$$stated_built" ] || [ -z "$$stated_disk" ]; then \
+		echo "ERROR: could not find the file-count sentence in CLAUDE.md's preamble"; \
+		exit 1; \
+	fi; \
+	if [ "$$stated_built" != "$$built" ]; then \
+		echo "ERROR: CLAUDE.md says $$stated_built proof files; _CoqProject lists $$built"; rc=1; \
+	fi; \
+	if [ "$$stated_disk" != "$$disk" ]; then \
+		echo "ERROR: CLAUDE.md says $$stated_disk .v files on disk; the tree has $$disk"; rc=1; \
+	fi; \
+	if [ "$$rc" -eq 0 ]; then \
+		echo "CLAUDE.md file counts agree ($$built built, $$disk on disk)."; \
+	fi; \
+	exit $$rc
+
+check: format-check admitted-check bench-config-check claude-md-counts-check category-theory print-assumptions
 	@echo "All checks passed."
 
 # Print Print-Assumptions output for the library's key definitions.
@@ -2010,8 +2042,10 @@ print-assumptions: category-theory
 	  echo 'Print Assumptions QuiverArrows_not_Faithful.'; \
 	  echo 'Print Assumptions QuiverElements_faithful_under_NodeUIP.'; \
 	  echo 'Print Assumptions SetQuiver_Concrete.'; \
-	  echo 'Print Assumptions Full_Compose.'; \
-	  echo 'Print Assumptions Faithful_Compose.'; \
+	  echo 'Print Assumptions Category.Theory.Functor.Full_Compose.'; \
+	  echo 'Print Assumptions Category.Theory.Functor.Faithful_Compose.'; \
+	  echo 'Print Assumptions Category.Structure.Groupoid.Basepoint.Full_Compose.'; \
+	  echo 'Print Assumptions Category.Structure.Groupoid.Basepoint.Faithful_Compose.'; \
 	  echo 'Print Assumptions faithful_reflects_monic.'; \
 	  echo 'Print Assumptions faithful_reflects_epic.'; \
 	  echo 'Print Assumptions EssentiallySurjective_Compose.'; \
@@ -3571,7 +3605,8 @@ print-assumptions: category-theory
 	  echo 'Print Assumptions Grp_split_legs_monic_injections.'; \
 	  echo 'Print Assumptions Grp_free_product_injections_Monic.'; \
 	  echo 'Print Assumptions Grp_Cocartesian.'; \
-	  echo 'Print Assumptions fp_generators_distinct.'; \
+	  echo 'Print Assumptions Category.Instance.Grp.Pushout.fp_generators_distinct.'; \
+	  echo 'Print Assumptions Category.Instance.Mon.Coproduct.fp_generators_distinct.'; \
 	  echo 'Print Assumptions amalgam_over_Z2_merges.'; \
 	  echo 'Print Assumptions Pushout_Top.'; \
 	  echo 'Print Assumptions Top_HasPushouts.'; \
@@ -5837,4 +5872,5 @@ force _CoqProject Makefile: ;
 	@+$(MAKE) -f Makefile.coq $@
 
 .PHONY: all clean force lint format-check format admitted-count admitted-check
-.PHONY: bench-config-check bench-config-check-selftest timing timing-report build-strict check print-assumptions
+.PHONY: bench-config-check bench-config-check-selftest timing timing-report
+.PHONY: claude-md-counts-check build-strict check print-assumptions

--- a/flake.nix
+++ b/flake.nix
@@ -225,7 +225,7 @@
             fi
             echo "No Admitted. proof holes."
             current=$(find . -name '*.v' -print0 \
-              | xargs -0 grep -ciE '([^_]admit|Abort\.)' 2>/dev/null \
+              | xargs -0 grep -ciE '(Admitted\.|[^_]admit|Abort\.)' 2>/dev/null \
               | awk -F: '{s+=$2} END {print s+0}')
             baseline=$(cat .admitted-baseline 2>/dev/null || echo 0)
             echo "Aborted-sketch count: $current, Baseline: $baseline"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -17,6 +17,9 @@ pre-commit:
     bench-config:
       glob: "{_CoqProject,*.opam,dune,dune-project}"
       run: make -s bench-config-check
+    claude-md-counts:
+      glob: "{CLAUDE.md,_CoqProject,*.v}"
+      run: make -s claude-md-counts-check
     nix-build:
       glob: "*.{v,nix}"
       run: nix build --no-warn-dirty 2>&1


### PR DESCRIPTION
Maintenance only; no statement, proof or definition changes — every `.v` change here is a rename or a comment. Items 1, 3 and 4 are decisions taken on 2026-09-06; item 2 was found while auditing item 1. Landed ahead of #404 so that branch can rebase on it.

**1. Colliding witness names (latent).** `BoolSet` was declared twice — `Instance/Sets/Quotient.v:551` (a `SetoidObject`) and `Instance/Sets/Pullback.v:689` (an object of `Sets`) — and `make print-assumptions` appends all eleven of its blocks into one file compiled by a single `coqc`, so a bare `Print Assumptions BoolSet.` would have audited whichever module was `Require`d last. The Pullback.v witness is now `PbBoolSet`; its neighbour `NatSet`, the same collision shape against `Instance/Sets/Cartesian/Closed/Adjunction.v:125`, is `PbNatSet`. Undoing both renames reproduces the parent file byte for byte. No file outside Pullback.v referenced either name — neither module is even in the transitive `Require` closure of the files using the surviving ones.

**2. A live collision of the same shape, found while auditing (1).** Sweeping the 277 modules the gate pulls into that one scope finds **32** top-level names declared in two of them at once, **three** of them audited under a bare name. One was resolving to the wrong constant: `fp_generators_distinct` is gated inside an unmistakably `Grp` block, but `Instance/Mon/Coproduct` is `Require`d after `Instance/Grp/Pushout`, so the gate was auditing the *monoid* theorem and never the group one — confirmed by `Locate`, which reports `Category.Instance.Mon.Coproduct.fp_generators_distinct` for the bare name. `Full_Compose`/`Faithful_Compose` were resolving to the intended `Theory/Functor.v` constants only by Require-order luck. All three entries are now fully qualified, the only spelling immune to Require-order drift; and since each name has two real constants, both are now audited — six entries where there were three. Gate: 5321 → 5324 entries, all closed, `Axioms:` line count still 1.

**3. One criterion for the aborted-sketch budget.** The lefthook `admitted` hook, `make admitted-count` and the flake's `admitted-check` counted with three different regexes. All three now use the hook's `(Admitted\.|[^_]admit|Abort\.)`, case-insensitive, and print `s+0` rather than `s` so they cannot disagree on an empty count either. Every variant reports 15 here, so `.admitted-baseline` is unchanged; the zero-tolerance `Admitted.` check is untouched.

**4. A guard for CLAUDE.md's file counts.** The preamble's "900 proof files … 904 `.v` files on disk" had gone stale once and has been hand-bumped in every PR since. `make claude-md-counts-check` compares both numbers against `_CoqProject` and the checkout, on the `bench-config-check` pattern: wired into `lint`, `check`, `.PHONY`, a lefthook pre-commit entry, and the bare-runner `config-check` job of `coq-ci.yml`. It skips `.pa-tmp/`, which `print-assumptions` generates inside the tree.

Measured on the branch: full `make` green (900 `.vo`), `make print-assumptions` green (5324 closed, one `Axioms:` line, "Axiom audit passed"), `make todo` 2030 lines and unchanged per edited file, `make admitted-count` 15, `format-check` / `bench-config-check` / `claude-md-counts-check` pass, the new target rejects all three of its error paths under scratch tamper testing, and `nix eval` of the edited flake check succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yc4J7ptQZJMXKtKbpBSoKn
